### PR TITLE
i18n: Label 타입 도입 + YAML 카탈로그(스키마) + Fluent 호환

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,6 +20,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Reduce disk usage on GitHub-hosted runners (debug info + incremental artifacts can be large).
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-C debuginfo=0"
 
 jobs:
   build-android:
@@ -69,7 +72,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-android-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-android-${{ matrix.target }}-
@@ -127,7 +129,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-android-check-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-android-check-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Reduce disk usage on GitHub-hosted runners (debug info + incremental artifacts can be large).
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-C debuginfo=0"
 
 jobs:
   check:
@@ -42,7 +45,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
@@ -88,7 +90,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
@@ -151,7 +152,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-clippy-
@@ -189,7 +189,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-docs-
@@ -243,7 +242,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-${{ matrix.target }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-cargo-release-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/blinc_core",
     "crates/blinc_animation",
     "crates/blinc_image",
+    "crates/blinc_i18n",
     "crates/blinc_layout",
     "crates/blinc_gpu",
     "crates/blinc_macros",

--- a/crates/blinc_app/Cargo.toml
+++ b/crates/blinc_app/Cargo.toml
@@ -27,6 +27,7 @@ blinc_platform = { path = "../blinc_platform", version = "0.1.12" }
 blinc_animation = { path = "../blinc_animation", version = "0.1.12" }
 blinc_macros = { path = "../blinc_macros", version = "0.1.12" }
 blinc_theme = { path = "../blinc_theme", version = "0.1.12" }
+blinc_i18n = { path = "../blinc_i18n", version = "0.1.12" }
 
 # GPU
 wgpu.workspace = true

--- a/crates/blinc_app/examples/i18n_demo.rs
+++ b/crates/blinc_app/examples/i18n_demo.rs
@@ -93,15 +93,11 @@ fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
                     button(toggle_btn, t!("demo-toggle"))
                         .on_click(|_| {
                             let i18n = I18nState::get();
-                            let available_locales = ["en-US", "ko-KR"];
-                            let current = i18n.locale();
-                            let current_pos = available_locales
-                                .iter()
-                                .position(|&l| l == current.as_str());
-                            let next_index =
-                                current_pos.map_or(0, |i| (i + 1) % available_locales.len());
-                            let next = available_locales[next_index];
-                            i18n.set_locale(next);
+                            if i18n.locale() == "en-US" {
+                                i18n.set_locale("ko-KR");
+                            } else {
+                                i18n.set_locale("en-US");
+                            }
                         })
                         .bg_color(Color::rgba(0.25, 0.55, 0.95, 1.0))
                         .hover_color(Color::rgba(0.30, 0.60, 1.0, 1.0))

--- a/crates/blinc_app/examples/i18n_demo.rs
+++ b/crates/blinc_app/examples/i18n_demo.rs
@@ -93,11 +93,14 @@ fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
                     button(toggle_btn, t!("demo-toggle"))
                         .on_click(|_| {
                             let i18n = I18nState::get();
-                            let next = if i18n.locale().starts_with("ko") {
-                                "en-US"
-                            } else {
-                                "ko-KR"
-                            };
+                            let available_locales = ["en-US", "ko-KR"];
+                            let current = i18n.locale();
+                            let current_index = available_locales
+                                .iter()
+                                .position(|&l| l == current)
+                                .unwrap_or(0);
+                            let next =
+                                available_locales[(current_index + 1) % available_locales.len()];
                             i18n.set_locale(next);
                         })
                         .bg_color(Color::rgba(0.25, 0.55, 0.95, 1.0))

--- a/crates/blinc_app/examples/i18n_demo.rs
+++ b/crates/blinc_app/examples/i18n_demo.rs
@@ -95,12 +95,19 @@ fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
                             let i18n = I18nState::get();
                             let available_locales = ["en-US", "ko-KR"];
                             let current = i18n.locale();
-                            let current_index = available_locales
+                            let next = match available_locales
                                 .iter()
-                                .position(|&l| l == current)
-                                .unwrap_or(0);
-                            let next =
-                                available_locales[(current_index + 1) % available_locales.len()];
+                                .position(|&l| l == current.as_str())
+                            {
+                                Some(current_index) => {
+                                    available_locales[(current_index + 1) % available_locales.len()]
+                                }
+                                None => {
+                                    // Demo only supports these locales; if the system locale isn't in
+                                    // the list, start from the first one instead of panicking.
+                                    available_locales[0]
+                                }
+                            };
                             i18n.set_locale(next);
                         })
                         .bg_color(Color::rgba(0.25, 0.55, 0.95, 1.0))

--- a/crates/blinc_app/examples/i18n_demo.rs
+++ b/crates/blinc_app/examples/i18n_demo.rs
@@ -95,18 +95,16 @@ fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
                             let i18n = I18nState::get();
                             let available_locales = ["en-US", "ko-KR"];
                             let current = i18n.locale();
-                            let next = match available_locales
-                                .iter()
-                                .position(|&l| l == current.as_str())
-                            {
-                                Some(current_index) => {
-                                    available_locales[(current_index + 1) % available_locales.len()]
-                                }
-                                None => {
-                                    // Demo only supports these locales; if the system locale isn't in
-                                    // the list, start from the first one instead of panicking.
-                                    available_locales[0]
-                                }
+                            let next = if available_locales.is_empty() {
+                                // Demo fallback.
+                                "en-US"
+                            } else {
+                                let current_pos = available_locales
+                                    .iter()
+                                    .position(|&l| l == current.as_str());
+                                let next_index =
+                                    current_pos.map_or(0, |i| (i + 1) % available_locales.len());
+                                available_locales[next_index]
                             };
                             i18n.set_locale(next);
                         })

--- a/crates/blinc_app/examples/i18n_demo.rs
+++ b/crates/blinc_app/examples/i18n_demo.rs
@@ -1,0 +1,100 @@
+//! i18n Demo (Simple + Fluent-compatible API)
+//!
+//! Run with:
+//! `cargo run -p blinc_app --example i18n_demo --features windowed`
+
+use blinc_app::prelude::*;
+use blinc_app::windowed::{WindowedApp, WindowedContext};
+use blinc_i18n::{t, I18nState};
+use blinc_layout::stateful::ButtonState;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    // Initialize catalogs before the first frame.
+    if I18nState::try_get().is_none() {
+        I18nState::init("en-US");
+    }
+    let i18n = I18nState::get();
+    i18n.load_simple_catalog_str(
+        "en-US",
+        include_str!("../../../resource/i18n/demo.en-US.yaml"),
+    )
+    .map_err(|e| BlincError::Other(e.to_string()))?;
+    i18n.load_simple_catalog_str(
+        "ko-KR",
+        include_str!("../../../resource/i18n/demo.ko-KR.yaml"),
+    )
+    .map_err(|e| BlincError::Other(e.to_string()))?;
+
+    // Fluent catalogs are loaded via the same API surface. (Enabled by default in blinc_i18n.)
+    i18n.load_fluent_ftl(
+        "en-US",
+        include_str!("../../../resource/i18n/demo.en-US.ftl"),
+    )
+    .map_err(|e| BlincError::Other(e.to_string()))?;
+    i18n.load_fluent_ftl(
+        "ko-KR",
+        include_str!("../../../resource/i18n/demo.ko-KR.ftl"),
+    )
+    .map_err(|e| BlincError::Other(e.to_string()))?;
+
+    let config = WindowConfig {
+        title: "Blinc i18n Demo".to_string(),
+        width: 900,
+        height: 600,
+        resizable: true,
+        ..Default::default()
+    };
+
+    WindowedApp::run(config, |ctx| build_ui(ctx))
+}
+
+fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
+    let i18n = I18nState::get();
+    let locale = i18n.locale();
+
+    let toggle_btn = ctx.use_state_for("toggle_locale_btn", ButtonState::Idle);
+
+    div()
+        .w(ctx.width)
+        .h(ctx.height)
+        .p(32.0)
+        .bg(Color::rgba(0.08, 0.09, 0.11, 1.0))
+        .child(
+            div()
+                .glass()
+                .rounded(18.0)
+                .p(24.0)
+                .gap(16.0)
+                .flex_col()
+                .child(text(t!("demo-title")).size(32.0).color(Color::WHITE))
+                .child(
+                    text(t!("demo-locale", { locale: locale.clone() }))
+                        .size(16.0)
+                        .color(Color::rgba(0.8, 0.85, 0.9, 1.0)),
+                )
+                .child(
+                    text(t!("demo-hello", { name: "Chris" }))
+                        .size(20.0)
+                        .color(Color::rgba(0.9, 0.92, 0.95, 1.0)),
+                )
+                .child(
+                    button(toggle_btn, t!("demo-toggle"))
+                        .on_click(|_| {
+                            let i18n = I18nState::get();
+                            let next = if i18n.locale().starts_with("ko") {
+                                "en-US"
+                            } else {
+                                "ko-KR"
+                            };
+                            i18n.set_locale(next);
+                        })
+                        .bg_color(Color::rgba(0.25, 0.55, 0.95, 1.0))
+                        .hover_color(Color::rgba(0.30, 0.60, 1.0, 1.0))
+                        .pressed_color(Color::rgba(0.18, 0.45, 0.85, 1.0)),
+                ),
+        )
+}

--- a/crates/blinc_app/examples/i18n_demo.rs
+++ b/crates/blinc_app/examples/i18n_demo.rs
@@ -95,17 +95,12 @@ fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
                             let i18n = I18nState::get();
                             let available_locales = ["en-US", "ko-KR"];
                             let current = i18n.locale();
-                            let next = if available_locales.is_empty() {
-                                // Demo fallback.
-                                "en-US"
-                            } else {
-                                let current_pos = available_locales
-                                    .iter()
-                                    .position(|&l| l == current.as_str());
-                                let next_index =
-                                    current_pos.map_or(0, |i| (i + 1) % available_locales.len());
-                                available_locales[next_index]
-                            };
+                            let current_pos = available_locales
+                                .iter()
+                                .position(|&l| l == current.as_str());
+                            let next_index =
+                                current_pos.map_or(0, |i| (i + 1) % available_locales.len());
+                            let next = available_locales[next_index];
                             i18n.set_locale(next);
                         })
                         .bg_color(Color::rgba(0.25, 0.55, 0.95, 1.0))

--- a/crates/blinc_app/examples/i18n_demo.rs
+++ b/crates/blinc_app/examples/i18n_demo.rs
@@ -18,28 +18,36 @@ fn main() -> Result<()> {
         I18nState::init("en-US");
     }
     let i18n = I18nState::get();
-    i18n.load_simple_catalog_str(
-        "en-US",
-        include_str!("../../../resource/i18n/demo.en-US.yaml"),
-    )
-    .map_err(|e| BlincError::Other(e.to_string()))?;
-    i18n.load_simple_catalog_str(
-        "ko-KR",
-        include_str!("../../../resource/i18n/demo.ko-KR.yaml"),
-    )
-    .map_err(|e| BlincError::Other(e.to_string()))?;
+    let simple_catalogs = [
+        (
+            "en-US",
+            include_str!("../../../resource/i18n/demo.en-US.yaml"),
+        ),
+        (
+            "ko-KR",
+            include_str!("../../../resource/i18n/demo.ko-KR.yaml"),
+        ),
+    ];
+    for (locale, content) in simple_catalogs {
+        i18n.load_simple_catalog_str(locale, content)
+            .map_err(|e| BlincError::Other(e.to_string()))?;
+    }
 
     // Fluent catalogs are loaded via the same API surface. (Enabled by default in blinc_i18n.)
-    i18n.load_fluent_ftl(
-        "en-US",
-        include_str!("../../../resource/i18n/demo.en-US.ftl"),
-    )
-    .map_err(|e| BlincError::Other(e.to_string()))?;
-    i18n.load_fluent_ftl(
-        "ko-KR",
-        include_str!("../../../resource/i18n/demo.ko-KR.ftl"),
-    )
-    .map_err(|e| BlincError::Other(e.to_string()))?;
+    let fluent_catalogs = [
+        (
+            "en-US",
+            include_str!("../../../resource/i18n/demo.en-US.ftl"),
+        ),
+        (
+            "ko-KR",
+            include_str!("../../../resource/i18n/demo.ko-KR.ftl"),
+        ),
+    ];
+    for (locale, content) in fluent_catalogs {
+        i18n.load_fluent_ftl(locale, content)
+            .map_err(|e| BlincError::Other(e.to_string()))?;
+    }
 
     let config = WindowConfig {
         title: "Blinc i18n Demo".to_string(),

--- a/crates/blinc_app/src/android.rs
+++ b/crates/blinc_app/src/android.rs
@@ -840,6 +840,19 @@ impl AndroidApp {
                 needs_rebuild = true;
             }
 
+            // Check if a full rebuild was requested by widgets (e.g., theme/locale changes).
+            if blinc_layout::widgets::take_needs_rebuild() {
+                tracing::debug!("Rebuild triggered by: widgets::request_full_rebuild()");
+                needs_rebuild = true;
+            }
+
+            // A relayout request implies a full rebuild on mobile paths (they don't have a
+            // separate layout-only refresh path).
+            if blinc_layout::widgets::take_needs_relayout() {
+                tracing::debug!("Rebuild triggered by: widgets::request_relayout()");
+                needs_rebuild = true;
+            }
+
             // Check if tree was marked dirty by event handlers
             if let Some(ref tree) = render_tree {
                 if tree.needs_rebuild() {

--- a/crates/blinc_app/src/android.rs
+++ b/crates/blinc_app/src/android.rs
@@ -91,15 +91,13 @@ impl AndroidApp {
             #[cfg(target_os = "android")]
             {
                 if blinc_platform_android::init_android_native_bridge(app).is_ok() {
-                    if blinc_core::native_bridge::NativeBridgeState::is_initialized() {
-                        if let Ok(l) = blinc_core::native_bridge::native_call::<String, _>(
-                            "device",
-                            "get_locale",
-                            (),
-                        ) {
-                            locale = Some(l);
-                        }
-                    }
+                    // `native_call` will fail if the bridge isn't initialized.
+                    locale = blinc_core::native_bridge::native_call::<String, _>(
+                        "device",
+                        "get_locale",
+                        (),
+                    )
+                    .ok();
                 }
             }
 

--- a/crates/blinc_app/src/ios.rs
+++ b/crates/blinc_app/src/ios.rs
@@ -91,11 +91,9 @@ impl IOSApp {
 
             // If the native bridge has been wired by Swift, use it to get the device locale.
             if blinc_core::native_bridge::NativeBridgeState::is_initialized() {
-                if let Ok(l) =
+                locale =
                     blinc_core::native_bridge::native_call::<String, _>("device", "get_locale", ())
-                {
-                    locale = Some(l);
-                }
+                        .ok();
             }
 
             I18nState::init(locale.unwrap_or_else(|| "en-US".to_string()));

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -1263,6 +1263,20 @@ impl WindowedContext {
     pub fn theme_radius(&self, token: blinc_theme::RadiusToken) -> f32 {
         blinc_theme::ThemeState::get().radius(token)
     }
+
+    // =========================================================================
+    // i18n API
+    // =========================================================================
+
+    /// Get the current locale identifier (e.g., "en-US", "ko-KR")
+    pub fn locale(&self) -> String {
+        blinc_i18n::I18nState::get().locale()
+    }
+
+    /// Set the current locale (triggers a full UI rebuild via i18n redraw callback)
+    pub fn set_locale(&self, locale: impl Into<String>) {
+        blinc_i18n::I18nState::get().set_locale(locale);
+    }
 }
 
 // =============================================================================
@@ -1418,6 +1432,53 @@ impl WindowedApp {
         });
     }
 
+    #[cfg(all(feature = "windowed", not(target_os = "android")))]
+    fn init_i18n() {
+        use blinc_i18n::I18nState;
+
+        fn parse_env_locale(raw: &str) -> Option<String> {
+            // Examples: "en_US.UTF-8", "ko_KR", "en-US", "C"
+            let mut s = raw.trim();
+            if s.is_empty() {
+                return None;
+            }
+            if let Some(pos) = s.find('.') {
+                s = &s[..pos];
+            }
+            if let Some(pos) = s.find('@') {
+                s = &s[..pos];
+            }
+            let s = s.trim();
+            if s.is_empty() || s == "C" || s == "POSIX" {
+                return None;
+            }
+            Some(s.replace('_', "-"))
+        }
+
+        fn detect_locale_from_env() -> Option<String> {
+            for key in ["LC_ALL", "LC_MESSAGES", "LANG"] {
+                if let Ok(v) = std::env::var(key) {
+                    if let Some(loc) = parse_env_locale(&v) {
+                        return Some(loc);
+                    }
+                }
+            }
+            None
+        }
+
+        // Only initialize if not already initialized
+        if I18nState::try_get().is_none() {
+            let locale = detect_locale_from_env().unwrap_or_else(|| "en-US".to_string());
+            I18nState::init(locale);
+        }
+
+        // Trigger full rebuild on locale changes (same behavior as theme changes).
+        blinc_i18n::set_redraw_callback(|| {
+            tracing::debug!("Locale changed - requesting full rebuild");
+            blinc_layout::widgets::request_full_rebuild();
+        });
+    }
+
     /// Run a windowed Blinc application on desktop platforms
     ///
     /// This is the main entry point for desktop applications. It creates
@@ -1465,6 +1526,9 @@ impl WindowedApp {
 
         // Initialize the theme system with platform detection
         Self::init_theme();
+
+        // Initialize i18n (locale + redraw hook)
+        Self::init_i18n();
 
         let platform = DesktopPlatform::new().map_err(|e| BlincError::Platform(e.to_string()))?;
         let event_loop = platform

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -1438,16 +1438,9 @@ impl WindowedApp {
 
         fn parse_env_locale(raw: &str) -> Option<String> {
             // Examples: "en_US.UTF-8", "ko_KR", "en-US", "C"
-            let mut s = raw.trim();
-            if s.is_empty() {
-                return None;
-            }
-            if let Some(pos) = s.find('.') {
-                s = &s[..pos];
-            }
-            if let Some(pos) = s.find('@') {
-                s = &s[..pos];
-            }
+            let s = raw.trim();
+            let s = s.split_once('.').map_or(s, |(part, _)| part);
+            let s = s.split_once('@').map_or(s, |(part, _)| part);
             let s = s.trim();
             if s.is_empty() || s == "C" || s == "POSIX" {
                 return None;

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -1449,14 +1449,9 @@ impl WindowedApp {
         }
 
         fn detect_locale_from_env() -> Option<String> {
-            for key in ["LC_ALL", "LC_MESSAGES", "LANG"] {
-                if let Ok(v) = std::env::var(key) {
-                    if let Some(loc) = parse_env_locale(&v) {
-                        return Some(loc);
-                    }
-                }
-            }
-            None
+            ["LC_ALL", "LC_MESSAGES", "LANG"]
+                .iter()
+                .find_map(|key| std::env::var(key).ok().and_then(|v| parse_env_locale(&v)))
         }
 
         // Only initialize if not already initialized

--- a/crates/blinc_cn/Cargo.toml
+++ b/crates/blinc_cn/Cargo.toml
@@ -20,6 +20,7 @@ blinc_layout = { path = "../blinc_layout", version = "0.1.12" }
 blinc_core = { path = "../blinc_core", version = "0.1.12" }
 blinc_animation = { path = "../blinc_animation", version = "0.1.12" }
 blinc_theme = { path = "../blinc_theme", version = "0.1.12" }
+blinc_i18n = { path = "../blinc_i18n", version = "0.1.12" }
 blinc_macros = { path = "../blinc_macros", version = "0.1.12" }
 blinc_icons = { path = "../blinc_icons", version = "0.1.12" }
 

--- a/crates/blinc_cn/src/components/alert.rs
+++ b/crates/blinc_cn/src/components/alert.rs
@@ -87,13 +87,13 @@ pub struct Alert {
 
 impl Alert {
     /// Create a new alert with a message
-    pub fn new(message: impl Into<String>) -> Self {
+    pub fn new(message: impl Into<Label>) -> Self {
         Self::with_variant(message, AlertVariant::default())
     }
 
-    fn with_variant(message: impl Into<String>, variant: AlertVariant) -> Self {
+    fn with_variant(message: impl Into<Label>, variant: AlertVariant) -> Self {
         let theme = ThemeState::get();
-        let message = message.into();
+        let message: Label = message.into();
 
         let bg = variant.background(&theme);
         let border_color = variant.border(&theme);
@@ -106,7 +106,7 @@ impl Alert {
             .border(1.0, border_color)
             .rounded(radius)
             .p_px(padding)
-            .child(text(&message).size(14.0).color(text_color));
+            .child(text(message).size(14.0).color(text_color));
 
         Self { inner }
     }
@@ -164,7 +164,7 @@ impl ElementBuilder for Alert {
 }
 
 /// Create a simple alert with a message
-pub fn alert(message: impl Into<String>) -> Alert {
+pub fn alert(message: impl Into<Label>) -> Alert {
     Alert::new(message)
 }
 

--- a/crates/blinc_cn/src/components/alert.rs
+++ b/crates/blinc_cn/src/components/alert.rs
@@ -32,6 +32,7 @@
 use std::ops::{Deref, DerefMut};
 
 use blinc_core::Color;
+use blinc_i18n::Label;
 use blinc_layout::div::{Div, ElementBuilder, ElementTypeId};
 use blinc_layout::prelude::*;
 use blinc_theme::{ColorToken, RadiusToken, SpacingToken, ThemeState};
@@ -212,7 +213,7 @@ impl AlertBox {
     }
 
     /// Set the alert title
-    pub fn title(mut self, title: impl Into<String>) -> Self {
+    pub fn title(mut self, title: impl Into<Label>) -> Self {
         let theme = ThemeState::get();
         let color = self.variant.text_color(&theme);
 
@@ -223,7 +224,7 @@ impl AlertBox {
     }
 
     /// Set the alert description
-    pub fn description(mut self, desc: impl Into<String>) -> Self {
+    pub fn description(mut self, desc: impl Into<Label>) -> Self {
         let theme = ThemeState::get();
         let color = theme.color(ColorToken::TextSecondary);
 

--- a/crates/blinc_cn/src/components/button.rs
+++ b/crates/blinc_cn/src/components/button.rs
@@ -295,8 +295,6 @@ impl Button {
         let radius = config.btn_size.border_radius(&theme);
         let variant = config.variant;
         let label = config.label.clone();
-        let resolved_label = blinc_i18n::resolve_label_ref(&label);
-        let label_is_empty = resolved_label.is_empty();
         let icon = config.icon.clone();
         let icon_position = config.icon_position;
         let border = variant.border(&theme);
@@ -326,7 +324,11 @@ impl Button {
 
                 // Build content with icon + label or just label
                 let mut content = blinc_layout::div::div().flex_row().items_center().gap(6.0);
-                let label_text = text(resolved_label.clone())
+                // Resolve label inside the callback so locale changes propagate even if the button
+                // element is cached.
+                let resolved_label = blinc_i18n::resolve_label_ref(&label);
+                let label_is_empty = resolved_label.is_empty();
+                let label_text = text(resolved_label)
                     .size(font_size)
                     .color(fg)
                     .no_wrap()

--- a/crates/blinc_cn/src/components/button.rs
+++ b/crates/blinc_cn/src/components/button.rs
@@ -26,6 +26,7 @@
 //! ```
 
 use blinc_core::Color;
+use blinc_i18n::Label;
 use blinc_layout::div::ElementBuilder;
 use blinc_layout::element::CursorStyle;
 use blinc_layout::prelude::*;
@@ -244,7 +245,7 @@ pub(crate) fn reset_button_state(key: &str) {
 /// }
 /// ```
 #[track_caller]
-pub fn button(label: impl Into<String>) -> ButtonBuilder {
+pub fn button(label: impl Into<Label>) -> ButtonBuilder {
     ButtonBuilder {
         key: InstanceKey::new("button"),
         config: ButtonConfig {
@@ -263,7 +264,7 @@ pub fn button(label: impl Into<String>) -> ButtonBuilder {
 /// Internal configuration for ButtonBuilder
 #[derive(Clone)]
 struct ButtonConfig {
-    label: String,
+    label: Label,
     variant: ButtonVariant,
     btn_size: ButtonSize,
     disabled: bool,
@@ -294,6 +295,7 @@ impl Button {
         let radius = config.btn_size.border_radius(&theme);
         let variant = config.variant;
         let label = config.label.clone();
+        let label_is_empty = matches!(&label, Label::Raw(s) if s.is_empty());
         let icon = config.icon.clone();
         let icon_position = config.icon_position;
         let border = variant.border(&theme);
@@ -323,7 +325,7 @@ impl Button {
 
                 // Build content with icon + label or just label
                 let mut content = blinc_layout::div::div().flex_row().items_center().gap(6.0);
-                let label_text = text(&label)
+                let label_text = text(label.clone())
                     .size(font_size)
                     .color(fg)
                     .no_wrap()
@@ -336,7 +338,7 @@ impl Button {
                     let svg_str = blinc_icons::to_svg(icon_str, icon_size);
                     let icon_svg = svg(&svg_str).size(icon_size, icon_size).color(fg);
 
-                    if label.is_empty() {
+                    if label_is_empty {
                         // Icon-only button
                         content = content.child(icon_svg);
                     } else {
@@ -457,7 +459,7 @@ impl ButtonBuilder {
     ///
     /// For most use cases, prefer `button()` which auto-generates a unique key.
     /// Use this when you need a deterministic key for programmatic access.
-    pub fn with_key(key: impl Into<String>, label: impl Into<String>) -> Self {
+    pub fn with_key(key: impl Into<String>, label: impl Into<Label>) -> Self {
         Self {
             key: InstanceKey::explicit(key),
             config: ButtonConfig {

--- a/crates/blinc_cn/src/components/button.rs
+++ b/crates/blinc_cn/src/components/button.rs
@@ -324,7 +324,7 @@ impl Button {
 
                 // Build content with icon + label or just label
                 let mut content = blinc_layout::div::div().flex_row().items_center().gap(6.0);
-                let resolved_label = blinc_i18n::resolve_label(label.clone());
+                let resolved_label = blinc_i18n::resolve_label_ref(&label);
                 let label_is_empty = resolved_label.is_empty();
                 let label_text = text(resolved_label)
                     .size(font_size)

--- a/crates/blinc_cn/src/components/button.rs
+++ b/crates/blinc_cn/src/components/button.rs
@@ -295,6 +295,8 @@ impl Button {
         let radius = config.btn_size.border_radius(&theme);
         let variant = config.variant;
         let label = config.label.clone();
+        let resolved_label = blinc_i18n::resolve_label_ref(&label);
+        let label_is_empty = resolved_label.is_empty();
         let icon = config.icon.clone();
         let icon_position = config.icon_position;
         let border = variant.border(&theme);
@@ -324,9 +326,7 @@ impl Button {
 
                 // Build content with icon + label or just label
                 let mut content = blinc_layout::div::div().flex_row().items_center().gap(6.0);
-                let resolved_label = blinc_i18n::resolve_label_ref(&label);
-                let label_is_empty = resolved_label.is_empty();
-                let label_text = text(resolved_label)
+                let label_text = text(resolved_label.clone())
                     .size(font_size)
                     .color(fg)
                     .no_wrap()

--- a/crates/blinc_cn/src/components/button.rs
+++ b/crates/blinc_cn/src/components/button.rs
@@ -295,7 +295,6 @@ impl Button {
         let radius = config.btn_size.border_radius(&theme);
         let variant = config.variant;
         let label = config.label.clone();
-        let label_is_empty = matches!(&label, Label::Raw(s) if s.is_empty());
         let icon = config.icon.clone();
         let icon_position = config.icon_position;
         let border = variant.border(&theme);
@@ -325,7 +324,9 @@ impl Button {
 
                 // Build content with icon + label or just label
                 let mut content = blinc_layout::div::div().flex_row().items_center().gap(6.0);
-                let label_text = text(label.clone())
+                let resolved_label = blinc_i18n::resolve_label(label.clone());
+                let label_is_empty = resolved_label.is_empty();
+                let label_text = text(resolved_label)
                     .size(font_size)
                     .color(fg)
                     .no_wrap()

--- a/crates/blinc_cn/src/components/card.rs
+++ b/crates/blinc_cn/src/components/card.rs
@@ -26,6 +26,7 @@
 
 use std::ops::{Deref, DerefMut};
 
+use blinc_i18n::Label;
 use blinc_layout::div::{Div, ElementBuilder, ElementTypeId};
 use blinc_layout::prelude::*;
 use blinc_theme::{ColorToken, RadiusToken, SpacingToken, ThemeState};
@@ -210,7 +211,7 @@ impl CardHeader {
     }
 
     /// Add a title
-    pub fn title(mut self, title: impl Into<String>) -> Self {
+    pub fn title(mut self, title: impl Into<Label>) -> Self {
         let theme = ThemeState::get();
         self.inner = self.inner.child(
             text(title)
@@ -222,7 +223,7 @@ impl CardHeader {
     }
 
     /// Add a description
-    pub fn description(mut self, desc: impl Into<String>) -> Self {
+    pub fn description(mut self, desc: impl Into<Label>) -> Self {
         let theme = ThemeState::get();
         self.inner = self.inner.child(
             text(desc)

--- a/crates/blinc_i18n/Cargo.toml
+++ b/crates/blinc_i18n/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "blinc_i18n"
+description = "Internationalization (i18n) for Blinc - labels, locale switching, and translation backends"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[features]
+default = ["simple", "fluent"]
+simple = []
+fluent = ["dep:fluent-bundle", "dep:unic-langid"]
+
+[dependencies]
+thiserror.workspace = true
+tracing.workspace = true
+
+# Fluent (optional)
+fluent-bundle = { version = "0.15", optional = true }
+unic-langid = { version = "0.9", optional = true }
+
+# YAML catalogs
+serde_yaml = "0.9"
+
+[dev-dependencies]
+pretty_assertions = "1.4"

--- a/crates/blinc_i18n/Cargo.toml
+++ b/crates/blinc_i18n/Cargo.toml
@@ -11,8 +11,7 @@ rust-version.workspace = true
 crate-type = ["lib"]
 
 [features]
-default = ["simple", "fluent"]
-simple = []
+default = ["fluent"]
 fluent = ["dep:fluent-bundle", "dep:unic-langid"]
 
 [dependencies]

--- a/crates/blinc_i18n/src/error.rs
+++ b/crates/blinc_i18n/src/error.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+
+use crate::simple::SimpleParseError;
+
+#[derive(Debug, Error)]
+pub enum I18nError {
+    #[error(transparent)]
+    SimpleParse(#[from] SimpleParseError),
+
+    #[error("fluent error: {0}")]
+    Fluent(String),
+}

--- a/crates/blinc_i18n/src/fluent.rs
+++ b/crates/blinc_i18n/src/fluent.rs
@@ -1,0 +1,84 @@
+#[cfg(feature = "fluent")]
+use std::collections::HashMap;
+
+#[cfg(feature = "fluent")]
+use fluent_bundle::concurrent::FluentBundle;
+use fluent_bundle::{FluentArgs, FluentResource, FluentValue};
+
+#[cfg(feature = "fluent")]
+use unic_langid::LanguageIdentifier;
+
+#[cfg(feature = "fluent")]
+use crate::label::{ArgValue, Message};
+
+#[cfg(feature = "fluent")]
+use crate::locale::normalize_locale;
+
+/// A Fluent bundle wrapper keyed by locale.
+///
+/// Note: we intentionally keep this thin; the stable API lives on `I18nState`.
+#[cfg(feature = "fluent")]
+#[derive(Default)]
+pub struct FluentStore {
+    bundles: HashMap<String, FluentBundle<FluentResource>>,
+}
+
+#[cfg(feature = "fluent")]
+impl FluentStore {
+    pub fn new() -> Self {
+        Self {
+            bundles: HashMap::new(),
+        }
+    }
+
+    pub fn load_from_str(&mut self, locale: &str, ftl: &str) -> Result<(), String> {
+        let loc = normalize_locale(locale);
+        let langid: LanguageIdentifier = loc
+            .parse()
+            .map_err(|e| format!("invalid locale `{}`: {}", loc, e))?;
+
+        let res = FluentResource::try_new(ftl.to_string())
+            .map_err(|(_res, errs)| format!("ftl parse error: {:?}", errs))?;
+
+        let mut bundle = FluentBundle::new_concurrent(vec![langid]);
+        bundle
+            .add_resource(res)
+            .map_err(|errs| format!("ftl add_resource error: {:?}", errs))?;
+
+        self.bundles.insert(loc, bundle);
+        Ok(())
+    }
+
+    pub fn format_message(&self, locale: &str, msg: &Message) -> Option<String> {
+        let loc = normalize_locale(locale);
+        let bundle = self.bundles.get(&loc)?;
+        let pattern = bundle.get_message(&msg.id)?.value()?;
+
+        let mut args = FluentArgs::new();
+        for (k, v) in &msg.args {
+            match v {
+                ArgValue::Str(s) => {
+                    args.set(k.as_ref(), FluentValue::from(s.as_str()));
+                }
+                ArgValue::Int(i) => {
+                    args.set(k.as_ref(), FluentValue::from(*i));
+                }
+                ArgValue::Float(f) => {
+                    args.set(k.as_ref(), FluentValue::from(*f));
+                }
+                ArgValue::Bool(b) => {
+                    // Fluent has no native bool; pass through as a string.
+                    args.set(k.as_ref(), FluentValue::from(b.to_string()));
+                }
+            }
+        }
+
+        let mut errs = Vec::new();
+        let s = bundle
+            .format_pattern(pattern, Some(&args), &mut errs)
+            .to_string();
+        Some(s)
+    }
+}
+
+// Intentionally no shared conversion helper: `FluentValue` carries lifetimes.

--- a/crates/blinc_i18n/src/fluent.rs
+++ b/crates/blinc_i18n/src/fluent.rs
@@ -43,8 +43,7 @@ impl FluentStore {
     }
 
     pub fn format_message(&self, locale: &str, msg: &Message) -> Option<String> {
-        let loc = normalize_locale(locale);
-        let bundle = self.bundles.get(&loc)?;
+        let bundle = self.bundles.get(locale)?;
         let pattern = bundle.get_message(&msg.id)?.value()?;
 
         let mut args = FluentArgs::new();
@@ -72,7 +71,7 @@ impl FluentStore {
             .to_string();
         if !errs.is_empty() {
             tracing::warn!(
-                locale = %loc,
+                locale = %locale,
                 message_id = %msg.id,
                 errors = ?errs,
                 "Fluent formatting errors"

--- a/crates/blinc_i18n/src/fluent.rs
+++ b/crates/blinc_i18n/src/fluent.rs
@@ -77,6 +77,14 @@ impl FluentStore {
         let s = bundle
             .format_pattern(pattern, Some(&args), &mut errs)
             .to_string();
+        if !errs.is_empty() {
+            tracing::warn!(
+                locale = %loc,
+                message_id = %msg.id,
+                errors = ?errs,
+                "Fluent formatting errors"
+            );
+        }
         Some(s)
     }
 }

--- a/crates/blinc_i18n/src/fluent.rs
+++ b/crates/blinc_i18n/src/fluent.rs
@@ -1,29 +1,22 @@
-#[cfg(feature = "fluent")]
 use std::collections::HashMap;
 
-#[cfg(feature = "fluent")]
 use fluent_bundle::concurrent::FluentBundle;
 use fluent_bundle::{FluentArgs, FluentResource, FluentValue};
 
-#[cfg(feature = "fluent")]
 use unic_langid::LanguageIdentifier;
 
-#[cfg(feature = "fluent")]
 use crate::label::{ArgValue, Message};
 
-#[cfg(feature = "fluent")]
 use crate::locale::normalize_locale;
 
 /// A Fluent bundle wrapper keyed by locale.
 ///
 /// Note: we intentionally keep this thin; the stable API lives on `I18nState`.
-#[cfg(feature = "fluent")]
 #[derive(Default)]
 pub struct FluentStore {
     bundles: HashMap<String, FluentBundle<FluentResource>>,
 }
 
-#[cfg(feature = "fluent")]
 impl FluentStore {
     pub fn new() -> Self {
         Self {

--- a/crates/blinc_i18n/src/label.rs
+++ b/crates/blinc_i18n/src/label.rs
@@ -1,0 +1,120 @@
+use std::borrow::Cow;
+
+/// A translation argument value.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ArgValue {
+    Str(String),
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+}
+
+impl From<String> for ArgValue {
+    fn from(v: String) -> Self {
+        Self::Str(v)
+    }
+}
+
+impl From<&str> for ArgValue {
+    fn from(v: &str) -> Self {
+        Self::Str(v.to_string())
+    }
+}
+
+impl From<i64> for ArgValue {
+    fn from(v: i64) -> Self {
+        Self::Int(v)
+    }
+}
+
+impl From<i32> for ArgValue {
+    fn from(v: i32) -> Self {
+        Self::Int(v as i64)
+    }
+}
+
+impl From<usize> for ArgValue {
+    fn from(v: usize) -> Self {
+        Self::Int(v as i64)
+    }
+}
+
+impl From<f64> for ArgValue {
+    fn from(v: f64) -> Self {
+        Self::Float(v)
+    }
+}
+
+impl From<f32> for ArgValue {
+    fn from(v: f32) -> Self {
+        Self::Float(v as f64)
+    }
+}
+
+impl From<bool> for ArgValue {
+    fn from(v: bool) -> Self {
+        Self::Bool(v)
+    }
+}
+
+/// A message key + arguments (backend-agnostic).
+#[derive(Clone, Debug, PartialEq)]
+pub struct Message {
+    pub id: Cow<'static, str>,
+    pub args: Vec<(Cow<'static, str>, ArgValue)>,
+}
+
+impl Message {
+    pub fn new(id: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            id: id.into(),
+            args: Vec::new(),
+        }
+    }
+
+    pub fn arg(mut self, name: impl Into<Cow<'static, str>>, value: impl Into<ArgValue>) -> Self {
+        self.args.push((name.into(), value.into()));
+        self
+    }
+}
+
+/// A UI label: either raw text or a translatable message key.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Label {
+    Raw(String),
+    Msg(Message),
+}
+
+impl Label {
+    pub fn raw(s: impl Into<String>) -> Self {
+        Self::Raw(s.into())
+    }
+
+    pub fn msg(m: Message) -> Self {
+        Self::Msg(m)
+    }
+}
+
+impl From<String> for Label {
+    fn from(s: String) -> Self {
+        Self::Raw(s)
+    }
+}
+
+impl From<&str> for Label {
+    fn from(s: &str) -> Self {
+        Self::Raw(s.to_string())
+    }
+}
+
+impl From<&String> for Label {
+    fn from(s: &String) -> Self {
+        Self::Raw(s.clone())
+    }
+}
+
+impl From<Message> for Label {
+    fn from(m: Message) -> Self {
+        Self::Msg(m)
+    }
+}

--- a/crates/blinc_i18n/src/lib.rs
+++ b/crates/blinc_i18n/src/lib.rs
@@ -4,7 +4,7 @@
 //! - Framework-level `Label` type (`text(label)`, `button(..., label)`, etc.)
 //! - Runtime locale switching with an app-provided redraw callback
 //! - Multiple translation backends behind a stable API:
-//!   - `simple`: Blinc key=value catalog format (default)
+//!   - `simple`: YAML mapping catalogs (default, with legacy key=value fallback)
 //!   - `fluent`: Fluent (.ftl) catalogs (optional feature)
 
 mod error;

--- a/crates/blinc_i18n/src/lib.rs
+++ b/crates/blinc_i18n/src/lib.rs
@@ -22,20 +22,27 @@ pub use locale::{locale_fallback_chain, normalize_locale};
 pub use simple::{SimpleCatalog, SimpleParseError};
 pub use state::{set_redraw_callback, I18nState};
 
+/// Translate a label to a displayable string using the global [`I18nState`] (borrowed).
+///
+/// Prefer this overload in hot paths to avoid cloning `Label` values.
+pub fn resolve_label_ref(label: &Label) -> String {
+    if let Some(st) = I18nState::try_get() {
+        st.resolve_label(label)
+    } else {
+        match label {
+            Label::Raw(s) => s.clone(),
+            Label::Msg(m) => m.id.to_string(),
+        }
+    }
+}
+
 /// Translate a label to a displayable string using the global [`I18nState`].
 ///
 /// If the state isn't initialized, this degrades gracefully:
 /// - `Label::Raw` returns its raw text
 /// - `Label::Msg` returns the key id
 pub fn resolve_label(label: Label) -> String {
-    if let Some(st) = I18nState::try_get() {
-        st.resolve_label(label)
-    } else {
-        match label {
-            Label::Raw(s) => s,
-            Label::Msg(m) => m.id.to_string(),
-        }
-    }
+    resolve_label_ref(&label)
 }
 
 /// Convenience macro for building a translation key + args as a [`Label`].

--- a/crates/blinc_i18n/src/lib.rs
+++ b/crates/blinc_i18n/src/lib.rs
@@ -1,0 +1,58 @@
+//! Blinc internationalization (i18n)
+//!
+//! Goals:
+//! - Framework-level `Label` type (`text(label)`, `button(..., label)`, etc.)
+//! - Runtime locale switching with an app-provided redraw callback
+//! - Multiple translation backends behind a stable API:
+//!   - `simple`: Blinc key=value catalog format (default)
+//!   - `fluent`: Fluent (.ftl) catalogs (optional feature)
+
+mod error;
+mod label;
+mod locale;
+mod simple;
+mod state;
+
+#[cfg(feature = "fluent")]
+mod fluent;
+
+pub use error::I18nError;
+pub use label::{ArgValue, Label, Message};
+pub use locale::{locale_fallback_chain, normalize_locale};
+pub use simple::{SimpleCatalog, SimpleParseError};
+pub use state::{set_redraw_callback, I18nState};
+
+/// Translate a label to a displayable string using the global [`I18nState`].
+///
+/// If the state isn't initialized, this degrades gracefully:
+/// - `Label::Raw` returns its raw text
+/// - `Label::Msg` returns the key id
+pub fn resolve_label(label: Label) -> String {
+    if let Some(st) = I18nState::try_get() {
+        st.resolve_label(label)
+    } else {
+        match label {
+            Label::Raw(s) => s,
+            Label::Msg(m) => m.id.to_string(),
+        }
+    }
+}
+
+/// Convenience macro for building a translation key + args as a [`Label`].
+///
+/// Examples:
+/// - `t!("app.title")`
+/// - `t!("greeting", { name: user_name, count: 3 })`
+#[macro_export]
+macro_rules! t {
+    ($id:literal) => {
+        $crate::Label::msg($crate::Message::new($id))
+    };
+    ($id:literal, { $($name:ident : $value:expr),* $(,)? }) => {{
+        let mut m = $crate::Message::new($id);
+        $(
+            m = m.arg(stringify!($name), $value);
+        )*
+        $crate::Label::msg(m)
+    }};
+}

--- a/crates/blinc_i18n/src/locale.rs
+++ b/crates/blinc_i18n/src/locale.rs
@@ -1,0 +1,38 @@
+/// Normalize locale identifiers to a canonical-ish form for lookup.
+///
+/// - Converts `_` to `-` (Android often reports `en_US`).
+/// - Trims whitespace.
+pub fn normalize_locale(s: &str) -> String {
+    s.trim().replace('_', "-")
+}
+
+/// Create a fallback chain for translation lookup.
+///
+/// Example:
+/// - `ko-KR` -> `["ko-KR", "ko", "en-US"]`
+/// - `en-US` -> `["en-US", "en", "en-US"]` (deduped to `["en-US", "en"]`)
+pub fn locale_fallback_chain(locale: &str) -> Vec<String> {
+    let l = normalize_locale(locale);
+    let mut chain = Vec::new();
+
+    if !l.is_empty() {
+        chain.push(l.clone());
+        if let Some(lang) = l.split('-').next() {
+            if !lang.is_empty() {
+                chain.push(lang.to_string());
+            }
+        }
+    }
+
+    // Hard fallback for now: English.
+    chain.push("en-US".to_string());
+
+    // Dedup, preserve order.
+    let mut out = Vec::new();
+    for x in chain {
+        if !out.contains(&x) {
+            out.push(x);
+        }
+    }
+    out
+}

--- a/crates/blinc_i18n/src/locale.rs
+++ b/crates/blinc_i18n/src/locale.rs
@@ -29,8 +29,9 @@ pub fn locale_fallback_chain(locale: &str) -> Vec<String> {
 
     // Dedup, preserve order.
     let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
     for x in chain {
-        if !out.contains(&x) {
+        if seen.insert(x.clone()) {
             out.push(x);
         }
     }

--- a/crates/blinc_i18n/src/simple.rs
+++ b/crates/blinc_i18n/src/simple.rs
@@ -246,24 +246,19 @@ fn apply_placeholders(tmpl: &str, args: &[(&str, &ArgValue)]) -> String {
             continue;
         }
 
-        if let Some(map) = args_map.as_ref() {
-            if let Some(v) = map.get(key) {
-                out.push_str(&arg_to_string(v));
-            } else {
-                // Keep unknown placeholders visible.
-                out.push('{');
-                out.push_str(key);
-                out.push('}');
-            }
+        let value = if let Some(map) = args_map.as_ref() {
+            map.get(key).copied()
         } else {
-            if let Some((_, v)) = args.iter().find(|(k, _)| *k == key) {
-                out.push_str(&arg_to_string(v));
-            } else {
-                // Keep unknown placeholders visible.
-                out.push('{');
-                out.push_str(key);
-                out.push('}');
-            }
+            args.iter().find(|(k, _)| *k == key).map(|(_, v)| *v)
+        };
+
+        if let Some(v) = value {
+            out.push_str(&arg_to_string(v));
+        } else {
+            // Keep unknown placeholders visible.
+            out.push('{');
+            out.push_str(key);
+            out.push('}');
         }
     }
 

--- a/crates/blinc_i18n/src/simple.rs
+++ b/crates/blinc_i18n/src/simple.rs
@@ -1,0 +1,272 @@
+use std::collections::HashMap;
+
+use thiserror::Error;
+
+use crate::label::ArgValue;
+use crate::label::Message;
+
+fn parse_yaml_map(src: &str) -> Result<HashMap<String, String>, String> {
+    let raw: HashMap<String, serde_yaml::Value> =
+        serde_yaml::from_str(src).map_err(|e| format!("yaml parse error: {e}"))?;
+
+    let mut out = HashMap::with_capacity(raw.len());
+    for (k, v) in raw {
+        let s = match v {
+            serde_yaml::Value::Null => "".to_string(),
+            serde_yaml::Value::Bool(b) => b.to_string(),
+            serde_yaml::Value::Number(n) => n.to_string(),
+            serde_yaml::Value::String(s) => s,
+            serde_yaml::Value::Sequence(_)
+            | serde_yaml::Value::Mapping(_)
+            | serde_yaml::Value::Tagged(_) => {
+                return Err(format!(
+                    "yaml value for key `{k}` must be a scalar (string/number/bool/null)"
+                ));
+            }
+        };
+        out.insert(k, s);
+    }
+    Ok(out)
+}
+
+/// A minimal Blinc catalog format:
+/// - One entry per line: `key = value`
+/// - Comments: `# ...` or `// ...`
+/// - Optional quoting: `"..."` or `'...'` (supports a few escapes)
+/// - Placeholders: `{name}` replaced with args by name (stringified)
+#[derive(Clone, Debug, Default)]
+pub struct SimpleCatalog {
+    entries: HashMap<String, String>,
+}
+
+impl SimpleCatalog {
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        self.entries.insert(key.into(), value.into());
+    }
+
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.entries.get(key).map(|s| s.as_str())
+    }
+
+    /// Parse a YAML mapping (preferred) or fall back to the legacy key=value format.
+    pub fn parse(src: &str) -> Result<Self, SimpleParseError> {
+        if let Ok(map) = parse_yaml_map(src) {
+            let mut cat = Self::new();
+            for (k, v) in map {
+                cat.insert(k, v);
+            }
+            return Ok(cat);
+        }
+
+        let mut cat = Self::new();
+        for (idx, raw_line) in src.lines().enumerate() {
+            let line_no = idx + 1;
+            let line = raw_line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            if line.starts_with('#') || line.starts_with("//") {
+                continue;
+            }
+
+            let Some(eq) = line.find('=') else {
+                return Err(SimpleParseError::Syntax {
+                    line: line_no,
+                    msg: "expected `key = value`".to_string(),
+                });
+            };
+
+            let key = line[..eq].trim();
+            let mut value = line[eq + 1..].trim().to_string();
+            if key.is_empty() {
+                return Err(SimpleParseError::Syntax {
+                    line: line_no,
+                    msg: "empty key".to_string(),
+                });
+            }
+
+            // Strip inline comments (only if preceded by whitespace).
+            if let Some(pos) = value.find(" #") {
+                value.truncate(pos);
+                value = value.trim().to_string();
+            }
+            if let Some(pos) = value.find(" //") {
+                value.truncate(pos);
+                value = value.trim().to_string();
+            }
+
+            let value = unquote_and_unescape(&value).map_err(|e| SimpleParseError::Syntax {
+                line: line_no,
+                msg: e,
+            })?;
+
+            cat.insert(key, value);
+        }
+        Ok(cat)
+    }
+
+    pub fn format_message(&self, msg: &Message) -> Option<String> {
+        let tmpl = self.get(msg.id.as_ref())?;
+        Some(apply_placeholders(
+            tmpl,
+            &msg.args
+                .iter()
+                .map(|(k, v)| (k.as_ref(), v))
+                .collect::<Vec<_>>(),
+        ))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SimpleParseError {
+    #[error("simple catalog syntax error at line {line}: {msg}")]
+    Syntax { line: usize, msg: String },
+}
+
+fn unquote_and_unescape(s: &str) -> Result<String, String> {
+    let s = s.trim();
+    if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
+        return Ok(unescape(&s[1..s.len() - 1])?);
+    }
+    if s.starts_with('\'') && s.ends_with('\'') && s.len() >= 2 {
+        return Ok(unescape(&s[1..s.len() - 1])?);
+    }
+    Ok(s.to_string())
+}
+
+fn unescape(s: &str) -> Result<String, String> {
+    let mut out = String::with_capacity(s.len());
+    let mut it = s.chars();
+    while let Some(c) = it.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        let Some(n) = it.next() else {
+            return Err("dangling escape".to_string());
+        };
+        match n {
+            'n' => out.push('\n'),
+            'r' => out.push('\r'),
+            't' => out.push('\t'),
+            '\\' => out.push('\\'),
+            '"' => out.push('"'),
+            '\'' => out.push('\''),
+            _ => {
+                // Keep unknown escapes as-is.
+                out.push(n);
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn arg_to_string(v: &ArgValue) -> String {
+    match v {
+        ArgValue::Str(s) => s.clone(),
+        ArgValue::Int(i) => i.to_string(),
+        ArgValue::Float(f) => {
+            // Keep it simple; formatting control is a future concern.
+            let mut s = f.to_string();
+            if s.contains('.') {
+                while s.ends_with('0') {
+                    s.pop();
+                }
+                if s.ends_with('.') {
+                    s.pop();
+                }
+            }
+            s
+        }
+        ArgValue::Bool(b) => b.to_string(),
+    }
+}
+
+fn apply_placeholders(tmpl: &str, args: &[(&str, &ArgValue)]) -> String {
+    if !tmpl.contains('{') {
+        return tmpl.to_string();
+    }
+
+    // Very small placeholder engine: replaces `{name}` tokens.
+    let mut out = String::with_capacity(tmpl.len() + 8);
+    let mut chars = tmpl.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c != '{' {
+            out.push(c);
+            continue;
+        }
+
+        // Read until `}`.
+        let mut key = String::new();
+        while let Some(&n) = chars.peek() {
+            chars.next();
+            if n == '}' {
+                break;
+            }
+            key.push(n);
+        }
+
+        let key = key.trim();
+        if key.is_empty() {
+            out.push_str("{}");
+            continue;
+        }
+
+        if let Some((_, v)) = args.iter().find(|(k, _)| *k == key) {
+            out.push_str(&arg_to_string(v));
+        } else {
+            // Keep unknown placeholders visible.
+            out.push('{');
+            out.push_str(key);
+            out.push('}');
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn parse_yaml_and_lookup() {
+        let src = r#"
+demo-title: "Blinc i18n Demo"
+demo-hello: "Hello, {name}!"
+"#;
+
+        let cat = SimpleCatalog::parse(src).unwrap();
+        assert_eq!(cat.get("demo-title"), Some("Blinc i18n Demo"));
+
+        let s = cat
+            .format_message(&Message::new("demo-hello").arg("name", "Chris"))
+            .unwrap();
+        assert_eq!(s, "Hello, Chris!");
+    }
+
+    #[test]
+    fn parse_legacy_kv_and_lookup() {
+        let src = r#"
+        # comment
+        demo-title = Blinc i18n Demo
+        demo-hello = "Hello, {name}!"
+        "#;
+
+        let cat = SimpleCatalog::parse(src).unwrap();
+        assert_eq!(cat.get("demo-title"), Some("Blinc i18n Demo"));
+
+        let s = cat
+            .format_message(&Message::new("demo-hello").arg("name", "Chris"))
+            .unwrap();
+        assert_eq!(s, "Hello, Chris!");
+    }
+}

--- a/crates/blinc_i18n/src/simple.rs
+++ b/crates/blinc_i18n/src/simple.rs
@@ -165,10 +165,10 @@ pub enum SimpleParseError {
 fn unquote_and_unescape(s: &str) -> Result<String, String> {
     let s = s.trim();
     if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
-        return Ok(unescape(&s[1..s.len() - 1])?);
+        return unescape(&s[1..s.len() - 1]);
     }
     if s.starts_with('\'') && s.ends_with('\'') && s.len() >= 2 {
-        return Ok(unescape(&s[1..s.len() - 1])?);
+        return unescape(&s[1..s.len() - 1]);
     }
     Ok(s.to_string())
 }

--- a/crates/blinc_i18n/src/simple.rs
+++ b/crates/blinc_i18n/src/simple.rs
@@ -371,7 +371,7 @@ fn apply_placeholders(tmpl: &str, args: &[(&str, &ArgValue)]) -> String {
         let value = if let Some(map) = args_map.as_ref() {
             map.get(key).copied()
         } else {
-            args.iter().find(|(k, _)| *k == key).map(|(_, v)| *v)
+            args.iter().find(|&&(k, _)| k == key).map(|(_, v)| *v)
         };
 
         if let Some(v) = value {

--- a/crates/blinc_i18n/src/simple.rs
+++ b/crates/blinc_i18n/src/simple.rs
@@ -193,8 +193,10 @@ fn apply_placeholders(tmpl: &str, args: &[(&str, &ArgValue)]) -> String {
         return tmpl.to_string();
     }
 
+    const LINEAR_SEARCH_THRESHOLD: usize = 8;
+
     // `args` is usually tiny; avoid allocating a HashMap for small argument sets.
-    let args_map = if args.len() > 8 {
+    let args_map = if args.len() > LINEAR_SEARCH_THRESHOLD {
         Some(
             args.iter()
                 .copied()

--- a/crates/blinc_i18n/src/state.rs
+++ b/crates/blinc_i18n/src/state.rs
@@ -144,10 +144,10 @@ impl I18nState {
         msg.id.to_string()
     }
 
-    pub fn resolve_label(&self, label: Label) -> String {
+    pub fn resolve_label(&self, label: &Label) -> String {
         match label {
-            Label::Raw(s) => s,
-            Label::Msg(m) => self.tr(&m),
+            Label::Raw(s) => s.clone(),
+            Label::Msg(m) => self.tr(m),
         }
     }
 }

--- a/crates/blinc_i18n/src/state.rs
+++ b/crates/blinc_i18n/src/state.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock, RwLock};
+
+use tracing::debug;
+
+use crate::label::{Label, Message};
+use crate::locale::{locale_fallback_chain, normalize_locale};
+use crate::simple::SimpleCatalog;
+use crate::I18nError;
+
+#[cfg(feature = "fluent")]
+use crate::fluent::FluentStore;
+
+/// Global i18n singleton.
+static I18N_STATE: OnceLock<I18nState> = OnceLock::new();
+
+/// Global redraw callback - set by the app layer to trigger UI updates
+static REDRAW_CALLBACK: Mutex<Option<fn()>> = Mutex::new(None);
+
+/// Set the redraw callback function.
+///
+/// The app should set this to something like `request_full_rebuild()`.
+pub fn set_redraw_callback(callback: fn()) {
+    *REDRAW_CALLBACK.lock().unwrap() = Some(callback);
+}
+
+fn trigger_redraw() {
+    if let Some(cb) = *REDRAW_CALLBACK.lock().unwrap() {
+        cb();
+    }
+}
+
+/// Runtime i18n state.
+pub struct I18nState {
+    locale: RwLock<String>,
+    simple: RwLock<HashMap<String, SimpleCatalog>>,
+
+    #[cfg(feature = "fluent")]
+    fluent: RwLock<FluentStore>,
+}
+
+impl I18nState {
+    /// Initialize the global i18n state.
+    ///
+    /// Safe to call multiple times; the first call wins.
+    pub fn init(locale: impl Into<String>) {
+        let loc = normalize_locale(&locale.into());
+        let st = I18nState {
+            locale: RwLock::new(if loc.is_empty() {
+                "en-US".to_string()
+            } else {
+                loc
+            }),
+            simple: RwLock::new(HashMap::new()),
+            #[cfg(feature = "fluent")]
+            fluent: RwLock::new(FluentStore::new()),
+        };
+
+        let _ = I18N_STATE.set(st);
+    }
+
+    pub fn get() -> &'static I18nState {
+        I18N_STATE
+            .get()
+            .expect("I18nState not initialized. Call I18nState::init() at app startup.")
+    }
+
+    pub fn try_get() -> Option<&'static I18nState> {
+        I18N_STATE.get()
+    }
+
+    pub fn locale(&self) -> String {
+        self.locale.read().unwrap().clone()
+    }
+
+    pub fn set_locale(&self, locale: impl Into<String>) {
+        let loc = normalize_locale(&locale.into());
+        if loc.is_empty() {
+            return;
+        }
+
+        let mut cur = self.locale.write().unwrap();
+        if *cur == loc {
+            return;
+        }
+        debug!("I18nState::set_locale: {} -> {}", *cur, loc);
+        *cur = loc;
+        drop(cur);
+
+        trigger_redraw();
+    }
+
+    /// Load a simple (key=value) catalog for a locale.
+    pub fn load_simple_catalog(&self, locale: &str, catalog: SimpleCatalog) {
+        let loc = normalize_locale(locale);
+        self.simple.write().unwrap().insert(loc, catalog);
+    }
+
+    /// Parse and load a simple (key=value) catalog for a locale.
+    pub fn load_simple_catalog_str(&self, locale: &str, src: &str) -> Result<(), I18nError> {
+        let cat = SimpleCatalog::parse(src)?;
+        self.load_simple_catalog(locale, cat);
+        Ok(())
+    }
+
+    /// Load a Fluent (.ftl) catalog for a locale.
+    #[cfg(feature = "fluent")]
+    pub fn load_fluent_ftl(&self, locale: &str, ftl: &str) -> Result<(), I18nError> {
+        self.fluent
+            .write()
+            .unwrap()
+            .load_from_str(locale, ftl)
+            .map_err(I18nError::Fluent)
+    }
+
+    /// Translate a message using the locale fallback chain.
+    pub fn tr(&self, msg: &Message) -> String {
+        let loc = self.locale();
+        let chain = locale_fallback_chain(&loc);
+
+        // 1) Fluent (if enabled)
+        #[cfg(feature = "fluent")]
+        {
+            let fluent = self.fluent.read().unwrap();
+            for l in &chain {
+                if let Some(s) = fluent.format_message(l, msg) {
+                    return s;
+                }
+            }
+        }
+
+        // 2) Simple catalog
+        {
+            let simple = self.simple.read().unwrap();
+            for l in &chain {
+                if let Some(cat) = simple.get(l) {
+                    if let Some(s) = cat.format_message(msg) {
+                        return s;
+                    }
+                    if let Some(v) = cat.get(msg.id.as_ref()) {
+                        return v.to_string();
+                    }
+                }
+            }
+        }
+
+        // Fallback: show the key id.
+        msg.id.to_string()
+    }
+
+    pub fn resolve_label(&self, label: Label) -> String {
+        match label {
+            Label::Raw(s) => s,
+            Label::Msg(m) => self.tr(&m),
+        }
+    }
+}

--- a/crates/blinc_i18n/src/state.rs
+++ b/crates/blinc_i18n/src/state.rs
@@ -137,10 +137,8 @@ impl I18nState {
 
             // 2) Simple catalog
             let simple = simple_guard.get_or_insert_with(|| self.simple.read().unwrap());
-            if let Some(cat) = simple.get(l) {
-                if let Some(s) = cat.format_message(msg) {
-                    return s;
-                }
+            if let Some(s) = simple.get(l).and_then(|cat| cat.format_message(msg)) {
+                return s;
             }
         }
 

--- a/crates/blinc_i18n/src/state.rs
+++ b/crates/blinc_i18n/src/state.rs
@@ -137,9 +137,6 @@ impl I18nState {
                     if let Some(s) = cat.format_message(msg) {
                         return s;
                     }
-                    if let Some(v) = cat.get(msg.id.as_ref()) {
-                        return v.to_string();
-                    }
                 }
             }
         }

--- a/crates/blinc_i18n/src/state.rs
+++ b/crates/blinc_i18n/src/state.rs
@@ -106,11 +106,10 @@ impl I18nState {
     /// Load a Fluent (.ftl) catalog for a locale.
     #[cfg(feature = "fluent")]
     pub fn load_fluent_ftl(&self, locale: &str, ftl: &str) -> Result<(), I18nError> {
-        self.fluent
-            .write()
-            .unwrap()
-            .load_from_str(locale, ftl)
-            .map_err(I18nError::Fluent)
+        // Parse outside the lock; FTL parsing can be expensive.
+        let (loc, bundle) = crate::fluent::parse_ftl(locale, ftl).map_err(I18nError::Fluent)?;
+        self.fluent.write().unwrap().add_bundle(loc, bundle);
+        Ok(())
     }
 
     /// Translate a message using the locale fallback chain.

--- a/crates/blinc_layout/Cargo.toml
+++ b/crates/blinc_layout/Cargo.toml
@@ -20,6 +20,7 @@ recorder = []
 blinc_core = { path = "../blinc_core", version = "0.1.12" }
 blinc_animation = { path = "../blinc_animation", version = "0.1.12" }
 blinc_theme = { path = "../blinc_theme", version = "0.1.12" }
+blinc_i18n = { path = "../blinc_i18n", version = "0.1.12" }
 
 # Layout
 taffy.workspace = true

--- a/crates/blinc_layout/src/text.rs
+++ b/crates/blinc_layout/src/text.rs
@@ -20,7 +20,7 @@
 //! ```
 
 use blinc_core::{Color, Shadow, Transform};
-use blinc_i18n::{resolve_label, Label};
+use blinc_i18n::{resolve_label_ref, Label};
 use html_escape::decode_html_entities;
 use taffy::prelude::*;
 
@@ -85,7 +85,8 @@ impl Text {
     /// - Decimal entities: `&#65;`, `&#8364;`, etc.
     /// - Hexadecimal entities: `&#x41;`, `&#x20AC;`, etc.
     pub fn new(content: impl Into<Label>) -> Self {
-        let resolved = resolve_label(content.into());
+        let label = content.into();
+        let resolved = resolve_label_ref(&label);
         // Decode HTML entities (e.g., &amp; -> &, &copy; -> ©)
         let raw_content = resolved;
         let decoded_content = decode_html_entities(&raw_content).into_owned();

--- a/crates/blinc_layout/src/text.rs
+++ b/crates/blinc_layout/src/text.rs
@@ -88,8 +88,7 @@ impl Text {
         let label = content.into();
         let resolved = resolve_label_ref(&label);
         // Decode HTML entities (e.g., &amp; -> &, &copy; -> ©)
-        let raw_content = resolved;
-        let decoded_content = decode_html_entities(&raw_content).into_owned();
+        let decoded_content = decode_html_entities(&resolved).into_owned();
 
         let mut text = Self {
             content: decoded_content,

--- a/crates/blinc_layout/src/text.rs
+++ b/crates/blinc_layout/src/text.rs
@@ -20,6 +20,7 @@
 //! ```
 
 use blinc_core::{Color, Shadow, Transform};
+use blinc_i18n::{resolve_label, Label};
 use html_escape::decode_html_entities;
 use taffy::prelude::*;
 
@@ -83,9 +84,10 @@ impl Text {
     /// - Named entities: `&amp;`, `&nbsp;`, `&copy;`, etc.
     /// - Decimal entities: `&#65;`, `&#8364;`, etc.
     /// - Hexadecimal entities: `&#x41;`, `&#x20AC;`, etc.
-    pub fn new(content: impl Into<String>) -> Self {
+    pub fn new(content: impl Into<Label>) -> Self {
+        let resolved = resolve_label(content.into());
         // Decode HTML entities (e.g., &amp; -> &, &copy; -> ©)
-        let raw_content = content.into();
+        let raw_content = resolved;
         let decoded_content = decode_html_entities(&raw_content).into_owned();
 
         let mut text = Self {
@@ -638,7 +640,7 @@ impl ElementBuilder for Text {
 }
 
 /// Convenience function to create a new text element
-pub fn text(content: impl Into<String>) -> Text {
+pub fn text(content: impl Into<Label>) -> Text {
     let mut t = Text::new(content);
     t.update_size_estimate();
     t

--- a/crates/blinc_layout/src/typography.rs
+++ b/crates/blinc_layout/src/typography.rs
@@ -50,6 +50,7 @@
 //!     .shadow(Shadow::new(0.0, 2.0, 4.0, Color::BLACK.with_alpha(0.5)))
 //! ```
 
+use blinc_i18n::Label;
 use blinc_theme::{ColorToken, ThemeState};
 
 use crate::text::{text, Text};
@@ -86,7 +87,7 @@ enum HeadingWeight {
 /// ```ignore
 /// h1("Page Title").color(Color::WHITE)
 /// ```
-pub fn h1(content: impl Into<String>) -> Text {
+pub fn h1(content: impl Into<Label>) -> Text {
     heading(1, content)
 }
 
@@ -97,7 +98,7 @@ pub fn h1(content: impl Into<String>) -> Text {
 /// ```ignore
 /// h2("Section Title").color(Color::WHITE)
 /// ```
-pub fn h2(content: impl Into<String>) -> Text {
+pub fn h2(content: impl Into<Label>) -> Text {
     heading(2, content)
 }
 
@@ -108,7 +109,7 @@ pub fn h2(content: impl Into<String>) -> Text {
 /// ```ignore
 /// h3("Subsection").color(Color::WHITE)
 /// ```
-pub fn h3(content: impl Into<String>) -> Text {
+pub fn h3(content: impl Into<Label>) -> Text {
     heading(3, content)
 }
 
@@ -119,7 +120,7 @@ pub fn h3(content: impl Into<String>) -> Text {
 /// ```ignore
 /// h4("Minor Section").color(Color::WHITE)
 /// ```
-pub fn h4(content: impl Into<String>) -> Text {
+pub fn h4(content: impl Into<Label>) -> Text {
     heading(4, content)
 }
 
@@ -130,7 +131,7 @@ pub fn h4(content: impl Into<String>) -> Text {
 /// ```ignore
 /// h5("Small Heading").color(Color::WHITE)
 /// ```
-pub fn h5(content: impl Into<String>) -> Text {
+pub fn h5(content: impl Into<Label>) -> Text {
     heading(5, content)
 }
 
@@ -141,7 +142,7 @@ pub fn h5(content: impl Into<String>) -> Text {
 /// ```ignore
 /// h6("Smallest Heading").color(Color::WHITE)
 /// ```
-pub fn h6(content: impl Into<String>) -> Text {
+pub fn h6(content: impl Into<Label>) -> Text {
     heading(6, content)
 }
 
@@ -159,7 +160,7 @@ pub fn h6(content: impl Into<String>) -> Text {
 /// // Equivalent to h2()
 /// heading(2, "Section Title")
 /// ```
-pub fn heading(level: u8, content: impl Into<String>) -> Text {
+pub fn heading(level: u8, content: impl Into<Label>) -> Text {
     let idx = (level.saturating_sub(1).min(5)) as usize;
     let (size, weight) = HEADING_CONFIG[idx];
 
@@ -183,7 +184,7 @@ pub fn heading(level: u8, content: impl Into<String>) -> Text {
 /// ```ignore
 /// div().child(b("Important")).child(text(" regular text"))
 /// ```
-pub fn b(content: impl Into<String>) -> Text {
+pub fn b(content: impl Into<Label>) -> Text {
     text(content).bold().no_wrap().v_baseline()
 }
 
@@ -194,7 +195,7 @@ pub fn b(content: impl Into<String>) -> Text {
 /// ```ignore
 /// strong("Very important")
 /// ```
-pub fn strong(content: impl Into<String>) -> Text {
+pub fn strong(content: impl Into<Label>) -> Text {
     b(content)
 }
 
@@ -208,7 +209,7 @@ pub fn strong(content: impl Into<String>) -> Text {
 /// ```ignore
 /// span("Some text").color(Color::BLUE)
 /// ```
-pub fn span(content: impl Into<String>) -> Text {
+pub fn span(content: impl Into<Label>) -> Text {
     text(content).no_wrap().v_baseline()
 }
 
@@ -219,7 +220,7 @@ pub fn span(content: impl Into<String>) -> Text {
 /// ```ignore
 /// small("Fine print").color(Color::GRAY)
 /// ```
-pub fn small(content: impl Into<String>) -> Text {
+pub fn small(content: impl Into<Label>) -> Text {
     text(content).size(12.0).no_wrap().v_baseline()
 }
 
@@ -236,7 +237,7 @@ pub fn small(content: impl Into<String>) -> Text {
 ///     .child(label("Username"))
 ///     .child(text_input(&state))
 /// ```
-pub fn label(content: impl Into<String>) -> Text {
+pub fn label(content: impl Into<Label>) -> Text {
     text(content).size(14.0).medium().no_wrap().v_baseline()
 }
 
@@ -249,7 +250,7 @@ pub fn label(content: impl Into<String>) -> Text {
 /// ```ignore
 /// muted("Less important information")
 /// ```
-pub fn muted(content: impl Into<String>) -> Text {
+pub fn muted(content: impl Into<Label>) -> Text {
     let theme = ThemeState::get();
     text(content)
         .color(theme.color(ColorToken::TextSecondary))
@@ -266,7 +267,7 @@ pub fn muted(content: impl Into<String>) -> Text {
 /// ```ignore
 /// p("This is a paragraph of text that may span multiple lines...")
 /// ```
-pub fn p(content: impl Into<String>) -> Text {
+pub fn p(content: impl Into<Label>) -> Text {
     text(content).size(16.0).line_height(1.5)
 }
 
@@ -279,7 +280,7 @@ pub fn p(content: impl Into<String>) -> Text {
 /// ```ignore
 /// caption("Figure 1: Architecture diagram")
 /// ```
-pub fn caption(content: impl Into<String>) -> Text {
+pub fn caption(content: impl Into<Label>) -> Text {
     let theme = ThemeState::get();
     text(content)
         .size(12.0)
@@ -303,7 +304,7 @@ pub fn caption(content: impl Into<String>) -> Text {
 ///     .child(inline_code("div()"))
 ///     .child(text(" function"))
 /// ```
-pub fn inline_code(content: impl Into<String>) -> Text {
+pub fn inline_code(content: impl Into<Label>) -> Text {
     let theme = ThemeState::get();
     text(content)
         .monospace()

--- a/crates/blinc_layout/src/widgets/button.rs
+++ b/crates/blinc_layout/src/widgets/button.rs
@@ -28,6 +28,7 @@ use std::sync::{Arc, Mutex};
 
 use blinc_core::reactive::SignalId;
 use blinc_core::Color;
+use blinc_i18n::Label;
 use blinc_theme::{ColorToken, ThemeState};
 
 use crate::div::{div, Div, ElementBuilder};
@@ -42,7 +43,7 @@ pub use crate::stateful::ButtonState as ButtonVisualState;
 /// Button-specific configuration (colors)
 #[derive(Clone)]
 pub struct ButtonConfig {
-    pub label: Option<String>,
+    pub label: Option<Label>,
     pub text_color: Color,
     pub text_size: f32,
     pub bg_color: Color,
@@ -96,7 +97,7 @@ impl Button {
     /// Button::new(btn_state, "Click me")
     ///     .on_click(|_| println!("Clicked!"))
     /// ```
-    pub fn new(state: SharedState<ButtonState>, label: impl Into<String>) -> Self {
+    pub fn new(state: SharedState<ButtonState>, label: impl Into<Label>) -> Self {
         let config = Arc::new(Mutex::new(ButtonConfig {
             label: Some(label.into()),
             ..Default::default()
@@ -455,7 +456,7 @@ impl Button {
 ///     .on_click(|_| save_data())
 ///     .bg_color(Color::GREEN)
 /// ```
-pub fn button(state: SharedState<ButtonState>, label: impl Into<String>) -> Button {
+pub fn button(state: SharedState<ButtonState>, label: impl Into<Label>) -> Button {
     Button::new(state, label)
         .px(12.0)
         .py(6.0)
@@ -545,9 +546,12 @@ impl ElementBuilder for Button {
                     if let Some(ref callback) = custom_callback {
                         callback(*state, &mut update);
                     } else if let Some(ref label) = cfg.label {
-                        tracing::debug!("Button adding label child: {}", label);
-                        update =
-                            update.child(text(label).size(cfg.text_size).color(cfg.text_color));
+                        tracing::debug!("Button adding label child: {:?}", label);
+                        update = update.child(
+                            text(label.clone())
+                                .size(cfg.text_size)
+                                .color(cfg.text_color),
+                        );
                     }
 
                     let update_children = update.children.len();

--- a/crates/blinc_layout/src/widgets/button.rs
+++ b/crates/blinc_layout/src/widgets/button.rs
@@ -546,7 +546,6 @@ impl ElementBuilder for Button {
                     if let Some(ref callback) = custom_callback {
                         callback(*state, &mut update);
                     } else if let Some(ref label) = cfg.label {
-                        tracing::debug!("Button adding label child: {:?}", label);
                         update = update.child(
                             text(label.clone())
                                 .size(cfg.text_size)

--- a/crates/blinc_layout/src/widgets/table.rs
+++ b/crates/blinc_layout/src/widgets/table.rs
@@ -59,6 +59,7 @@
 //! ```
 
 use blinc_core::Color;
+use blinc_i18n::Label;
 use blinc_theme::{ColorToken, ThemeState};
 
 use crate::div::{div, Div};
@@ -335,7 +336,7 @@ impl crate::div::ElementBuilder for TableCell {
 /// th("Column Name")
 /// th("Right Aligned").justify_end()
 /// ```
-pub fn th(content: impl Into<String>) -> TableCell {
+pub fn th(content: impl Into<Label>) -> TableCell {
     let txt = text(content)
         .size(DEFAULT_FONT_SIZE)
         .color(header_text_color())
@@ -354,7 +355,7 @@ pub fn th(content: impl Into<String>) -> TableCell {
 /// td("Cell content")
 /// td("123.45").justify_end()  // Right-align numbers
 /// ```
-pub fn td(content: impl Into<String>) -> TableCell {
+pub fn td(content: impl Into<Label>) -> TableCell {
     let txt = text(content)
         .size(DEFAULT_FONT_SIZE)
         .color(cell_text_color());
@@ -520,7 +521,7 @@ impl Default for TableBuilder {
 ///
 /// Returns a Text element that you can further style.
 /// Use `th()` if you need cell-level styling (padding, background).
-pub fn th_text(content: impl Into<String>) -> Text {
+pub fn th_text(content: impl Into<Label>) -> Text {
     text(content)
         .size(DEFAULT_FONT_SIZE)
         .color(header_text_color())
@@ -531,7 +532,7 @@ pub fn th_text(content: impl Into<String>) -> Text {
 ///
 /// Returns a Text element that you can further style.
 /// Use `td()` if you need cell-level styling (padding, background).
-pub fn td_text(content: impl Into<String>) -> Text {
+pub fn td_text(content: impl Into<Label>) -> Text {
     text(content)
         .size(DEFAULT_FONT_SIZE)
         .color(cell_text_color())

--- a/resource/i18n/blinc-i18n.schema.json
+++ b/resource/i18n/blinc-i18n.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Blinc i18n Catalog",
+  "description": "YAML mapping of translation keys to localized strings. Values may contain placeholders like {name}.",
+  "type": "object",
+  "patternProperties": {
+    "^[A-Za-z0-9][A-Za-z0-9_.-]*$": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}
+

--- a/resource/i18n/demo.en-US.ftl
+++ b/resource/i18n/demo.en-US.ftl
@@ -1,0 +1,5 @@
+demo-title = Blinc i18n Demo
+demo-locale = Locale: { $locale }
+demo-toggle = Toggle English/Korean
+demo-hello = Hello, { $name }!
+

--- a/resource/i18n/demo.en-US.yaml
+++ b/resource/i18n/demo.en-US.yaml
@@ -1,0 +1,5 @@
+demo-title: "Blinc i18n Demo"
+demo-locale: "Locale: {locale}"
+demo-toggle: "Toggle English/Korean"
+demo-hello: "Hello, {name}!"
+

--- a/resource/i18n/demo.ko-KR.ftl
+++ b/resource/i18n/demo.ko-KR.ftl
@@ -1,0 +1,5 @@
+demo-title = Blinc i18n 데모
+demo-locale = 언어: { $locale }
+demo-toggle = 영어/한국어 전환
+demo-hello = 안녕하세요, { $name }!
+

--- a/resource/i18n/demo.ko-KR.yaml
+++ b/resource/i18n/demo.ko-KR.yaml
@@ -1,0 +1,5 @@
+demo-title: "Blinc i18n 데모"
+demo-locale: "언어: {locale}"
+demo-toggle: "영어/한국어 전환"
+demo-hello: "안녕하세요, {name}!"
+


### PR DESCRIPTION
## What
- 프레임워크 레벨에서 번역 가능한 `Label`/`Message` 타입 도입
- 런타임 로케일 전환(`I18nState::set_locale`) 시 전체 UI rebuild 트리거
- 번역 카탈로그 포맷: YAML(표준) 우선 + JSON Schema 제공
- Fluent(.ftl)도 동일 `Message` API로 로딩/포맷(호환성 확보)

## How
- `crates/blinc_i18n`: i18n 전역 상태, YAML/legacy key=value 파서, Fluent 백엔드
- `blinc_layout` 프리미티브(`text`, `button`, typography/table helpers)가 `impl Into<Label>` 수용
- `blinc_app`(windowed/android/ios)에서 i18n redraw 콜백을 `request_full_rebuild()`로 연결

## Demo
- `blinc_app/examples/i18n_demo.rs`
- `resource/i18n/demo.en-US.yaml`, `resource/i18n/demo.ko-KR.yaml`
- Fluent 샘플: `resource/i18n/demo.*.ftl`

## Schema
- `resource/i18n/blinc-i18n.schema.json`
- (옵션) VSCode 설정 예시:
  ```json
  {"yaml.schemas": {"./resource/i18n/blinc-i18n.schema.json": ["resource/i18n/*.yaml"]}}
  ```

## Testing
- `RUSTFLAGS="-C debuginfo=0" cargo test -p blinc_i18n`
- `RUSTFLAGS="-C debuginfo=0" cargo check -p blinc_app --features windowed --examples`
- `cargo run -p blinc_app --example i18n_demo --features windowed`

## Notes
- 키 네이밍 규칙을 더 빡세게 강제할지는 후속에서 결정