### PR TITLE
Allow GPU renderer env overrides

### DIFF
--- a/crates/blinc_gpu/README.md
+++ b/crates/blinc_gpu/README.md
@@ -22,6 +22,15 @@ GPU renderer for Blinc UI using [wgpu](https://wgpu.rs/) with SDF-based renderin
 - **Compositing**: Layer blending with various blend modes
 - **Cross-Platform**: Works on macOS, Windows, Linux, iOS, Android, and WebGPU
 
+## Environment Overrides
+
+Use these environment variables to override renderer capacities at startup. Values are clamped to adapter limits.
+
+- `BLINC_WGPU_MAX_BUFFER_MB`: Override wgpu `max_buffer_size` (MiB), clamped to adapter-supported max.
+- `BLINC_GPU_MAX_PRIMITIVES`: Override max SDF primitives per batch (clamped by storage buffer binding size).
+- `BLINC_GPU_MAX_GLYPHS`: Override max glyphs per batch (clamped by storage buffer binding size).
+- `BLINC_GPU_MAX_GLASS_PRIMITIVES`: Override max glass primitives per batch (clamped by storage buffer binding size).
+
 ## Architecture
 
 ```

--- a/crates/blinc_gpu/src/renderer.rs
+++ b/crates/blinc_gpu/src/renderer.rs
@@ -21,7 +21,9 @@ use crate::shaders::{
 };
 
 fn env_u64(name: &str) -> Option<u64> {
-    std::env::var(name).ok().and_then(|v| v.trim().parse::<u64>().ok())
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
 }
 
 fn env_usize(name: &str) -> Option<usize> {

--- a/crates/blinc_gpu/src/renderer.rs
+++ b/crates/blinc_gpu/src/renderer.rs
@@ -101,6 +101,16 @@ fn apply_renderer_config_overrides(
     config
 }
 
+fn log_renderer_config(config: &RendererConfig) {
+    tracing::info!(
+        "gpu config: max_primitives={}, max_glyphs={}, max_glass_primitives={}, sample_count={}",
+        config.max_primitives,
+        config.max_glyphs,
+        config.max_glass_primitives,
+        config.sample_count
+    );
+}
+
 /// Error type for renderer operations
 #[derive(Debug)]
 pub enum RendererError {
@@ -876,14 +886,7 @@ impl GpuRenderer {
 
         let required_limits = device_required_limits(&adapter);
         let config = apply_renderer_config_overrides(config, &required_limits);
-
-        tracing::info!(
-            "gpu config: max_primitives={}, max_glyphs={}, max_glass_primitives={}, sample_count={}",
-            config.max_primitives,
-            config.max_glyphs,
-            config.max_glass_primitives,
-            config.sample_count
-        );
+        log_renderer_config(&config);
 
         let (device, queue) = adapter
             .request_device(
@@ -952,14 +955,7 @@ impl GpuRenderer {
 
         let required_limits = device_required_limits(&adapter);
         let config = apply_renderer_config_overrides(config, &required_limits);
-
-        tracing::info!(
-            "gpu config: max_primitives={}, max_glyphs={}, max_glass_primitives={}, sample_count={}",
-            config.max_primitives,
-            config.max_glyphs,
-            config.max_glass_primitives,
-            config.sample_count
-        );
+        log_renderer_config(&config);
 
         let (device, queue) = adapter
             .request_device(
@@ -1046,14 +1042,7 @@ impl GpuRenderer {
 
         let required_limits = device_required_limits(&adapter);
         let config = apply_renderer_config_overrides(config, &required_limits);
-
-        tracing::info!(
-            "gpu config: max_primitives={}, max_glyphs={}, max_glass_primitives={}, sample_count={}",
-            config.max_primitives,
-            config.max_glyphs,
-            config.max_glass_primitives,
-            config.sample_count
-        );
+        log_renderer_config(&config);
 
         let (device, queue) = adapter
             .request_device(


### PR DESCRIPTION
## Summary
- allow env overrides for GPU renderer limits
- centralize GPU config logging
- tidy renderer helpers formatting