### PR TITLE
refactor(core)!: switch DrawContext image APIs to owned buffers

### DIFF
--- a/crates/blinc_core/src/draw.rs
+++ b/crates/blinc_core/src/draw.rs
@@ -1188,7 +1188,7 @@ pub trait DrawContext {
     /// Default implementation returns [`ImageId::UNSUPPORTED`].
     fn create_image_rgba(
         &mut self,
-        _pixels: &[u8],
+        _pixels: Vec<u8>,
         _width: u32,
         _height: u32,
         _label: &str,
@@ -1213,7 +1213,7 @@ pub trait DrawContext {
         _y: u32,
         _width: u32,
         _height: u32,
-        _pixels: &[u8],
+        _pixels: Vec<u8>,
     ) {
     }
 

--- a/crates/blinc_gpu/src/paint.rs
+++ b/crates/blinc_gpu/src/paint.rs
@@ -1608,7 +1608,7 @@ impl<'a> DrawContext for GpuPaintContext<'a> {
 
     fn create_image_rgba(
         &mut self,
-        pixels: &[u8],
+        pixels: Vec<u8>,
         width: u32,
         height: u32,
         label: &str,
@@ -1619,7 +1619,7 @@ impl<'a> DrawContext for GpuPaintContext<'a> {
             width,
             height,
             label: Some(label.to_string()),
-            pixels: Some(pixels.to_vec()),
+            pixels: Some(pixels),
         });
         self.image_sizes.insert(id, (width, height));
         id
@@ -1645,7 +1645,7 @@ impl<'a> DrawContext for GpuPaintContext<'a> {
         y: u32,
         width: u32,
         height: u32,
-        pixels: &[u8],
+        pixels: Vec<u8>,
     ) {
         if image.0 == 0 {
             return;
@@ -1656,7 +1656,7 @@ impl<'a> DrawContext for GpuPaintContext<'a> {
             y,
             width,
             height,
-            pixels: pixels.to_vec(),
+            pixels,
         });
     }
 


### PR DESCRIPTION
## Summary
- change `DrawContext::create_image_rgba` to take owned pixel data (`Vec<u8>`) instead of borrowed slices
- change `DrawContext::write_image_rgba` to take owned pixel data (`Vec<u8>`) instead of borrowed slices
- update `GpuPaintContext` implementation to move buffers into queued image operations without extra `to_vec()` copies

## Why
Gemini review correctly pointed out repeated `to_vec()` allocations in hot paths. This PR isolates the required breaking API change from stability/security fixes and reduces avoidable copies when callers already own pixel data.

## Breaking Change
This modifies the `DrawContext` trait signatures:
- `create_image_rgba(&[u8], ...)` -> `create_image_rgba(Vec<u8>, ...)`
- `write_image_rgba(..., &[u8])` -> `write_image_rgba(..., Vec<u8>)`

Downstream call sites must pass owned buffers.

## Validation
- `cargo check -p blinc_core -p blinc_gpu`
- `cargo test -p blinc_core draw::tests::test_draw_context_ext`
