### PR TITLE
blinc_charts: add more chart types + gallery demo

### DIFF
--- a/crates/blinc_app/examples/charts_gallery_demo.rs
+++ b/crates/blinc_app/examples/charts_gallery_demo.rs
@@ -289,14 +289,11 @@ fn make_multi_series(series_n: usize, points_n: usize) -> Vec<TimeSeriesF32> {
         let mut x = Vec::with_capacity(points_n);
         let mut y = Vec::with_capacity(points_n);
         let phase = s as f32 * 0.37;
+        let mut cur_x = 0.0f32;
         for i in 0..points_n {
-            let xx = i as f32;
-            // Force small gaps to exercise segmentation.
-            if i % 37 == 0 && i != 0 {
-                x.push(xx + 8.0);
-            } else {
-                x.push(xx);
-            }
+            // Force occasional gaps while keeping x sorted (monotonic).
+            cur_x += if i % 37 == 0 && i != 0 { 9.0 } else { 1.0 };
+            x.push(cur_x);
             let t = i as f32 * 0.06;
             let vv = (t + phase).sin() * 0.7 + (t * 0.17 + phase).sin() * 0.2;
             y.push(vv);

--- a/crates/blinc_app/examples/charts_gallery_demo.rs
+++ b/crates/blinc_app/examples/charts_gallery_demo.rs
@@ -1,0 +1,375 @@
+//! blinc_charts Gallery Demo
+//!
+//! Run with:
+//! `cargo run -p blinc_app --example charts_gallery_demo --features windowed`
+//!
+//! This demo is a living gallery: every chart candidate gets at least one section.
+//! Some sections are placeholders until their dedicated chart types land.
+
+use blinc_app::prelude::*;
+use blinc_app::windowed::{WindowedApp, WindowedContext};
+use blinc_charts::prelude::*;
+use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextStyle};
+use blinc_layout::prelude::Scroll;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    let config = WindowConfig {
+        title: "blinc_charts: Gallery".to_string(),
+        width: 1200,
+        height: 840,
+        resizable: true,
+        ..Default::default()
+    };
+
+    WindowedApp::run(config, |ctx| build_ui(ctx))
+}
+
+fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
+    // Core datasets (kept deterministic; no RNG needed).
+    let line_n = std::env::var("BLINC_CHARTS_N")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&v| v >= 2)
+        .unwrap_or(200_000);
+
+    let line_series = make_series(line_n).expect("failed to create series (x must be sorted)");
+    let line_handle = LineChartHandle::new(LineChartModel::new(line_series.clone()));
+
+    let area_handle = AreaChartHandle::new(AreaChartModel::new(line_series.clone()));
+
+    let scatter_handle = ScatterChartHandle::new(ScatterChartModel::new(line_series.clone()));
+
+    let multi_handle = MultiLineChartHandle::new(
+        MultiLineChartModel::new(make_multi_series(64, 240)).expect("multiline requires series"),
+    );
+
+    let bar_handle = BarChartHandle::new(
+        BarChartModel::new(make_bar_series(3, 3_000)).expect("bar requires series"),
+    );
+
+    let hist_handle =
+        HistogramChartHandle::new(HistogramChartModel::new(make_hist_values(100_000)).unwrap());
+
+    let candle_handle = CandlestickChartHandle::new(CandlestickChartModel::new(
+        CandleSeries::new(make_candles(120_000)).expect("candles must be sorted"),
+    ));
+
+    let heat_handle = HeatmapChartHandle::new(
+        HeatmapChartModel::new(320, 160, make_heat_values(320, 160)).expect("valid heatmap"),
+    );
+
+    let header = div()
+        .flex_row()
+        .items_end()
+        .justify_between()
+        .child(
+            text("blinc_charts gallery")
+                .size(24.0)
+                .weight(FontWeight::Bold)
+                .color(Color::rgba(0.95, 0.96, 0.98, 1.0)),
+        )
+        .child(
+            text(format!("BLINC_CHARTS_N = {line_n}"))
+                .size(12.0)
+                .color(Color::rgba(0.70, 0.75, 0.82, 1.0)),
+        );
+
+    div()
+        .w(ctx.width)
+        .h(ctx.height)
+        .bg(Color::rgba(0.06, 0.07, 0.09, 1.0))
+        .p(12.0)
+        .flex_col()
+        .gap(12.0)
+        .child(header)
+        .child(
+            Scroll::new()
+                .w_full()
+                .h_full()
+                .rounded(14.0)
+                .bg(Color::rgba(0.04, 0.05, 0.07, 1.0))
+                .p(10.0)
+                .child(
+                    div()
+                        .flex_col()
+                        .gap(14.0)
+                        .child(section(
+                            "Line",
+                            "Ultra-large time series line (LOD downsampling + GPU polyline path).",
+                            div()
+                                .h(320.0)
+                                .rounded(14.0)
+                                .overflow_clip()
+                                .border(1.0, Color::rgba(1.0, 1.0, 1.0, 0.08))
+                                .child(line_chart(line_handle)),
+                        ))
+                        .child(section(
+                            "Multi-line",
+                            "Many series with gap breaks + global segment budgeting.",
+                            div()
+                                .h(320.0)
+                                .rounded(14.0)
+                                .overflow_clip()
+                                .border(1.0, Color::rgba(1.0, 1.0, 1.0, 0.08))
+                                .child(multi_line_chart(multi_handle)),
+                        ))
+                        .child(section(
+                            "Area",
+                            "Single-series area fill + outline (same LOD as line).",
+                            div()
+                                .h(300.0)
+                                .rounded(14.0)
+                                .overflow_clip()
+                                .border(1.0, Color::rgba(1.0, 1.0, 1.0, 0.08))
+                                .child(area_chart(area_handle)),
+                        ))
+                        .child(section(
+                            "Bar / Stacked bar",
+                            "Stacked bars with screen-binned aggregation (mean per x-bin).",
+                            div()
+                                .h(300.0)
+                                .rounded(14.0)
+                                .overflow_clip()
+                                .border(1.0, Color::rgba(1.0, 1.0, 1.0, 0.08))
+                                .child(bar_chart(bar_handle)),
+                        ))
+                        .child(section(
+                            "Histogram",
+                            "Pre-binned histogram (demo: global bins).",
+                            div()
+                                .h(260.0)
+                                .rounded(14.0)
+                                .overflow_clip()
+                                .border(1.0, Color::rgba(1.0, 1.0, 1.0, 0.08))
+                                .child(histogram_chart(hist_handle)),
+                        ))
+                        .child(section(
+                            "Scatter / Bubble",
+                            "Scatter using min/max downsample per x-bin (capped point count).",
+                            div()
+                                .h(300.0)
+                                .rounded(14.0)
+                                .overflow_clip()
+                                .border(1.0, Color::rgba(1.0, 1.0, 1.0, 0.08))
+                                .child(scatter_chart(scatter_handle)),
+                        ))
+                        .child(section(
+                            "Candlestick (OHLC)",
+                            "Candles resampled to screen bins, then drawn as wick+body.",
+                            div()
+                                .h(320.0)
+                                .rounded(14.0)
+                                .overflow_clip()
+                                .border(1.0, Color::rgba(1.0, 1.0, 1.0, 0.08))
+                                .child(candlestick_chart(candle_handle)),
+                        ))
+                        .child(section(
+                            "Heatmap (2D bins)",
+                            "Grid heatmap screen-sampled to keep cost bounded.",
+                            div()
+                                .h(320.0)
+                                .rounded(14.0)
+                                .overflow_clip()
+                                .border(1.0, Color::rgba(1.0, 1.0, 1.0, 0.08))
+                                .child(heatmap_chart(heat_handle)),
+                        ))
+                        // Placeholders for remaining candidates (canvas-first).
+                        .child(section(
+                            "Area (stacked)",
+                            "Placeholder: stacked area renderer (will share binning/LOD with multi-line).",
+                            todo_canvas("TODO: stacked area"),
+                        ))
+                        .child(section(
+                            "Density map / patch_map",
+                            "Placeholder: integrate existing patch_map implementation as a linked chart view.",
+                            todo_canvas("TODO: patch_map chart adapter"),
+                        ))
+                        .child(section(
+                            "Contour / Isobands",
+                            "Placeholder: contouring over 2D bins.",
+                            todo_canvas("TODO: contours"),
+                        ))
+                        .child(section(
+                            "Boxplot / Violin / Error bands",
+                            "Placeholder: analytics overlays and distribution charts.",
+                            todo_canvas("TODO: box/violin/error bands"),
+                        ))
+                        .child(section(
+                            "Treemap / Sunburst / Icicle / Packing",
+                            "Placeholder: hierarchy layout + canvas renderer.",
+                            todo_canvas("TODO: hierarchy"),
+                        ))
+                        .child(section(
+                            "Graph / Sankey / Chord",
+                            "Placeholder: node-link and flow layouts.",
+                            todo_canvas("TODO: network/flow"),
+                        ))
+                        .child(section(
+                            "Parallel coordinates / Polar / Radar",
+                            "Placeholder: alternative coordinate systems.",
+                            todo_canvas("TODO: coords"),
+                        ))
+                        .child(section(
+                            "Gauge / Funnel / Streamgraph",
+                            "Placeholder: specialized series types.",
+                            todo_canvas("TODO: specialized"),
+                        ))
+                        .child(section(
+                            "Geo",
+                            "Placeholder: projections + tile/image layers.",
+                            todo_canvas("TODO: geo"),
+                        )),
+                ),
+        )
+}
+
+fn section(title: &str, desc: &str, content: impl ElementBuilder + 'static) -> impl ElementBuilder {
+    div()
+        .flex_col()
+        .gap(8.0)
+        .child(
+            div()
+                .flex_col()
+                .gap(2.0)
+                .child(
+                    text(title)
+                        .size(16.0)
+                        .weight(FontWeight::SemiBold)
+                        .color(Color::rgba(0.92, 0.93, 0.95, 1.0)),
+                )
+                .child(
+                    text(desc)
+                        .size(12.0)
+                        .color(Color::rgba(0.68, 0.72, 0.78, 1.0)),
+                ),
+        )
+        .child(content)
+}
+
+fn todo_canvas(label: &'static str) -> impl ElementBuilder {
+    div()
+        .h(220.0)
+        .rounded(14.0)
+        .overflow_clip()
+        .border(1.0, Color::rgba(1.0, 1.0, 1.0, 0.08))
+        .child(
+            blinc_layout::canvas::canvas(move |ctx: &mut dyn DrawContext, bounds| {
+                ctx.fill_rect(
+                    Rect::new(0.0, 0.0, bounds.width, bounds.height),
+                    0.0.into(),
+                    Brush::Solid(Color::rgba(0.08, 0.09, 0.11, 1.0)),
+                );
+                let style = TextStyle::new(14.0).with_color(Color::rgba(1.0, 1.0, 1.0, 0.75));
+                ctx.draw_text(label, Point::new(14.0, 14.0), &style);
+            })
+            .w_full()
+            .h_full(),
+        )
+}
+
+fn make_series(n: usize) -> anyhow::Result<TimeSeriesF32> {
+    let mut x = Vec::with_capacity(n);
+    let mut y = Vec::with_capacity(n);
+    for i in 0..n {
+        let t = i as f32 * 0.001;
+        let v = (t * 1.0).sin() * 0.8 + (t * 0.13).sin() * 0.2 + (t.fract() - 0.5) * 0.05;
+        x.push(i as f32);
+        y.push(v);
+    }
+    TimeSeriesF32::new(x, y)
+}
+
+fn make_multi_series(series_n: usize, points_n: usize) -> Vec<TimeSeriesF32> {
+    let mut out = Vec::with_capacity(series_n);
+    for s in 0..series_n {
+        let mut x = Vec::with_capacity(points_n);
+        let mut y = Vec::with_capacity(points_n);
+        let phase = s as f32 * 0.37;
+        for i in 0..points_n {
+            let xx = i as f32;
+            // Force small gaps to exercise segmentation.
+            if i % 37 == 0 && i != 0 {
+                x.push(xx + 8.0);
+            } else {
+                x.push(xx);
+            }
+            let t = i as f32 * 0.06;
+            let vv = (t + phase).sin() * 0.7 + (t * 0.17 + phase).sin() * 0.2;
+            y.push(vv);
+        }
+        out.push(TimeSeriesF32::new(x, y).expect("sorted by construction"));
+    }
+    out
+}
+
+fn make_bar_series(series_n: usize, n: usize) -> Vec<TimeSeriesF32> {
+    let mut out = Vec::with_capacity(series_n);
+    for s in 0..series_n {
+        let mut x = Vec::with_capacity(n);
+        let mut y = Vec::with_capacity(n);
+        let phase = s as f32 * 0.85;
+        for i in 0..n {
+            let t = i as f32 * 0.01;
+            let v = ((t + phase).sin() * 0.5 + 0.6).max(0.0);
+            x.push(i as f32);
+            y.push(v);
+        }
+        out.push(TimeSeriesF32::new(x, y).expect("sorted by construction"));
+    }
+    out
+}
+
+fn make_hist_values(n: usize) -> Vec<f32> {
+    let mut out = Vec::with_capacity(n);
+    // Two-lobe distribution (deterministic).
+    for i in 0..n {
+        let t = i as f32 * 0.001;
+        let a = (t * 1.7).sin() * 0.6 + (t * 0.11).sin() * 0.15;
+        let b = (t * 0.9).cos() * 0.4;
+        out.push(a + b);
+    }
+    out
+}
+
+fn make_candles(n: usize) -> Vec<Candle> {
+    let mut out = Vec::with_capacity(n);
+    let mut last = 0.0f32;
+    for i in 0..n {
+        let t = i as f32 * 0.01;
+        let drift = (t * 0.23).sin() * 0.02;
+        let noise = (t * 1.7).sin() * 0.03 + (t * 2.1).cos() * 0.01;
+        let close = last + drift + noise;
+        let open = last;
+        let hi = open.max(close) + (t * 0.7).sin().abs() * 0.04;
+        let lo = open.min(close) - (t * 0.9).cos().abs() * 0.04;
+        out.push(Candle {
+            x: i as f32,
+            open,
+            high: hi,
+            low: lo,
+            close,
+        });
+        last = close;
+    }
+    out
+}
+
+fn make_heat_values(w: usize, h: usize) -> Vec<f32> {
+    let mut out = vec![0.0f32; w * h];
+    let cx = (w as f32) * 0.55;
+    let cy = (h as f32) * 0.45;
+    for y in 0..h {
+        for x in 0..w {
+            let dx = (x as f32 - cx) / (w as f32);
+            let dy = (y as f32 - cy) / (h as f32);
+            let r2 = dx * dx + dy * dy;
+            let v = (-r2 * 38.0).exp() + (dx * 18.0).sin() * (dy * 14.0).cos() * 0.15;
+            out[y * w + x] = v;
+        }
+    }
+    out
+}

--- a/crates/blinc_app/examples/charts_gallery_demo.rs
+++ b/crates/blinc_app/examples/charts_gallery_demo.rs
@@ -154,7 +154,9 @@ fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
             )
             .child(div().h(1.0).bg(Color::rgba(1.0, 1.0, 1.0, 0.06)))
             .child({
-                let mut list = div().flex_1().overflow_y_scroll().flex_col().gap(6.0);
+                // In a flex column, allow the scroll container to shrink below its content size.
+                // (Similar to CSS `min-height: 0` for scrollables inside flex.)
+                let mut list = div().flex_col().gap(6.0);
                 for (i, (title, _desc)) in ITEMS.iter().enumerate() {
                     let title = *title;
                     let selected_for_state = selected_for_list.clone();
@@ -195,7 +197,12 @@ fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
                             }),
                     );
                 }
-                list
+                div()
+                    .flex_1()
+                    .min_h(0.0)
+                    .w_full()
+                    .overflow_y_scroll()
+                    .child(list)
             })
     };
 

--- a/crates/blinc_app/examples/charts_gallery_demo.rs
+++ b/crates/blinc_app/examples/charts_gallery_demo.rs
@@ -46,8 +46,7 @@ struct GalleryModels {
 
 impl GalleryModels {
     fn new(line_n: usize) -> Self {
-        // IMPORTANT: This initializer runs while WindowedContext holds its internal
-        // reactive graph lock. Do not call ctx.use_* or State::get/try_get here.
+        // Keep this initializer pure and deterministic (no context access).
         let line_series = make_series(line_n).expect("failed to create series (x must be sorted)");
 
         let line = LineChartHandle::new(LineChartModel::new(line_series.clone()));

--- a/crates/blinc_app/examples/charts_linked_brush_demo.rs
+++ b/crates/blinc_app/examples/charts_linked_brush_demo.rs
@@ -1,0 +1,110 @@
+//! blinc_charts Linked + Brush Demo
+//!
+//! Run with:
+//! `cargo run -p blinc_app --example charts_linked_brush_demo --features windowed`
+//!
+//! Interactions:
+//! - Drag: pan (shared X domain)
+//! - Scroll / pinch: zoom (shared X domain)
+//! - Shift + drag: brush-select X range (shared selection)
+//!
+//! Optional:
+//! - Set `BLINC_CHARTS_N` to control the number of points (default: 200_000)
+
+use blinc_app::prelude::*;
+use blinc_app::windowed::{WindowedApp, WindowedContext};
+use blinc_charts::prelude::*;
+use blinc_core::Color;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    let config = WindowConfig {
+        title: "blinc_charts: Linked + Brush Demo".to_string(),
+        width: 1200,
+        height: 820,
+        resizable: true,
+        ..Default::default()
+    };
+
+    WindowedApp::run(config, |ctx| build_ui(ctx))
+}
+
+fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
+    let n = std::env::var("BLINC_CHARTS_N")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&v| v >= 2)
+        .unwrap_or(200_000);
+
+    let series_a = make_series(n, 1.0).expect("failed to create series (x must be sorted)");
+    let series_b = make_series(n, 0.35).expect("failed to create series (x must be sorted)");
+
+    let (x0, x1) = series_a.x_min_max();
+    let link = chart_link(x0, x1);
+
+    let handle_a = LineChartHandle::new(LineChartModel::new(series_a));
+    let handle_b = LineChartHandle::new(LineChartModel::new(series_b));
+
+    div()
+        .w(ctx.width)
+        .h(ctx.height)
+        .bg(Color::rgba(0.06, 0.07, 0.09, 1.0))
+        .flex_col()
+        .gap(10.0)
+        .p(12.0)
+        .child(
+            div()
+                .flex_row()
+                .items_center()
+                .gap(12.0)
+                .child(
+                    text("blinc_charts: linked X-domain + brush selection")
+                        .size(20.0)
+                        .color(Color::rgba(0.95, 0.96, 0.98, 1.0)),
+                )
+                .child(
+                    text(format!("N = {n} (env: BLINC_CHARTS_N)"))
+                        .size(12.0)
+                        .color(Color::rgba(0.7, 0.75, 0.82, 1.0)),
+                )
+                .child(
+                    text("Drag: pan | Wheel/Pinch: zoom | Shift+Drag: brush")
+                        .size(12.0)
+                        .color(Color::rgba(0.7, 0.75, 0.82, 1.0)),
+                ),
+        )
+        .child(
+            div()
+                .flex_1()
+                .rounded(14.0)
+                .overflow_clip()
+                .border(1.0, Color::rgba(1.0, 1.0, 1.0, 0.08))
+                .child(linked_line_chart(handle_a, link.clone())),
+        )
+        .child(
+            div()
+                .flex_1()
+                .rounded(14.0)
+                .overflow_clip()
+                .border(1.0, Color::rgba(1.0, 1.0, 1.0, 0.08))
+                .child(linked_line_chart(handle_b, link)),
+        )
+}
+
+fn make_series(n: usize, amp: f32) -> anyhow::Result<TimeSeriesF32> {
+    let mut x = Vec::with_capacity(n);
+    let mut y = Vec::with_capacity(n);
+
+    for i in 0..n {
+        let t = i as f32 * 0.001;
+        let v = (t * 1.0).sin() * 0.8 + (t * 0.13).sin() * 0.2 + (t.fract() - 0.5) * 0.05;
+        x.push(i as f32);
+        y.push(v * amp);
+    }
+
+    TimeSeriesF32::new(x, y)
+}
+

--- a/crates/blinc_app/examples/charts_linked_brush_demo.rs
+++ b/crates/blinc_app/examples/charts_linked_brush_demo.rs
@@ -107,4 +107,3 @@ fn make_series(n: usize, amp: f32) -> anyhow::Result<TimeSeriesF32> {
 
     TimeSeriesF32::new(x, y)
 }
-

--- a/crates/blinc_app/src/context.rs
+++ b/crates/blinc_app/src/context.rs
@@ -529,6 +529,10 @@ impl RenderContext {
                     self.renderer
                         .render_line_segments_overlay(target, &fg_batch.line_segments);
                 }
+                if !fg_batch.foreground_line_segments.is_empty() {
+                    self.renderer
+                        .render_line_segments_overlay(target, &fg_batch.foreground_line_segments);
+                }
 
                 // Render paths with MSAA for smooth edges (paths are not included in unified primitives)
                 if use_msaa_overlay && fg_batch.has_paths() {
@@ -630,6 +634,10 @@ impl RenderContext {
                 if !fg_batch.line_segments.is_empty() {
                     self.renderer
                         .render_line_segments_overlay(target, &fg_batch.line_segments);
+                }
+                if !fg_batch.foreground_line_segments.is_empty() {
+                    self.renderer
+                        .render_line_segments_overlay(target, &fg_batch.foreground_line_segments);
                 }
 
                 // Render paths with MSAA for smooth edges (paths are not included in unified primitives)

--- a/crates/blinc_app/src/demos/charts_gallery.rs
+++ b/crates/blinc_app/src/demos/charts_gallery.rs
@@ -1,0 +1,48 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LayoutMode {
+    Wide,
+    Narrow,
+}
+
+pub const NARROW_BREAKPOINT_W: f32 = 900.0;
+
+pub fn layout_mode(width: f32, _height: f32) -> LayoutMode {
+    if width < NARROW_BREAKPOINT_W {
+        LayoutMode::Narrow
+    } else {
+        LayoutMode::Wide
+    }
+}
+
+pub fn parse_initial_selected(selected: Option<&str>, items_len: usize) -> usize {
+    if items_len == 0 {
+        return 0;
+    }
+    selected
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|&i| i < items_len)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_layout_mode_breakpoint() {
+        assert_eq!(layout_mode(1200.0, 800.0), LayoutMode::Wide);
+        assert_eq!(layout_mode(900.0, 800.0), LayoutMode::Wide);
+        assert_eq!(layout_mode(899.0, 800.0), LayoutMode::Narrow);
+    }
+
+    #[test]
+    fn test_parse_initial_selected() {
+        assert_eq!(parse_initial_selected(None, 10), 0);
+        assert_eq!(parse_initial_selected(Some("0"), 10), 0);
+        assert_eq!(parse_initial_selected(Some("9"), 10), 9);
+        assert_eq!(parse_initial_selected(Some("10"), 10), 0);
+        assert_eq!(parse_initial_selected(Some(" 3 "), 10), 3);
+        assert_eq!(parse_initial_selected(Some("nope"), 10), 0);
+        assert_eq!(parse_initial_selected(Some("1"), 0), 0);
+    }
+}

--- a/crates/blinc_app/src/demos/mod.rs
+++ b/crates/blinc_app/src/demos/mod.rs
@@ -1,0 +1,1 @@
+pub mod charts_gallery;

--- a/crates/blinc_app/src/lib.rs
+++ b/crates/blinc_app/src/lib.rs
@@ -124,6 +124,7 @@ pub fn system_font_paths() -> &'static [&'static str] {
 
 mod app;
 mod context;
+pub mod demos;
 mod error;
 mod text_measurer;
 

--- a/crates/blinc_app/src/tests.rs
+++ b/crates/blinc_app/src/tests.rs
@@ -289,6 +289,11 @@ fn test_tessellated_path_stroke_is_visible() {
             .h_full(),
         );
 
+    // Optional artifact for local debugging.
+    if std::env::var_os("BLINC_TEST_WRITE_ARTIFACTS").is_some() {
+        render_to_png(&mut app, "debug_canvas_polyline", &ui, 240, 180);
+    }
+
     let img = render_to_image(&mut app, &ui, 240, 180);
 
     // Count "blue-ish" pixels. Thresholds are conservative to be robust to AA.
@@ -337,9 +342,6 @@ fn test_compact_polyline_is_visible() {
             .w_full()
             .h_full(),
         );
-
-    // Persist an artifact for local debugging when this test fails.
-    render_to_png(&mut app, "debug_canvas_polyline", &ui, 240, 180);
 
     let img = render_to_image(&mut app, &ui, 240, 180);
 

--- a/crates/blinc_charts/src/area.rs
+++ b/crates/blinc_charts/src/area.rs
@@ -1,11 +1,12 @@
 use std::sync::{Arc, Mutex};
 
-use blinc_core::{Brush, Color, CornerRadius, DrawContext, Point, Rect, Stroke, TextStyle};
+use blinc_core::{Brush, Color, DrawContext, Path, Point, Rect, Stroke, TextStyle};
 use blinc_layout::canvas::canvas;
 use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
 use crate::brush::BrushX;
+use crate::common::{draw_grid, fill_bg};
 use crate::link::ChartLinkHandle;
 use crate::lod::{downsample_min_max, DownsampleParams};
 use crate::time_series::TimeSeriesF32;
@@ -30,67 +31,59 @@ impl SampleKey {
     }
 }
 
-/// Visual styling for the line chart.
 #[derive(Clone, Debug)]
-pub struct LineChartStyle {
+pub struct AreaChartStyle {
     pub bg: Color,
     pub grid: Color,
     pub line: Color,
+    pub area: Color,
     pub crosshair: Color,
     pub text: Color,
     pub stroke_width: f32,
+    pub baseline_y: f32,
     pub scroll_zoom_factor: f32,
     pub pinch_zoom_min: f32,
 }
 
-impl Default for LineChartStyle {
+impl Default for AreaChartStyle {
     fn default() -> Self {
         Self {
             bg: Color::rgba(0.08, 0.09, 0.11, 1.0),
             grid: Color::rgba(1.0, 1.0, 1.0, 0.08),
             line: Color::rgba(0.35, 0.65, 1.0, 1.0),
+            area: Color::rgba(0.35, 0.65, 1.0, 0.20),
             crosshair: Color::rgba(1.0, 1.0, 1.0, 0.35),
             text: Color::rgba(1.0, 1.0, 1.0, 0.85),
             stroke_width: 1.5,
+            baseline_y: 0.0,
             scroll_zoom_factor: 0.02,
             pinch_zoom_min: 0.01,
         }
     }
 }
 
-/// Mutable model for an interactive line chart.
-///
-/// Store this behind an `Arc<Mutex<_>>` and reuse across rebuilds.
-pub struct LineChartModel {
+pub struct AreaChartModel {
     pub series: TimeSeriesF32,
     pub view: ChartView,
-    pub style: LineChartStyle,
+    pub style: AreaChartStyle,
 
-    pub crosshair_x: Option<f32>,   // local px in plot area
-    pub hover_point: Option<Point>, // data coords
+    pub crosshair_x: Option<f32>,
+    pub hover_point: Option<Point>,
 
-    downsampled: Vec<Point>, // data coords
-    points_px: Vec<Point>,   // screen coords (local)
+    downsampled: Vec<Point>,
+    points_px: Vec<Point>,
     downsample_params: DownsampleParams,
     user_max_points: usize,
-
-    // Cache key for (re)sampling. Hover-only interactions should not force
-    // downsampling or point transforms on every frame.
     last_sample_key: Option<SampleKey>,
-
-    // EventRouter's drag_delta_x/y are "offset from drag start", not per-frame deltas.
-    // Track last observed totals so we can convert to incremental deltas for panning.
     last_drag_total_x: Option<f32>,
-
     brush_x: BrushX,
 }
 
-impl LineChartModel {
+impl AreaChartModel {
     pub fn new(series: TimeSeriesF32) -> Self {
         let (x0, x1) = series.x_min_max();
         let (mut y0, mut y1) = series.y_min_max();
         if !(y1 > y0) {
-            // Handle degenerate or invalid y-ranges (e.g. all NaN -> (0,0)).
             if y0.is_finite() && y1.is_finite() {
                 y0 -= 1.0;
                 y1 += 1.0;
@@ -103,7 +96,7 @@ impl LineChartModel {
         Self {
             series,
             view: ChartView::new(domain),
-            style: LineChartStyle::default(),
+            style: AreaChartStyle::default(),
             crosshair_x: None,
             hover_point: None,
             downsampled: Vec::new(),
@@ -153,17 +146,9 @@ impl LineChartModel {
         }
         let cursor_x_px = cursor_x_px.clamp(px, px + pw);
         let pivot_x = self.view.px_to_x(cursor_x_px, px, pw);
-
-        // Trackpad/mouse wheel: delta_y > 0 typically means scroll down.
-        // Use exponential zoom so it feels consistent across devices.
-        //
-        // Note: On desktop, pixel scroll deltas are normalized in the platform layer,
-        // so use a larger factor to keep zoom responsive.
         let delta_y = delta_y.clamp(-250.0, 250.0);
         let zoom = (-delta_y * self.style.scroll_zoom_factor).exp();
         self.view.domain.x.zoom_about(pivot_x, zoom);
-
-        // Prevent collapsing to 0 span.
         self.view.domain.x.clamp_span_min(1e-6);
     }
 
@@ -174,28 +159,23 @@ impl LineChartModel {
         }
         let cursor_x_px = cursor_x_px.clamp(px, px + pw);
         let pivot_x = self.view.px_to_x(cursor_x_px, px, pw);
-
-        // EventContext::pinch_scale is "ratio delta per update (1.0 = no change)".
         let zoom = scale_delta.max(self.style.pinch_zoom_min);
         self.view.domain.x.zoom_about(pivot_x, zoom);
         self.view.domain.x.clamp_span_min(1e-6);
     }
 
-    /// Pan using drag "total delta from start" (EventContext::drag_delta_x).
     pub fn on_drag_pan_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
         let (_px, _py, pw, _ph) = self.plot_rect(w, h);
         if pw <= 0.0 {
             return;
         }
 
-        // Convert total-from-start to incremental delta since last event.
         let prev = self.last_drag_total_x.replace(drag_total_dx);
         let drag_dx = match prev {
             Some(p) => drag_total_dx - p,
             None => 0.0,
         };
 
-        // Convert pixel delta to domain delta.
         let dx = -drag_dx / pw * self.view.domain.x.span();
         self.view.domain.x.pan_by(dx);
     }
@@ -224,12 +204,10 @@ impl LineChartModel {
         if pw <= 0.0 {
             return;
         }
-        // Brush updates track cursor position. DRAG provides delta-from-start, so infer current x.
-        let Some(start_x) = self.brush_x.anchor_px() else {
-            return;
-        };
-        let x = start_x + drag_total_dx;
-        self.brush_x.update(x.clamp(px, px + pw));
+        if let Some(anchor) = self.brush_x.anchor_px() {
+            self.brush_x
+                .update((anchor + drag_total_dx).clamp(px, px + pw));
+        }
     }
 
     pub fn on_mouse_up_finish_brush_x(&mut self, w: f32, h: f32) -> Option<(f32, f32)> {
@@ -239,6 +217,8 @@ impl LineChartModel {
             return None;
         }
         let (a_px, b_px) = self.brush_x.take_final_px()?;
+        let a_px = a_px.clamp(px, px + pw);
+        let b_px = b_px.clamp(px, px + pw);
         let a = self.view.px_to_x(a_px, px, pw);
         let b = self.view.px_to_x(b_px, px, pw);
         Some(if a <= b { (a, b) } else { (b, a) })
@@ -247,9 +227,6 @@ impl LineChartModel {
     fn ensure_samples(&mut self, w: f32, h: f32) {
         let (px, py, pw, ph) = self.plot_rect(w, h);
         if pw <= 0.0 || ph <= 0.0 {
-            self.downsampled.clear();
-            self.points_px.clear();
-            self.last_sample_key = None;
             return;
         }
 
@@ -258,7 +235,6 @@ impl LineChartModel {
             return;
         }
 
-        // Keep output bounded by pixels (2 points per pixel column is plenty).
         let max_points = (pw.ceil() as usize).saturating_mul(2).clamp(128, 200_000);
         self.downsample_params.max_points = self.user_max_points.min(max_points);
 
@@ -270,12 +246,10 @@ impl LineChartModel {
             &mut self.downsampled,
         );
 
-        // Ensure at least 2 points for drawing.
         if self.downsampled.len() == 1 {
             self.downsampled.push(self.downsampled[0]);
         }
 
-        // Convert to local pixel points once.
         self.points_px.clear();
         self.points_px.reserve(self.downsampled.len());
         for p in &self.downsampled {
@@ -287,39 +261,31 @@ impl LineChartModel {
     }
 
     pub fn render_plot(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
-        // Background
-        ctx.fill_rect(
-            Rect::new(0.0, 0.0, w, h),
-            CornerRadius::default(),
-            Brush::Solid(self.style.bg),
-        );
+        fill_bg(ctx, w, h, self.style.bg);
 
         let (px, py, pw, ph) = self.plot_rect(w, h);
         if pw <= 0.0 || ph <= 0.0 {
             return;
         }
+        draw_grid(ctx, px, py, pw, ph, self.style.grid, 4);
 
-        // Grid (cheap, fixed count)
-        let grid_n = 4;
-        for i in 0..=grid_n {
-            let t = i as f32 / grid_n as f32;
-            let x = px + t * pw;
-            let y = py + t * ph;
-            ctx.fill_rect(
-                Rect::new(x, py, 1.0, ph),
-                0.0.into(),
-                Brush::Solid(self.style.grid),
-            );
-            ctx.fill_rect(
-                Rect::new(px, y, pw, 1.0),
-                0.0.into(),
-                Brush::Solid(self.style.grid),
-            );
-        }
-
-        // Series (cached)
         self.ensure_samples(w, h);
         if self.points_px.len() >= 2 {
+            // Area fill
+            let baseline_px = self.view.y_to_px(self.style.baseline_y, py, ph);
+            let mut path = Path::new();
+            // Clamp baseline to plot.
+            let baseline_px = baseline_px.clamp(py, py + ph);
+            let first = self.points_px[0];
+            path = path.move_to(first.x, baseline_px);
+            for p in &self.points_px {
+                path = path.line_to(p.x, p.y);
+            }
+            let last = self.points_px[self.points_px.len() - 1];
+            path = path.line_to(last.x, baseline_px).close();
+            ctx.fill_path(&path, Brush::Solid(self.style.area));
+
+            // Outline
             let stroke = Stroke::new(self.style.stroke_width);
             ctx.stroke_polyline(&self.points_px, &stroke, Brush::Solid(self.style.line));
         }
@@ -331,7 +297,6 @@ impl LineChartModel {
             return;
         }
 
-        // In-progress brush (X-only).
         if let Some((a, b)) = self.brush_x.range_px() {
             let x = a.clamp(px, px + pw);
             let w = (b - a).abs().max(1.0);
@@ -342,7 +307,6 @@ impl LineChartModel {
             );
         }
 
-        // Crosshair
         if let Some(cx) = self.crosshair_x {
             let x = cx.clamp(px, px + pw);
             ctx.fill_rect(
@@ -352,42 +316,27 @@ impl LineChartModel {
             );
         }
 
-        // Tooltip (simple)
         if let Some(p) = self.hover_point {
             let text = format!("x={:.3}  y={:.3}", p.x, p.y);
             let style = TextStyle::new(12.0).with_color(self.style.text);
-            // Anchor near top-left of plot.
             ctx.draw_text(&text, Point::new(px + 6.0, py + 6.0), &style);
         }
     }
 }
 
-/// Shared handle for a line chart model.
 #[derive(Clone)]
-pub struct LineChartHandle(pub Arc<Mutex<LineChartModel>>);
+pub struct AreaChartHandle(pub Arc<Mutex<AreaChartModel>>);
 
-impl LineChartHandle {
-    pub fn new(model: LineChartModel) -> Self {
+impl AreaChartHandle {
+    pub fn new(model: AreaChartModel) -> Self {
         Self(Arc::new(Mutex::new(model)))
     }
 }
 
-/// Create an interactive line chart element.
-///
-/// Composition:
-/// - Root: `stack()` (so callers can overlay additional canvases/elements)
-/// - Child 1: plot `canvas` (background layer)
-/// - Child 2: overlay `canvas` (foreground layer)
-///
-/// Interactions (using Blinc events):
-/// - `on_mouse_move`: updates crosshair + nearest-point hover
-/// - `on_scroll` / `on_pinch`: zoom X about cursor
-/// - `on_drag`: pan X
-pub fn line_chart(handle: LineChartHandle) -> impl ElementBuilder {
+pub fn area_chart(handle: AreaChartHandle) -> impl ElementBuilder {
     let model_plot = handle.0.clone();
     let model_overlay = handle.0.clone();
 
-    // Events mutate the shared model and request a redraw (no tree rebuild).
     let model_move = handle.0.clone();
     let model_scroll = handle.0.clone();
     let model_pinch = handle.0.clone();
@@ -435,9 +384,9 @@ pub fn line_chart(handle: LineChartHandle) -> impl ElementBuilder {
                 blinc_layout::stateful::request_redraw();
             }
         })
-        .on_mouse_up(move |_e| {
+        .on_mouse_up(move |e| {
             if let Ok(mut m) = model_up.lock() {
-                let _ = m.on_mouse_up_finish_brush_x(_e.bounds_width, _e.bounds_height);
+                let _ = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height);
                 m.on_drag_end();
                 blinc_layout::stateful::request_redraw();
             }
@@ -468,13 +417,7 @@ pub fn line_chart(handle: LineChartHandle) -> impl ElementBuilder {
         )
 }
 
-/// Create a linked line chart element.
-///
-/// Additional behaviors:
-/// - Pan/zoom is synchronized via `link.x_domain` (shared X domain).
-/// - Hover is broadcast via `link.hover_x`.
-/// - Selection (brush) is created with Shift+Drag and stored in `link.selection_x`.
-pub fn linked_line_chart(handle: LineChartHandle, link: ChartLinkHandle) -> impl ElementBuilder {
+pub fn linked_area_chart(handle: AreaChartHandle, link: ChartLinkHandle) -> impl ElementBuilder {
     let model_plot = handle.0.clone();
     let model_overlay = handle.0.clone();
 
@@ -505,7 +448,6 @@ pub fn linked_line_chart(handle: LineChartHandle, link: ChartLinkHandle) -> impl
                 m.view.domain.x = l.x_domain;
                 m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
 
-                // Publish hover x in domain units (or None when out of plot).
                 let (px, _py, pw, _ph) = m.plot_rect(e.bounds_width, e.bounds_height);
                 if pw > 0.0 && m.crosshair_x.is_some() {
                     let x = m.view.px_to_x(e.local_x.clamp(px, px + pw), px, pw);
@@ -552,9 +494,9 @@ pub fn linked_line_chart(handle: LineChartHandle, link: ChartLinkHandle) -> impl
         })
         .on_mouse_up(move |e| {
             if let (Ok(mut l), Ok(mut m)) = (link_up.lock(), model_up.lock()) {
-                m.view.domain.x = l.x_domain;
-                if let Some(sel) = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height) {
-                    l.set_selection_x(Some(sel));
+                if let Some((a, b)) = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height)
+                {
+                    l.set_selection_x(Some((a, b)));
                 }
                 m.on_drag_end();
                 blinc_layout::stateful::request_redraw();
@@ -579,29 +521,6 @@ pub fn linked_line_chart(handle: LineChartHandle, link: ChartLinkHandle) -> impl
             canvas(move |ctx, bounds| {
                 if let (Ok(l), Ok(mut m)) = (link_overlay.lock(), model_overlay.lock()) {
                     m.view.domain.x = l.x_domain;
-                    // Selection highlight (committed).
-                    if let Some((a, b)) = l.selection_x {
-                        let (px, py, pw, ph) = m.plot_rect(bounds.width, bounds.height);
-                        if pw > 0.0 && ph > 0.0 {
-                            let xa = m.view.x_to_px(a, px, pw);
-                            let xb = m.view.x_to_px(b, px, pw);
-                            let x0 = xa.min(xb).clamp(px, px + pw);
-                            let x1 = xa.max(xb).clamp(px, px + pw);
-                            ctx.fill_rect(
-                                Rect::new(x0, py, (x1 - x0).max(1.0), ph),
-                                0.0.into(),
-                                Brush::Solid(Color::rgba(1.0, 1.0, 1.0, 0.06)),
-                            );
-                        }
-                    }
-
-                    // Linked hover crosshair.
-                    if let Some(hx) = l.hover_x {
-                        let (px, _py, pw, _ph) = m.plot_rect(bounds.width, bounds.height);
-                        if pw > 0.0 {
-                            m.crosshair_x = Some(m.view.x_to_px(hx, px, pw));
-                        }
-                    }
                     m.render_overlay(ctx, bounds.width, bounds.height);
                 }
             })

--- a/crates/blinc_charts/src/brush.rs
+++ b/crates/blinc_charts/src/brush.rs
@@ -1,0 +1,68 @@
+/// Minimal 1D brush state (X axis), in local pixel coordinates.
+///
+/// We keep this in pixel space for two reasons:
+/// - gesture handling is naturally in pixels
+/// - domain conversion depends on the current view transform
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BrushX {
+    active: bool,
+    start_px: f32,
+    cur_px: f32,
+}
+
+impl BrushX {
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    pub fn anchor_px(&self) -> Option<f32> {
+        if self.active { Some(self.start_px) } else { None }
+    }
+
+    pub fn begin(&mut self, x_px: f32) {
+        self.active = true;
+        self.start_px = x_px;
+        self.cur_px = x_px;
+    }
+
+    pub fn update(&mut self, x_px: f32) {
+        if self.active {
+            self.cur_px = x_px;
+        }
+    }
+
+    pub fn cancel(&mut self) {
+        self.active = false;
+    }
+
+    pub fn range_px(&self) -> Option<(f32, f32)> {
+        if !self.active {
+            return None;
+        }
+        let (a, b) = (self.start_px, self.cur_px);
+        Some(if a <= b { (a, b) } else { (b, a) })
+    }
+
+    pub fn take_final_px(&mut self) -> Option<(f32, f32)> {
+        let r = self.range_px();
+        self.active = false;
+        r
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn brush_tracks_range() {
+        let mut b = BrushX::default();
+        assert_eq!(b.range_px(), None);
+        b.begin(10.0);
+        assert_eq!(b.range_px(), Some((10.0, 10.0)));
+        b.update(3.0);
+        assert_eq!(b.range_px(), Some((3.0, 10.0)));
+        assert_eq!(b.take_final_px(), Some((3.0, 10.0)));
+        assert_eq!(b.range_px(), None);
+    }
+}

--- a/crates/blinc_charts/src/brush.rs
+++ b/crates/blinc_charts/src/brush.rs
@@ -16,7 +16,11 @@ impl BrushX {
     }
 
     pub fn anchor_px(&self) -> Option<f32> {
-        if self.active { Some(self.start_px) } else { None }
+        if self.active {
+            Some(self.start_px)
+        } else {
+            None
+        }
     }
 
     pub fn begin(&mut self, x_px: f32) {

--- a/crates/blinc_charts/src/common.rs
+++ b/crates/blinc_charts/src/common.rs
@@ -1,0 +1,40 @@
+use blinc_core::{Brush, Color, CornerRadius, DrawContext, Rect};
+
+pub fn fill_bg(ctx: &mut dyn DrawContext, w: f32, h: f32, bg: Color) {
+    ctx.fill_rect(
+        Rect::new(0.0, 0.0, w, h),
+        CornerRadius::default(),
+        Brush::Solid(bg),
+    );
+}
+
+pub fn draw_grid(
+    ctx: &mut dyn DrawContext,
+    plot_x: f32,
+    plot_y: f32,
+    plot_w: f32,
+    plot_h: f32,
+    grid: Color,
+    grid_n: usize,
+) {
+    if plot_w <= 0.0 || plot_h <= 0.0 {
+        return;
+    }
+
+    let grid_n = grid_n.max(1);
+    for i in 0..=grid_n {
+        let t = i as f32 / grid_n as f32;
+        let x = plot_x + t * plot_w;
+        let y = plot_y + t * plot_h;
+        ctx.fill_rect(
+            Rect::new(x, plot_y, 1.0, plot_h),
+            0.0.into(),
+            Brush::Solid(grid),
+        );
+        ctx.fill_rect(
+            Rect::new(plot_x, y, plot_w, 1.0),
+            0.0.into(),
+            Brush::Solid(grid),
+        );
+    }
+}

--- a/crates/blinc_charts/src/heatmap.rs
+++ b/crates/blinc_charts/src/heatmap.rs
@@ -115,11 +115,16 @@ impl HeatmapChartModel {
         // Fit to screen to keep cost bounded.
         let cells_x = self.grid_w.min(self.style.max_cells_x);
         let cells_y = self.grid_h.min(self.style.max_cells_y);
-        let step_x = (self.grid_w as f32 / cells_x as f32).max(1.0) as usize;
-        let step_y = (self.grid_h as f32 / cells_y as f32).max(1.0) as usize;
+        // Choose steps so the sampled grid does not exceed max_cells_{x,y}.
+        // Use integer ceil-div to avoid oversampling due to float truncation.
+        let step_x = ((self.grid_w + cells_x - 1) / cells_x).max(1);
+        let step_y = ((self.grid_h + cells_y - 1) / cells_y).max(1);
 
-        let cell_w = (pw / (self.grid_w as f32 / step_x as f32)).max(1.0);
-        let cell_h = (ph / (self.grid_h as f32 / step_y as f32)).max(1.0);
+        let sampled_w = ((self.grid_w + step_x - 1) / step_x).max(1) as f32;
+        let sampled_h = ((self.grid_h + step_y - 1) / step_y).max(1) as f32;
+
+        let cell_w = (pw / sampled_w).max(1.0);
+        let cell_h = (ph / sampled_h).max(1.0);
 
         for gy in (0..self.grid_h).step_by(step_y) {
             for gx in (0..self.grid_w).step_by(step_x) {

--- a/crates/blinc_charts/src/heatmap.rs
+++ b/crates/blinc_charts/src/heatmap.rs
@@ -24,8 +24,10 @@ impl Default for HeatmapChartStyle {
             bg: Color::rgba(0.08, 0.09, 0.11, 1.0),
             grid: Color::rgba(1.0, 1.0, 1.0, 0.08),
             text: Color::rgba(1.0, 1.0, 1.0, 0.85),
-            max_cells_x: 256,
-            max_cells_y: 192,
+            // Keep total rect count <= ~8k so we don't overrun Blinc's default
+            // `max_primitives` buffer (this is a demo renderer, not an image-based one).
+            max_cells_x: 128,
+            max_cells_y: 64,
         }
     }
 }

--- a/crates/blinc_charts/src/heatmap.rs
+++ b/crates/blinc_charts/src/heatmap.rs
@@ -1,0 +1,166 @@
+use std::sync::{Arc, Mutex};
+
+use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextStyle};
+use blinc_layout::canvas::canvas;
+use blinc_layout::stack::stack;
+use blinc_layout::ElementBuilder;
+
+use crate::common::{draw_grid, fill_bg};
+use crate::view::{ChartView, Domain1D, Domain2D};
+
+#[derive(Clone, Debug)]
+pub struct HeatmapChartStyle {
+    pub bg: Color,
+    pub grid: Color,
+    pub text: Color,
+
+    pub max_cells_x: usize,
+    pub max_cells_y: usize,
+}
+
+impl Default for HeatmapChartStyle {
+    fn default() -> Self {
+        Self {
+            bg: Color::rgba(0.08, 0.09, 0.11, 1.0),
+            grid: Color::rgba(1.0, 1.0, 1.0, 0.08),
+            text: Color::rgba(1.0, 1.0, 1.0, 0.85),
+            max_cells_x: 256,
+            max_cells_y: 192,
+        }
+    }
+}
+
+pub struct HeatmapChartModel {
+    pub grid_w: usize,
+    pub grid_h: usize,
+    pub values: Vec<f32>, // row-major: y*grid_w + x
+    pub view: ChartView,
+    pub style: HeatmapChartStyle,
+}
+
+impl HeatmapChartModel {
+    pub fn new(grid_w: usize, grid_h: usize, values: Vec<f32>) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            grid_w > 0 && grid_h > 0,
+            "HeatmapChartModel requires non-empty grid"
+        );
+        anyhow::ensure!(
+            values.len() == grid_w * grid_h,
+            "values must be grid_w*grid_h"
+        );
+
+        let domain = Domain2D::new(
+            Domain1D::new(0.0, grid_w as f32),
+            Domain1D::new(0.0, grid_h as f32),
+        );
+        Ok(Self {
+            grid_w,
+            grid_h,
+            values,
+            view: ChartView::new(domain),
+            style: HeatmapChartStyle::default(),
+        })
+    }
+
+    fn plot_rect(&self, w: f32, h: f32) -> (f32, f32, f32, f32) {
+        self.view.plot_rect(w, h)
+    }
+
+    fn value_range(&self) -> (f32, f32) {
+        let mut vmin = f32::INFINITY;
+        let mut vmax = f32::NEG_INFINITY;
+        for &v in &self.values {
+            if v.is_finite() {
+                vmin = vmin.min(v);
+                vmax = vmax.max(v);
+            }
+        }
+        if !vmin.is_finite() || !vmax.is_finite() || !(vmax > vmin) {
+            (0.0, 1.0)
+        } else {
+            (vmin, vmax)
+        }
+    }
+
+    fn color_map(&self, t: f32) -> Color {
+        // Cheap blue->cyan->yellow->red ramp (no allocations).
+        let t = t.clamp(0.0, 1.0);
+        let (r, g, b) = if t < 0.33 {
+            let u = t / 0.33;
+            (0.10, 0.30 + 0.50 * u, 0.95)
+        } else if t < 0.66 {
+            let u = (t - 0.33) / 0.33;
+            (0.10 + 0.85 * u, 0.80, 0.95 - 0.75 * u)
+        } else {
+            let u = (t - 0.66) / 0.34;
+            (0.95, 0.80 - 0.65 * u, 0.20)
+        };
+        Color::rgba(r, g, b, 0.95)
+    }
+
+    pub fn render_plot(&self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        fill_bg(ctx, w, h, self.style.bg);
+
+        let (px, py, pw, ph) = self.plot_rect(w, h);
+        if pw <= 0.0 || ph <= 0.0 {
+            return;
+        }
+        draw_grid(ctx, px, py, pw, ph, self.style.grid, 4);
+
+        let (vmin, vmax) = self.value_range();
+        let inv = 1.0 / (vmax - vmin).max(1e-12);
+
+        // Fit to screen to keep cost bounded.
+        let cells_x = self.grid_w.min(self.style.max_cells_x);
+        let cells_y = self.grid_h.min(self.style.max_cells_y);
+        let step_x = (self.grid_w as f32 / cells_x as f32).max(1.0) as usize;
+        let step_y = (self.grid_h as f32 / cells_y as f32).max(1.0) as usize;
+
+        let cell_w = (pw / (self.grid_w as f32 / step_x as f32)).max(1.0);
+        let cell_h = (ph / (self.grid_h as f32 / step_y as f32)).max(1.0);
+
+        for gy in (0..self.grid_h).step_by(step_y) {
+            for gx in (0..self.grid_w).step_by(step_x) {
+                let idx = gy * self.grid_w + gx;
+                let v = self.values[idx];
+                if !v.is_finite() {
+                    continue;
+                }
+                let t = (v - vmin) * inv;
+                let x = px + (gx as f32 / step_x as f32) * cell_w;
+                let y = py + (gy as f32 / step_y as f32) * cell_h;
+                ctx.fill_rect(
+                    Rect::new(x, y, cell_w + 0.5, cell_h + 0.5),
+                    0.0.into(),
+                    Brush::Solid(self.color_map(t)),
+                );
+            }
+        }
+
+        let text = format!("grid={}x{} (screen-sampled)", self.grid_w, self.grid_h);
+        let style = TextStyle::new(12.0).with_color(self.style.text);
+        ctx.draw_text(&text, Point::new(px + 6.0, py + 6.0), &style);
+    }
+}
+
+#[derive(Clone)]
+pub struct HeatmapChartHandle(pub Arc<Mutex<HeatmapChartModel>>);
+
+impl HeatmapChartHandle {
+    pub fn new(model: HeatmapChartModel) -> Self {
+        Self(Arc::new(Mutex::new(model)))
+    }
+}
+
+pub fn heatmap_chart(handle: HeatmapChartHandle) -> impl ElementBuilder {
+    let model_plot = handle.0.clone();
+    stack().w_full().h_full().overflow_clip().child(
+        canvas(move |ctx, bounds| {
+            if let Ok(m) = model_plot.lock() {
+                m.render_plot(ctx, bounds.width, bounds.height);
+            }
+        })
+        .w_full()
+        .h_full(),
+    )
+}

--- a/crates/blinc_charts/src/histogram.rs
+++ b/crates/blinc_charts/src/histogram.rs
@@ -1,0 +1,331 @@
+use std::sync::{Arc, Mutex};
+
+use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextStyle};
+use blinc_layout::canvas::canvas;
+use blinc_layout::stack::stack;
+use blinc_layout::ElementBuilder;
+
+use crate::brush::BrushX;
+use crate::common::{draw_grid, fill_bg};
+use crate::view::{ChartView, Domain1D, Domain2D};
+
+#[derive(Clone, Debug)]
+pub struct HistogramChartStyle {
+    pub bg: Color,
+    pub grid: Color,
+    pub bar: Color,
+    pub crosshair: Color,
+    pub text: Color,
+    pub bins: usize,
+}
+
+impl Default for HistogramChartStyle {
+    fn default() -> Self {
+        Self {
+            bg: Color::rgba(0.08, 0.09, 0.11, 1.0),
+            grid: Color::rgba(1.0, 1.0, 1.0, 0.08),
+            bar: Color::rgba(0.35, 0.65, 1.0, 0.85),
+            crosshair: Color::rgba(1.0, 1.0, 1.0, 0.35),
+            text: Color::rgba(1.0, 1.0, 1.0, 0.85),
+            bins: 256,
+        }
+    }
+}
+
+pub struct HistogramChartModel {
+    pub values: Vec<f32>,
+    pub view: ChartView,
+    pub style: HistogramChartStyle,
+
+    pub crosshair_x: Option<f32>,
+    pub hover_x: Option<f32>,
+
+    hist: Vec<u32>,
+    x_min: f32,
+    x_max: f32,
+    max_count: u32,
+
+    last_drag_total_x: Option<f32>,
+    brush_x: BrushX,
+}
+
+impl HistogramChartModel {
+    pub fn new(values: Vec<f32>) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            !values.is_empty(),
+            "HistogramChartModel requires non-empty values"
+        );
+
+        let mut x_min = f32::INFINITY;
+        let mut x_max = f32::NEG_INFINITY;
+        for &v in &values {
+            if v.is_finite() {
+                x_min = x_min.min(v);
+                x_max = x_max.max(v);
+            }
+        }
+        if !x_min.is_finite() || !x_max.is_finite() || !(x_max > x_min) {
+            x_min = 0.0;
+            x_max = 1.0;
+        }
+
+        let domain = Domain2D::new(Domain1D::new(x_min, x_max), Domain1D::new(0.0, 1.0));
+        let mut m = Self {
+            values,
+            view: ChartView::new(domain),
+            style: HistogramChartStyle::default(),
+            crosshair_x: None,
+            hover_x: None,
+            hist: Vec::new(),
+            x_min,
+            x_max,
+            max_count: 1,
+            last_drag_total_x: None,
+            brush_x: BrushX::default(),
+        };
+        m.recompute_hist();
+        Ok(m)
+    }
+
+    fn plot_rect(&self, w: f32, h: f32) -> (f32, f32, f32, f32) {
+        self.view.plot_rect(w, h)
+    }
+
+    fn recompute_hist(&mut self) {
+        let bins = self.style.bins.clamp(8, 8192);
+        self.hist.clear();
+        self.hist.resize(bins, 0);
+        let span = (self.x_max - self.x_min).max(1e-12);
+        let inv_span = 1.0 / span;
+
+        for &v in &self.values {
+            if !v.is_finite() {
+                continue;
+            }
+            let t = ((v - self.x_min) * inv_span).clamp(0.0, 0.999_999);
+            let bin = (t * bins as f32) as usize;
+            self.hist[bin] = self.hist[bin].saturating_add(1);
+        }
+
+        self.max_count = self.hist.iter().copied().max().unwrap_or(1).max(1);
+        // Sync Y domain to counts.
+        self.view.domain.y.min = 0.0;
+        self.view.domain.y.max = self.max_count as f32;
+    }
+
+    pub fn on_mouse_move(&mut self, local_x: f32, local_y: f32, w: f32, h: f32) {
+        let (px, py, pw, ph) = self.plot_rect(w, h);
+        if pw <= 0.0 || ph <= 0.0 {
+            self.crosshair_x = None;
+            self.hover_x = None;
+            return;
+        }
+
+        if local_x < px || local_x > px + pw || local_y < py || local_y > py + ph {
+            self.crosshair_x = None;
+            self.hover_x = None;
+            return;
+        }
+
+        self.crosshair_x = Some(local_x);
+        self.hover_x = Some(self.view.px_to_x(local_x, px, pw));
+    }
+
+    pub fn on_drag_pan_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        let (_px, _py, pw, _ph) = self.plot_rect(w, h);
+        if pw <= 0.0 {
+            return;
+        }
+        let prev = self.last_drag_total_x.replace(drag_total_dx);
+        let drag_dx = match prev {
+            Some(p) => drag_total_dx - p,
+            None => 0.0,
+        };
+        let dx = -drag_dx / pw * self.view.domain.x.span();
+        self.view.domain.x.pan_by(dx);
+    }
+
+    pub fn on_drag_end(&mut self) {
+        self.last_drag_total_x = None;
+    }
+
+    pub fn on_mouse_down(&mut self, shift: bool, local_x: f32, w: f32, h: f32) {
+        if !shift {
+            return;
+        }
+        let (px, _py, pw, _ph) = self.plot_rect(w, h);
+        if pw <= 0.0 {
+            return;
+        }
+        self.brush_x.begin(local_x.clamp(px, px + pw));
+        self.last_drag_total_x = None;
+    }
+
+    pub fn on_drag_brush_x_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        if !self.brush_x.is_active() {
+            return;
+        }
+        let (px, _py, pw, _ph) = self.plot_rect(w, h);
+        if pw <= 0.0 {
+            return;
+        }
+        if let Some(anchor) = self.brush_x.anchor_px() {
+            self.brush_x
+                .update((anchor + drag_total_dx).clamp(px, px + pw));
+        }
+    }
+
+    pub fn on_mouse_up_finish_brush_x(&mut self, w: f32, h: f32) -> Option<(f32, f32)> {
+        let (px, _py, pw, _ph) = self.plot_rect(w, h);
+        if pw <= 0.0 {
+            self.brush_x.cancel();
+            return None;
+        }
+        let (a_px, b_px) = self.brush_x.take_final_px()?;
+        let a_px = a_px.clamp(px, px + pw);
+        let b_px = b_px.clamp(px, px + pw);
+        let a = self.view.px_to_x(a_px, px, pw);
+        let b = self.view.px_to_x(b_px, px, pw);
+        Some(if a <= b { (a, b) } else { (b, a) })
+    }
+
+    pub fn render_plot(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        fill_bg(ctx, w, h, self.style.bg);
+        let (px, py, pw, ph) = self.plot_rect(w, h);
+        if pw <= 0.0 || ph <= 0.0 {
+            return;
+        }
+        draw_grid(ctx, px, py, pw, ph, self.style.grid, 4);
+
+        // Histogram is currently global (no pan/zoom recompute). Keep it simple for the demo.
+        if self.hist.is_empty() {
+            return;
+        }
+
+        let bar_w = (pw / self.hist.len() as f32).max(1.0);
+        for (i, &c) in self.hist.iter().enumerate() {
+            let x = px + i as f32 * (pw / self.hist.len() as f32);
+            let y = c as f32;
+            let y_px = self.view.y_to_px(y, py, ph);
+            let top = y_px.min(py + ph);
+            let bottom = py + ph;
+            let rect_h = (bottom - top).max(0.5);
+            ctx.fill_rect(
+                Rect::new(x, top, bar_w, rect_h),
+                0.0.into(),
+                Brush::Solid(self.style.bar),
+            );
+        }
+    }
+
+    pub fn render_overlay(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        let (px, py, pw, ph) = self.plot_rect(w, h);
+        if pw <= 0.0 || ph <= 0.0 {
+            return;
+        }
+
+        if let Some((a, b)) = self.brush_x.range_px() {
+            let x = a.clamp(px, px + pw);
+            let w = (b - a).abs().max(1.0);
+            ctx.fill_rect(
+                Rect::new(x.min(px + pw), py, w.min(pw), ph),
+                0.0.into(),
+                Brush::Solid(Color::rgba(0.35, 0.65, 1.0, 0.10)),
+            );
+        }
+
+        if let Some(cx) = self.crosshair_x {
+            let x = cx.clamp(px, px + pw);
+            ctx.fill_rect(
+                Rect::new(x, py, 1.0, ph),
+                0.0.into(),
+                Brush::Solid(self.style.crosshair),
+            );
+        }
+
+        if let Some(x) = self.hover_x {
+            let text = format!("x={:.3}", x);
+            let style = TextStyle::new(12.0).with_color(self.style.text);
+            ctx.draw_text(&text, Point::new(px + 6.0, py + 6.0), &style);
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HistogramChartHandle(pub Arc<Mutex<HistogramChartModel>>);
+
+impl HistogramChartHandle {
+    pub fn new(model: HistogramChartModel) -> Self {
+        Self(Arc::new(Mutex::new(model)))
+    }
+}
+
+pub fn histogram_chart(handle: HistogramChartHandle) -> impl ElementBuilder {
+    let model_plot = handle.0.clone();
+    let model_overlay = handle.0.clone();
+
+    let model_move = handle.0.clone();
+    let model_down = handle.0.clone();
+    let model_drag = handle.0.clone();
+    let model_up = handle.0.clone();
+    let model_drag_end = handle.0.clone();
+
+    stack()
+        .w_full()
+        .h_full()
+        .overflow_clip()
+        .cursor(blinc_layout::element::CursorStyle::Crosshair)
+        .on_mouse_move(move |e| {
+            if let Ok(mut m) = model_move.lock() {
+                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_mouse_down(move |e| {
+            if let Ok(mut m) = model_down.lock() {
+                m.on_mouse_down(e.shift, e.local_x, e.bounds_width, e.bounds_height);
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_drag(move |e| {
+            if let Ok(mut m) = model_drag.lock() {
+                if e.shift {
+                    m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
+                } else {
+                    m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
+                }
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_mouse_up(move |e| {
+            if let Ok(mut m) = model_up.lock() {
+                let _ = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height);
+                m.on_drag_end();
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_drag_end(move |_e| {
+            if let Ok(mut m) = model_drag_end.lock() {
+                m.on_drag_end();
+            }
+        })
+        .child(
+            canvas(move |ctx, bounds| {
+                if let Ok(mut m) = model_plot.lock() {
+                    m.render_plot(ctx, bounds.width, bounds.height);
+                }
+            })
+            .w_full()
+            .h_full(),
+        )
+        .child(
+            canvas(move |ctx, bounds| {
+                if let Ok(mut m) = model_overlay.lock() {
+                    m.render_overlay(ctx, bounds.width, bounds.height);
+                }
+            })
+            .w_full()
+            .h_full()
+            .foreground(),
+        )
+}

--- a/crates/blinc_charts/src/input.rs
+++ b/crates/blinc_charts/src/input.rs
@@ -1,0 +1,96 @@
+/// Interaction bindings for charts.
+///
+/// `blinc_charts` is a library crate, so gesture/key bindings must be configurable.
+/// We keep bindings simple and purely data-driven so they can be shared across chart types.
+
+/// A "required modifiers" mask.
+///
+/// If a field is `true`, the corresponding key must be held. Non-required keys are ignored.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ModifiersReq {
+    pub shift: bool,
+    pub ctrl: bool,
+    pub alt: bool,
+    pub meta: bool,
+}
+
+impl ModifiersReq {
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    pub fn shift() -> Self {
+        Self {
+            shift: true,
+            ..Self::default()
+        }
+    }
+
+    pub fn matches(&self, shift: bool, ctrl: bool, alt: bool, meta: bool) -> bool {
+        (!self.shift || shift)
+            && (!self.ctrl || ctrl)
+            && (!self.alt || alt)
+            && (!self.meta || meta)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DragAction {
+    None,
+    PanX,
+    BrushX,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DragBinding {
+    pub required: ModifiersReq,
+    pub action: DragAction,
+}
+
+impl DragBinding {
+    pub fn none() -> Self {
+        Self {
+            required: ModifiersReq::none(),
+            action: DragAction::None,
+        }
+    }
+}
+
+/// Common interaction bindings shared by charts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChartInputBindings {
+    /// Which drag gesture is interpreted as a brush.
+    pub brush_drag: DragBinding,
+    /// Which drag gesture is interpreted as pan (when not brushing).
+    pub pan_drag: DragBinding,
+}
+
+impl Default for ChartInputBindings {
+    fn default() -> Self {
+        Self {
+            brush_drag: DragBinding {
+                required: ModifiersReq::shift(),
+                action: DragAction::BrushX,
+            },
+            pan_drag: DragBinding {
+                required: ModifiersReq::none(),
+                action: DragAction::PanX,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn modifiers_req_matches_required_only() {
+        let r = ModifiersReq::shift();
+        assert!(r.matches(true, false, false, false));
+        // Extra modifiers should not prevent a match.
+        assert!(r.matches(true, true, false, true));
+        assert!(!r.matches(false, true, false, false));
+    }
+}
+

--- a/crates/blinc_charts/src/lib.rs
+++ b/crates/blinc_charts/src/lib.rs
@@ -7,17 +7,25 @@
 //! - Use Blinc's built-in event routing (mouse/touch/scroll/pinch/drag)
 //! - Prioritize performance for large datasets via sampling/LOD and GPU pipelines
 
-mod lod;
 mod brush;
+mod common;
 mod link;
+mod lod;
 mod segments;
 mod time_series;
 mod view;
 
+pub mod area;
+pub mod bar;
+pub mod candlestick;
+pub mod heatmap;
+pub mod histogram;
 pub mod line;
 pub mod multi_line;
+pub mod scatter;
 
 pub use brush::BrushX;
+pub use candlestick::{Candle, CandleSeries};
 pub use link::{chart_link, ChartLink, ChartLinkHandle};
 pub use lod::{downsample_min_max, DownsampleParams};
 pub use segments::runs_by_gap;
@@ -26,13 +34,33 @@ pub use view::{ChartView, Domain1D, Domain2D};
 
 /// Common imports for chart users.
 pub mod prelude {
-    pub use crate::link::{chart_link, ChartLink, ChartLinkHandle};
+    pub use crate::area::{
+        area_chart, linked_area_chart, AreaChartHandle, AreaChartModel, AreaChartStyle,
+    };
+    pub use crate::bar::{
+        bar_chart, linked_bar_chart, BarChartHandle, BarChartModel, BarChartStyle,
+    };
+    pub use crate::candlestick::{
+        candlestick_chart, linked_candlestick_chart, Candle, CandleSeries, CandlestickChartHandle,
+        CandlestickChartModel, CandlestickChartStyle,
+    };
+    pub use crate::heatmap::{
+        heatmap_chart, HeatmapChartHandle, HeatmapChartModel, HeatmapChartStyle,
+    };
+    pub use crate::histogram::{
+        histogram_chart, HistogramChartHandle, HistogramChartModel, HistogramChartStyle,
+    };
     pub use crate::line::{
         line_chart, linked_line_chart, LineChartHandle, LineChartModel, LineChartStyle,
     };
+    pub use crate::link::{chart_link, ChartLink, ChartLinkHandle};
     pub use crate::multi_line::{
         linked_multi_line_chart, multi_line_chart, MultiLineChartHandle, MultiLineChartModel,
         MultiLineChartStyle,
+    };
+    pub use crate::scatter::{
+        linked_scatter_chart, scatter_chart, ScatterChartHandle, ScatterChartModel,
+        ScatterChartStyle,
     };
     pub use crate::time_series::TimeSeriesF32;
     pub use crate::view::{ChartView, Domain1D, Domain2D};

--- a/crates/blinc_charts/src/lib.rs
+++ b/crates/blinc_charts/src/lib.rs
@@ -8,6 +8,8 @@
 //! - Prioritize performance for large datasets via sampling/LOD and GPU pipelines
 
 mod lod;
+mod brush;
+mod link;
 mod segments;
 mod time_series;
 mod view;
@@ -15,6 +17,8 @@ mod view;
 pub mod line;
 pub mod multi_line;
 
+pub use brush::BrushX;
+pub use link::{chart_link, ChartLink, ChartLinkHandle};
 pub use lod::{downsample_min_max, DownsampleParams};
 pub use segments::runs_by_gap;
 pub use time_series::TimeSeriesF32;
@@ -22,9 +26,13 @@ pub use view::{ChartView, Domain1D, Domain2D};
 
 /// Common imports for chart users.
 pub mod prelude {
-    pub use crate::line::{line_chart, LineChartHandle, LineChartModel, LineChartStyle};
+    pub use crate::link::{chart_link, ChartLink, ChartLinkHandle};
+    pub use crate::line::{
+        line_chart, linked_line_chart, LineChartHandle, LineChartModel, LineChartStyle,
+    };
     pub use crate::multi_line::{
-        multi_line_chart, MultiLineChartHandle, MultiLineChartModel, MultiLineChartStyle,
+        linked_multi_line_chart, multi_line_chart, MultiLineChartHandle, MultiLineChartModel,
+        MultiLineChartStyle,
     };
     pub use crate::time_series::TimeSeriesF32;
     pub use crate::view::{ChartView, Domain1D, Domain2D};

--- a/crates/blinc_charts/src/link.rs
+++ b/crates/blinc_charts/src/link.rs
@@ -47,4 +47,3 @@ pub type ChartLinkHandle = Arc<Mutex<ChartLink>>;
 pub fn chart_link(x_min: f32, x_max: f32) -> ChartLinkHandle {
     Arc::new(Mutex::new(ChartLink::new(Domain1D::new(x_min, x_max))))
 }
-

--- a/crates/blinc_charts/src/link.rs
+++ b/crates/blinc_charts/src/link.rs
@@ -1,0 +1,50 @@
+use std::sync::{Arc, Mutex};
+
+use crate::view::Domain1D;
+
+/// Shared chart state for linking interactions across multiple charts/canvases.
+///
+/// Design goals:
+/// - Pure data (no renderer coupling)
+/// - Cheap to clone/share (Arc<Mutex<_>>)
+/// - Minimal surface to integrate with external tools (e.g. patch_map)
+#[derive(Clone, Copy, Debug)]
+pub struct ChartLink {
+    /// Shared X domain (time axis) for pan/zoom synchronization.
+    pub x_domain: Domain1D,
+
+    /// Shared hover x position in domain units (if any).
+    pub hover_x: Option<f32>,
+
+    /// Shared X-range selection in domain units (min..max). Inclusive semantics are up to consumers.
+    pub selection_x: Option<(f32, f32)>,
+}
+
+impl ChartLink {
+    pub fn new(x_domain: Domain1D) -> Self {
+        Self {
+            x_domain,
+            hover_x: None,
+            selection_x: None,
+        }
+    }
+
+    pub fn set_x_domain(&mut self, x_domain: Domain1D) {
+        self.x_domain = x_domain;
+    }
+
+    pub fn set_hover_x(&mut self, hover_x: Option<f32>) {
+        self.hover_x = hover_x;
+    }
+
+    pub fn set_selection_x(&mut self, selection_x: Option<(f32, f32)>) {
+        self.selection_x = selection_x.map(|(a, b)| if a <= b { (a, b) } else { (b, a) });
+    }
+}
+
+pub type ChartLinkHandle = Arc<Mutex<ChartLink>>;
+
+pub fn chart_link(x_min: f32, x_max: f32) -> ChartLinkHandle {
+    Arc::new(Mutex::new(ChartLink::new(Domain1D::new(x_min, x_max))))
+}
+

--- a/crates/blinc_charts/src/scatter.rs
+++ b/crates/blinc_charts/src/scatter.rs
@@ -55,7 +55,9 @@ impl Default for ScatterChartStyle {
             point_radius: 1.5,
             scroll_zoom_factor: 0.02,
             pinch_zoom_min: 0.01,
-            max_points: 50_000,
+            // Each point is currently rendered as a separate GPU primitive.
+            // Keep this below the default renderer primitive budget.
+            max_points: 8_000,
         }
     }
 }

--- a/crates/blinc_charts/src/scatter.rs
+++ b/crates/blinc_charts/src/scatter.rs
@@ -1,11 +1,12 @@
 use std::sync::{Arc, Mutex};
 
-use blinc_core::{Brush, Color, CornerRadius, DrawContext, Point, Rect, Stroke, TextStyle};
+use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextStyle};
 use blinc_layout::canvas::canvas;
 use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
 use crate::brush::BrushX;
+use crate::common::{draw_grid, fill_bg};
 use crate::link::ChartLinkHandle;
 use crate::lod::{downsample_min_max, DownsampleParams};
 use crate::time_series::TimeSeriesF32;
@@ -30,67 +31,58 @@ impl SampleKey {
     }
 }
 
-/// Visual styling for the line chart.
 #[derive(Clone, Debug)]
-pub struct LineChartStyle {
+pub struct ScatterChartStyle {
     pub bg: Color,
     pub grid: Color,
-    pub line: Color,
+    pub points: Color,
     pub crosshair: Color,
     pub text: Color,
-    pub stroke_width: f32,
+    pub point_radius: f32,
     pub scroll_zoom_factor: f32,
     pub pinch_zoom_min: f32,
+    pub max_points: usize,
 }
 
-impl Default for LineChartStyle {
+impl Default for ScatterChartStyle {
     fn default() -> Self {
         Self {
             bg: Color::rgba(0.08, 0.09, 0.11, 1.0),
             grid: Color::rgba(1.0, 1.0, 1.0, 0.08),
-            line: Color::rgba(0.35, 0.65, 1.0, 1.0),
+            points: Color::rgba(0.35, 0.65, 1.0, 0.55),
             crosshair: Color::rgba(1.0, 1.0, 1.0, 0.35),
             text: Color::rgba(1.0, 1.0, 1.0, 0.85),
-            stroke_width: 1.5,
+            point_radius: 1.5,
             scroll_zoom_factor: 0.02,
             pinch_zoom_min: 0.01,
+            max_points: 50_000,
         }
     }
 }
 
-/// Mutable model for an interactive line chart.
-///
-/// Store this behind an `Arc<Mutex<_>>` and reuse across rebuilds.
-pub struct LineChartModel {
+pub struct ScatterChartModel {
     pub series: TimeSeriesF32,
     pub view: ChartView,
-    pub style: LineChartStyle,
+    pub style: ScatterChartStyle,
 
-    pub crosshair_x: Option<f32>,   // local px in plot area
-    pub hover_point: Option<Point>, // data coords
+    pub crosshair_x: Option<f32>,
+    pub hover_point: Option<Point>,
 
-    downsampled: Vec<Point>, // data coords
-    points_px: Vec<Point>,   // screen coords (local)
+    points_px: Vec<Point>,
+    downsampled: Vec<Point>,
     downsample_params: DownsampleParams,
     user_max_points: usize,
-
-    // Cache key for (re)sampling. Hover-only interactions should not force
-    // downsampling or point transforms on every frame.
     last_sample_key: Option<SampleKey>,
 
-    // EventRouter's drag_delta_x/y are "offset from drag start", not per-frame deltas.
-    // Track last observed totals so we can convert to incremental deltas for panning.
     last_drag_total_x: Option<f32>,
-
     brush_x: BrushX,
 }
 
-impl LineChartModel {
+impl ScatterChartModel {
     pub fn new(series: TimeSeriesF32) -> Self {
         let (x0, x1) = series.x_min_max();
         let (mut y0, mut y1) = series.y_min_max();
         if !(y1 > y0) {
-            // Handle degenerate or invalid y-ranges (e.g. all NaN -> (0,0)).
             if y0.is_finite() && y1.is_finite() {
                 y0 -= 1.0;
                 y1 += 1.0;
@@ -103,11 +95,11 @@ impl LineChartModel {
         Self {
             series,
             view: ChartView::new(domain),
-            style: LineChartStyle::default(),
+            style: ScatterChartStyle::default(),
             crosshair_x: None,
             hover_point: None,
-            downsampled: Vec::new(),
             points_px: Vec::new(),
+            downsampled: Vec::new(),
             downsample_params: DownsampleParams::default(),
             user_max_points: DownsampleParams::default().max_points,
             last_sample_key: None,
@@ -116,8 +108,8 @@ impl LineChartModel {
         }
     }
 
-    pub fn set_downsample_max_points(&mut self, max_points: usize) {
-        self.user_max_points = max_points.max(64);
+    pub fn set_max_points(&mut self, max_points: usize) {
+        self.user_max_points = max_points.max(256);
     }
 
     fn plot_rect(&self, w: f32, h: f32) -> (f32, f32, f32, f32) {
@@ -131,13 +123,11 @@ impl LineChartModel {
             self.hover_point = None;
             return;
         }
-
         if local_x < px || local_x > px + pw || local_y < py || local_y > py + ph {
             self.crosshair_x = None;
             self.hover_point = None;
             return;
         }
-
         self.crosshair_x = Some(local_x);
         let x = self.view.px_to_x(local_x, px, pw);
         self.hover_point = self
@@ -153,17 +143,9 @@ impl LineChartModel {
         }
         let cursor_x_px = cursor_x_px.clamp(px, px + pw);
         let pivot_x = self.view.px_to_x(cursor_x_px, px, pw);
-
-        // Trackpad/mouse wheel: delta_y > 0 typically means scroll down.
-        // Use exponential zoom so it feels consistent across devices.
-        //
-        // Note: On desktop, pixel scroll deltas are normalized in the platform layer,
-        // so use a larger factor to keep zoom responsive.
         let delta_y = delta_y.clamp(-250.0, 250.0);
         let zoom = (-delta_y * self.style.scroll_zoom_factor).exp();
         self.view.domain.x.zoom_about(pivot_x, zoom);
-
-        // Prevent collapsing to 0 span.
         self.view.domain.x.clamp_span_min(1e-6);
     }
 
@@ -174,28 +156,21 @@ impl LineChartModel {
         }
         let cursor_x_px = cursor_x_px.clamp(px, px + pw);
         let pivot_x = self.view.px_to_x(cursor_x_px, px, pw);
-
-        // EventContext::pinch_scale is "ratio delta per update (1.0 = no change)".
         let zoom = scale_delta.max(self.style.pinch_zoom_min);
         self.view.domain.x.zoom_about(pivot_x, zoom);
         self.view.domain.x.clamp_span_min(1e-6);
     }
 
-    /// Pan using drag "total delta from start" (EventContext::drag_delta_x).
     pub fn on_drag_pan_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
         let (_px, _py, pw, _ph) = self.plot_rect(w, h);
         if pw <= 0.0 {
             return;
         }
-
-        // Convert total-from-start to incremental delta since last event.
         let prev = self.last_drag_total_x.replace(drag_total_dx);
         let drag_dx = match prev {
             Some(p) => drag_total_dx - p,
             None => 0.0,
         };
-
-        // Convert pixel delta to domain delta.
         let dx = -drag_dx / pw * self.view.domain.x.span();
         self.view.domain.x.pan_by(dx);
     }
@@ -224,12 +199,10 @@ impl LineChartModel {
         if pw <= 0.0 {
             return;
         }
-        // Brush updates track cursor position. DRAG provides delta-from-start, so infer current x.
-        let Some(start_x) = self.brush_x.anchor_px() else {
-            return;
-        };
-        let x = start_x + drag_total_dx;
-        self.brush_x.update(x.clamp(px, px + pw));
+        if let Some(anchor) = self.brush_x.anchor_px() {
+            self.brush_x
+                .update((anchor + drag_total_dx).clamp(px, px + pw));
+        }
     }
 
     pub fn on_mouse_up_finish_brush_x(&mut self, w: f32, h: f32) -> Option<(f32, f32)> {
@@ -239,6 +212,8 @@ impl LineChartModel {
             return None;
         }
         let (a_px, b_px) = self.brush_x.take_final_px()?;
+        let a_px = a_px.clamp(px, px + pw);
+        let b_px = b_px.clamp(px, px + pw);
         let a = self.view.px_to_x(a_px, px, pw);
         let b = self.view.px_to_x(b_px, px, pw);
         Some(if a <= b { (a, b) } else { (b, a) })
@@ -247,9 +222,6 @@ impl LineChartModel {
     fn ensure_samples(&mut self, w: f32, h: f32) {
         let (px, py, pw, ph) = self.plot_rect(w, h);
         if pw <= 0.0 || ph <= 0.0 {
-            self.downsampled.clear();
-            self.points_px.clear();
-            self.last_sample_key = None;
             return;
         }
 
@@ -258,8 +230,10 @@ impl LineChartModel {
             return;
         }
 
-        // Keep output bounded by pixels (2 points per pixel column is plenty).
-        let max_points = (pw.ceil() as usize).saturating_mul(2).clamp(128, 200_000);
+        // For scatter, keep a hard cap (points-per-frame) for both perf and minimal resources.
+        let max_points = (pw.ceil() as usize)
+            .saturating_mul(4)
+            .clamp(512, self.style.max_points);
         self.downsample_params.max_points = self.user_max_points.min(max_points);
 
         downsample_min_max(
@@ -270,58 +244,29 @@ impl LineChartModel {
             &mut self.downsampled,
         );
 
-        // Ensure at least 2 points for drawing.
-        if self.downsampled.len() == 1 {
-            self.downsampled.push(self.downsampled[0]);
-        }
-
-        // Convert to local pixel points once.
         self.points_px.clear();
-        self.points_px.reserve(self.downsampled.len());
+        self.points_px
+            .reserve(self.downsampled.len().min(max_points));
         for p in &self.downsampled {
-            self.points_px
-                .push(self.view.data_to_px(*p, px, py, pw, ph));
+            let pp = self.view.data_to_px(*p, px, py, pw, ph);
+            self.points_px.push(pp);
         }
 
         self.last_sample_key = Some(key);
     }
 
     pub fn render_plot(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
-        // Background
-        ctx.fill_rect(
-            Rect::new(0.0, 0.0, w, h),
-            CornerRadius::default(),
-            Brush::Solid(self.style.bg),
-        );
+        fill_bg(ctx, w, h, self.style.bg);
 
         let (px, py, pw, ph) = self.plot_rect(w, h);
         if pw <= 0.0 || ph <= 0.0 {
             return;
         }
+        draw_grid(ctx, px, py, pw, ph, self.style.grid, 4);
 
-        // Grid (cheap, fixed count)
-        let grid_n = 4;
-        for i in 0..=grid_n {
-            let t = i as f32 / grid_n as f32;
-            let x = px + t * pw;
-            let y = py + t * ph;
-            ctx.fill_rect(
-                Rect::new(x, py, 1.0, ph),
-                0.0.into(),
-                Brush::Solid(self.style.grid),
-            );
-            ctx.fill_rect(
-                Rect::new(px, y, pw, 1.0),
-                0.0.into(),
-                Brush::Solid(self.style.grid),
-            );
-        }
-
-        // Series (cached)
         self.ensure_samples(w, h);
-        if self.points_px.len() >= 2 {
-            let stroke = Stroke::new(self.style.stroke_width);
-            ctx.stroke_polyline(&self.points_px, &stroke, Brush::Solid(self.style.line));
+        for p in &self.points_px {
+            ctx.fill_circle(*p, self.style.point_radius, Brush::Solid(self.style.points));
         }
     }
 
@@ -331,7 +276,6 @@ impl LineChartModel {
             return;
         }
 
-        // In-progress brush (X-only).
         if let Some((a, b)) = self.brush_x.range_px() {
             let x = a.clamp(px, px + pw);
             let w = (b - a).abs().max(1.0);
@@ -342,7 +286,6 @@ impl LineChartModel {
             );
         }
 
-        // Crosshair
         if let Some(cx) = self.crosshair_x {
             let x = cx.clamp(px, px + pw);
             ctx.fill_rect(
@@ -352,42 +295,27 @@ impl LineChartModel {
             );
         }
 
-        // Tooltip (simple)
         if let Some(p) = self.hover_point {
             let text = format!("x={:.3}  y={:.3}", p.x, p.y);
             let style = TextStyle::new(12.0).with_color(self.style.text);
-            // Anchor near top-left of plot.
             ctx.draw_text(&text, Point::new(px + 6.0, py + 6.0), &style);
         }
     }
 }
 
-/// Shared handle for a line chart model.
 #[derive(Clone)]
-pub struct LineChartHandle(pub Arc<Mutex<LineChartModel>>);
+pub struct ScatterChartHandle(pub Arc<Mutex<ScatterChartModel>>);
 
-impl LineChartHandle {
-    pub fn new(model: LineChartModel) -> Self {
+impl ScatterChartHandle {
+    pub fn new(model: ScatterChartModel) -> Self {
         Self(Arc::new(Mutex::new(model)))
     }
 }
 
-/// Create an interactive line chart element.
-///
-/// Composition:
-/// - Root: `stack()` (so callers can overlay additional canvases/elements)
-/// - Child 1: plot `canvas` (background layer)
-/// - Child 2: overlay `canvas` (foreground layer)
-///
-/// Interactions (using Blinc events):
-/// - `on_mouse_move`: updates crosshair + nearest-point hover
-/// - `on_scroll` / `on_pinch`: zoom X about cursor
-/// - `on_drag`: pan X
-pub fn line_chart(handle: LineChartHandle) -> impl ElementBuilder {
+pub fn scatter_chart(handle: ScatterChartHandle) -> impl ElementBuilder {
     let model_plot = handle.0.clone();
     let model_overlay = handle.0.clone();
 
-    // Events mutate the shared model and request a redraw (no tree rebuild).
     let model_move = handle.0.clone();
     let model_scroll = handle.0.clone();
     let model_pinch = handle.0.clone();
@@ -435,9 +363,9 @@ pub fn line_chart(handle: LineChartHandle) -> impl ElementBuilder {
                 blinc_layout::stateful::request_redraw();
             }
         })
-        .on_mouse_up(move |_e| {
+        .on_mouse_up(move |e| {
             if let Ok(mut m) = model_up.lock() {
-                let _ = m.on_mouse_up_finish_brush_x(_e.bounds_width, _e.bounds_height);
+                let _ = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height);
                 m.on_drag_end();
                 blinc_layout::stateful::request_redraw();
             }
@@ -468,13 +396,10 @@ pub fn line_chart(handle: LineChartHandle) -> impl ElementBuilder {
         )
 }
 
-/// Create a linked line chart element.
-///
-/// Additional behaviors:
-/// - Pan/zoom is synchronized via `link.x_domain` (shared X domain).
-/// - Hover is broadcast via `link.hover_x`.
-/// - Selection (brush) is created with Shift+Drag and stored in `link.selection_x`.
-pub fn linked_line_chart(handle: LineChartHandle, link: ChartLinkHandle) -> impl ElementBuilder {
+pub fn linked_scatter_chart(
+    handle: ScatterChartHandle,
+    link: ChartLinkHandle,
+) -> impl ElementBuilder {
     let model_plot = handle.0.clone();
     let model_overlay = handle.0.clone();
 
@@ -504,12 +429,8 @@ pub fn linked_line_chart(handle: LineChartHandle, link: ChartLinkHandle) -> impl
             if let (Ok(mut l), Ok(mut m)) = (link_move.lock(), model_move.lock()) {
                 m.view.domain.x = l.x_domain;
                 m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
-
-                // Publish hover x in domain units (or None when out of plot).
-                let (px, _py, pw, _ph) = m.plot_rect(e.bounds_width, e.bounds_height);
-                if pw > 0.0 && m.crosshair_x.is_some() {
-                    let x = m.view.px_to_x(e.local_x.clamp(px, px + pw), px, pw);
-                    l.set_hover_x(Some(x));
+                if let Some(p) = m.hover_point {
+                    l.set_hover_x(Some(p.x));
                 } else {
                     l.set_hover_x(None);
                 }
@@ -552,9 +473,9 @@ pub fn linked_line_chart(handle: LineChartHandle, link: ChartLinkHandle) -> impl
         })
         .on_mouse_up(move |e| {
             if let (Ok(mut l), Ok(mut m)) = (link_up.lock(), model_up.lock()) {
-                m.view.domain.x = l.x_domain;
-                if let Some(sel) = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height) {
-                    l.set_selection_x(Some(sel));
+                if let Some((a, b)) = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height)
+                {
+                    l.set_selection_x(Some((a, b)));
                 }
                 m.on_drag_end();
                 blinc_layout::stateful::request_redraw();
@@ -579,29 +500,6 @@ pub fn linked_line_chart(handle: LineChartHandle, link: ChartLinkHandle) -> impl
             canvas(move |ctx, bounds| {
                 if let (Ok(l), Ok(mut m)) = (link_overlay.lock(), model_overlay.lock()) {
                     m.view.domain.x = l.x_domain;
-                    // Selection highlight (committed).
-                    if let Some((a, b)) = l.selection_x {
-                        let (px, py, pw, ph) = m.plot_rect(bounds.width, bounds.height);
-                        if pw > 0.0 && ph > 0.0 {
-                            let xa = m.view.x_to_px(a, px, pw);
-                            let xb = m.view.x_to_px(b, px, pw);
-                            let x0 = xa.min(xb).clamp(px, px + pw);
-                            let x1 = xa.max(xb).clamp(px, px + pw);
-                            ctx.fill_rect(
-                                Rect::new(x0, py, (x1 - x0).max(1.0), ph),
-                                0.0.into(),
-                                Brush::Solid(Color::rgba(1.0, 1.0, 1.0, 0.06)),
-                            );
-                        }
-                    }
-
-                    // Linked hover crosshair.
-                    if let Some(hx) = l.hover_x {
-                        let (px, _py, pw, _ph) = m.plot_rect(bounds.width, bounds.height);
-                        if pw > 0.0 {
-                            m.crosshair_x = Some(m.view.x_to_px(hx, px, pw));
-                        }
-                    }
                     m.render_overlay(ctx, bounds.width, bounds.height);
                 }
             })

--- a/crates/blinc_charts/src/scatter.rs
+++ b/crates/blinc_charts/src/scatter.rs
@@ -267,8 +267,17 @@ impl ScatterChartModel {
         draw_grid(ctx, px, py, pw, ph, self.style.grid, 4);
 
         self.ensure_samples(w, h);
+        // Avoid `fill_circle` here: circles go through the glass primitive path and
+        // quickly exceed the default `max_glass_primitives` budget. Render points as
+        // tiny rects so the primitive cost stays predictable.
+        let r = self.style.point_radius.max(0.5);
+        let d = r * 2.0;
         for p in &self.points_px {
-            ctx.fill_circle(*p, self.style.point_radius, Brush::Solid(self.style.points));
+            ctx.fill_rect(
+                Rect::new(p.x - r, p.y - r, d, d),
+                0.0.into(),
+                Brush::Solid(self.style.points),
+            );
         }
     }
 

--- a/crates/blinc_gpu/src/renderer.rs
+++ b/crates/blinc_gpu/src/renderer.rs
@@ -34,6 +34,17 @@ fn env_usize(name: &str) -> Option<usize> {
         .and_then(|v| v.trim().parse::<usize>().ok())
 }
 
+const fn align256(v: u64) -> u64 {
+    (v + 255) & !255
+}
+
+const PATH_UNIFORM_SIZE: u64 = std::mem::size_of::<PathUniforms>() as u64;
+const PATH_UNIFORM_STRIDE: u64 = align256(PATH_UNIFORM_SIZE);
+
+fn has_path_geometry(paths: &crate::primitives::PathBatch) -> bool {
+    !paths.vertices.is_empty() && !paths.indices.is_empty()
+}
+
 fn device_required_limits(adapter: &wgpu::Adapter) -> wgpu::Limits {
     // Default wgpu limits include `max_buffer_size = 256 MiB`.
     // This is conservative and may be smaller than what the hardware supports.
@@ -883,6 +894,56 @@ struct BindGroupLayouts {
 }
 
 impl GpuRenderer {
+    fn merged_paths_for_msaa(
+        a: &crate::primitives::PathBatch,
+        b: &crate::primitives::PathBatch,
+    ) -> Option<crate::primitives::PathBatch> {
+        if !has_path_geometry(a) && !has_path_geometry(b) {
+            return None;
+        }
+        if !has_path_geometry(b) {
+            return Some(a.clone());
+        }
+        if !has_path_geometry(a) {
+            return Some(b.clone());
+        }
+
+        // Merge into one batch so MSAA render paths can draw everything in a single pass.
+        // Note: brush metadata is still batch-wide; when both batches use conflicting
+        // advanced brush features simultaneously, this will pick a "best effort" merge.
+        let mut out = a.clone();
+        let base_vertex = out.vertices.len() as u32;
+        let base_index = out.indices.len() as u32;
+
+        out.vertices.extend_from_slice(&b.vertices);
+        out.indices
+            .extend(b.indices.iter().copied().map(|i| i + base_vertex));
+        out.draws.extend(b.draws.iter().map(|d| {
+            let mut dd = *d;
+            dd.index_start = dd.index_start.saturating_add(base_index);
+            dd
+        }));
+
+        out.use_gradient_texture |= b.use_gradient_texture;
+        if out.gradient_stops.is_none() && b.gradient_stops.is_some() {
+            out.gradient_stops = b.gradient_stops.clone();
+        }
+        out.use_image_texture |= b.use_image_texture;
+        if out.image_source.is_none() && b.image_source.is_some() {
+            out.image_source = b.image_source.clone();
+        }
+        if !out.use_image_texture && b.use_image_texture {
+            out.image_uv_bounds = b.image_uv_bounds;
+        }
+        out.use_glass_effect |= b.use_glass_effect;
+        if !out.use_glass_effect && b.use_glass_effect {
+            out.glass_params = b.glass_params;
+            out.glass_tint = b.glass_tint;
+        }
+
+        Some(out)
+    }
+
     /// Get the preferred backend for the current platform
     ///
     /// Using the primary backend instead of all backends reduces memory usage
@@ -915,10 +976,12 @@ impl GpuRenderer {
         }
     }
 
-    /// Safely write primitives to buffer, truncating if necessary to prevent overflow
-    fn write_primitives_safe(&self, primitives: &[GpuPrimitive]) {
+    /// Safely write primitives to buffer, truncating if necessary to prevent overflow.
+    ///
+    /// Returns the number of primitives written (after truncation).
+    fn write_primitives_safe(&self, primitives: &[GpuPrimitive]) -> usize {
         if primitives.is_empty() {
-            return;
+            return 0;
         }
         let max_primitives = self.config.max_primitives;
         let primitives_to_write = if primitives.len() > max_primitives {
@@ -936,6 +999,7 @@ impl GpuRenderer {
             0,
             bytemuck::cast_slice(primitives_to_write),
         );
+        primitives_to_write.len()
     }
 
     /// Safely write line segments to buffer, truncating if necessary to prevent overflow
@@ -1675,8 +1739,8 @@ impl GpuRenderer {
                     visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
+                        has_dynamic_offset: true,
+                        min_binding_size: wgpu::BufferSize::new(PATH_UNIFORM_SIZE),
                     },
                     count: None,
                 },
@@ -2664,7 +2728,9 @@ impl GpuRenderer {
 
         let path_uniforms = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Path Uniforms Buffer"),
-            size: std::mem::size_of::<PathUniforms>() as u64,
+            // Dynamic offsets require 256-byte alignment. Allocate one stride by default;
+            // we grow this buffer on demand based on the number of path draw calls.
+            size: PATH_UNIFORM_STRIDE.max(256),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -2798,7 +2864,11 @@ impl GpuRenderer {
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
-                    resource: buffers.path_uniforms.as_entire_binding(),
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &buffers.path_uniforms,
+                        offset: 0,
+                        size: wgpu::BufferSize::new(PATH_UNIFORM_SIZE),
+                    }),
                 },
                 // Gradient texture (binding 1)
                 wgpu::BindGroupEntry {
@@ -3179,6 +3249,83 @@ impl GpuRenderer {
             }
         }
 
+        if std::env::var_os("BLINC_DEBUG_PATH_BOUNDS").is_some()
+            && !batch.paths.vertices.is_empty()
+            && !batch.paths.indices.is_empty()
+        {
+            use std::sync::atomic::{AtomicU32, Ordering};
+            static LOGS: AtomicU32 = AtomicU32::new(0);
+            let n = LOGS.fetch_add(1, Ordering::Relaxed);
+            if n < 3 {
+                let mut min_x = f32::INFINITY;
+                let mut min_y = f32::INFINITY;
+                let mut max_x = f32::NEG_INFINITY;
+                let mut max_y = f32::NEG_INFINITY;
+                let vp_w = self.viewport_size.0 as f32;
+                let vp_h = self.viewport_size.1 as f32;
+                let mut in_vp = 0usize;
+                for v in &batch.paths.vertices {
+                    min_x = min_x.min(v.position[0]);
+                    min_y = min_y.min(v.position[1]);
+                    max_x = max_x.max(v.position[0]);
+                    max_y = max_y.max(v.position[1]);
+                    if v.position[0].is_finite()
+                        && v.position[1].is_finite()
+                        && v.position[0] >= 0.0
+                        && v.position[0] <= vp_w
+                        && v.position[1] >= 0.0
+                        && v.position[1] <= vp_h
+                    {
+                        in_vp += 1;
+                    }
+                }
+
+                let draws = batch.paths.draws.len();
+                let first = batch.paths.draws.first().copied();
+                tracing::info!(
+                    "paths: draws={} v_bounds=({:.2},{:.2})..({:.2},{:.2}) v_in_viewport={} first_draw={:?}",
+                    draws,
+                    min_x,
+                    min_y,
+                    max_x,
+                    max_y,
+                    in_vp,
+                    first
+                );
+
+                // Also compute bounds for the first draw's index range to validate clipping.
+                if let Some(d) = first {
+                    let start = d.index_start as usize;
+                    let end = (d.index_start + d.index_count) as usize;
+                    if start < end && end <= batch.paths.indices.len() {
+                        let mut dmin_x = f32::INFINITY;
+                        let mut dmin_y = f32::INFINITY;
+                        let mut dmax_x = f32::NEG_INFINITY;
+                        let mut dmax_y = f32::NEG_INFINITY;
+                        for &idx in &batch.paths.indices[start..end] {
+                            let vi = idx as usize;
+                            if let Some(v) = batch.paths.vertices.get(vi) {
+                                dmin_x = dmin_x.min(v.position[0]);
+                                dmin_y = dmin_y.min(v.position[1]);
+                                dmax_x = dmax_x.max(v.position[0]);
+                                dmax_y = dmax_y.max(v.position[1]);
+                            }
+                        }
+                        tracing::info!(
+                            "paths: first_draw_i_bounds=({:.2},{:.2})..({:.2},{:.2}) clip_bounds={:?} clip_radius={:?} clip_type={}",
+                            dmin_x,
+                            dmin_y,
+                            dmax_x,
+                            dmax_y,
+                            d.clip_bounds,
+                            d.clip_radius,
+                            d.clip_type
+                        );
+                    }
+                }
+            }
+        }
+
         // Update uniforms
         let uniforms = Uniforms {
             viewport_size: [self.viewport_size.0 as f32, self.viewport_size.1 as f32],
@@ -3188,7 +3335,7 @@ impl GpuRenderer {
             .write_buffer(&self.buffers.uniforms, 0, bytemuck::bytes_of(&uniforms));
 
         // Update primitives buffer (with safety limit to prevent buffer overflow)
-        self.write_primitives_safe(&batch.primitives);
+        let prim_count = self.write_primitives_safe(&batch.primitives);
 
         // Update line segments buffer
         let line_count = self.write_line_segments_safe(&batch.line_segments);
@@ -3198,10 +3345,11 @@ impl GpuRenderer {
         // When active_glyph_atlas is set, rebind uses the real atlas automatically.
         self.update_aux_data_buffer(batch);
 
-        // Update path buffers if we have path geometry
-        let has_paths = !batch.paths.vertices.is_empty() && !batch.paths.indices.is_empty();
+        // Update path buffers if we have background path geometry.
+        let has_paths = has_path_geometry(&batch.paths);
+        let has_foreground_paths = has_path_geometry(&batch.foreground_paths);
         if has_paths {
-            self.update_path_buffers(batch);
+            self.update_path_buffers(&batch.paths);
         }
 
         // Create command encoder
@@ -3234,11 +3382,11 @@ impl GpuRenderer {
             });
 
             // Render SDF primitives
-            if !batch.primitives.is_empty() {
+            if prim_count > 0 {
                 render_pass.set_pipeline(&self.pipelines.sdf);
                 render_pass.set_bind_group(0, &self.bind_groups.sdf, &[]);
                 // 6 vertices per quad (2 triangles), one instance per primitive
-                render_pass.draw(0..6, 0..batch.primitives.len() as u32);
+                render_pass.draw(0..6, 0..prim_count as u32);
             }
 
             // Render compact line segments
@@ -3250,16 +3398,36 @@ impl GpuRenderer {
 
             // Render paths
             if has_paths {
-                if let (Some(vb), Some(ib)) =
-                    (&self.buffers.path_vertices, &self.buffers.path_indices)
-                {
-                    render_pass.set_pipeline(&self.pipelines.path);
-                    render_pass.set_bind_group(0, &self.bind_groups.path, &[]);
-                    render_pass.set_vertex_buffer(0, vb.slice(..));
-                    render_pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
-                    render_pass.draw_indexed(0..batch.paths.indices.len() as u32, 0, 0..1);
-                }
+                render_pass.set_pipeline(&self.pipelines.path);
+                self.draw_path_batch(&mut render_pass, &batch.paths, &self.bind_groups.path);
             }
+        }
+
+        // Foreground paths (rendered after the main pass; required for `set_foreground_layer(true)`).
+        if has_foreground_paths {
+            self.update_path_buffers(&batch.foreground_paths);
+
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Blinc Foreground Path Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: target,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+
+            render_pass.set_pipeline(&self.pipelines.path);
+            self.draw_path_batch(
+                &mut render_pass,
+                &batch.foreground_paths,
+                &self.bind_groups.path,
+            );
         }
 
         // Submit commands
@@ -3487,7 +3655,10 @@ impl GpuRenderer {
             .map(|(_, p)| *p)
             .collect();
 
-        if included_primitives.is_empty() && batch.paths.vertices.is_empty() {
+        if included_primitives.is_empty()
+            && !has_path_geometry(&batch.paths)
+            && !has_path_geometry(&batch.foreground_paths)
+        {
             // Just clear the target
             let mut encoder = self
                 .device
@@ -3530,19 +3701,14 @@ impl GpuRenderer {
         // Update auxiliary data buffer
         self.update_aux_data_buffer(batch);
 
-        // Update primitives buffer with filtered primitives
-        if !included_primitives.is_empty() {
-            self.queue.write_buffer(
-                &self.buffers.primitives,
-                0,
-                bytemuck::cast_slice(&included_primitives),
-            );
-        }
+        // Update primitives buffer with filtered primitives (bounded by buffer capacity)
+        let prim_count = self.write_primitives_safe(&included_primitives);
 
-        // Update path buffers if we have path geometry
-        let has_paths = !batch.paths.vertices.is_empty() && !batch.paths.indices.is_empty();
+        // Update path buffers if we have background paths.
+        let has_paths = has_path_geometry(&batch.paths);
+        let has_foreground_paths = has_path_geometry(&batch.foreground_paths);
         if has_paths {
-            self.update_path_buffers(batch);
+            self.update_path_buffers(&batch.paths);
         }
 
         // Create command encoder
@@ -3575,24 +3741,43 @@ impl GpuRenderer {
             });
 
             // Render SDF primitives (filtered)
-            if !included_primitives.is_empty() {
+            if prim_count > 0 {
                 render_pass.set_pipeline(&self.pipelines.sdf);
                 render_pass.set_bind_group(0, &self.bind_groups.sdf, &[]);
-                render_pass.draw(0..6, 0..included_primitives.len() as u32);
+                render_pass.draw(0..6, 0..prim_count as u32);
             }
 
             // Render paths (always rendered - path filtering would be more complex)
             if has_paths {
-                if let (Some(vb), Some(ib)) =
-                    (&self.buffers.path_vertices, &self.buffers.path_indices)
-                {
-                    render_pass.set_pipeline(&self.pipelines.path);
-                    render_pass.set_bind_group(0, &self.bind_groups.path, &[]);
-                    render_pass.set_vertex_buffer(0, vb.slice(..));
-                    render_pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
-                    render_pass.draw_indexed(0..batch.paths.indices.len() as u32, 0, 0..1);
-                }
+                render_pass.set_pipeline(&self.pipelines.path);
+                self.draw_path_batch(&mut render_pass, &batch.paths, &self.bind_groups.path);
             }
+        }
+
+        if has_foreground_paths {
+            self.update_path_buffers(&batch.foreground_paths);
+
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Filtered Foreground Path Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: target,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+
+            render_pass.set_pipeline(&self.pipelines.path);
+            self.draw_path_batch(
+                &mut render_pass,
+                &batch.foreground_paths,
+                &self.bind_groups.path,
+            );
         }
 
         // Submit commands
@@ -3680,11 +3865,59 @@ impl GpuRenderer {
         });
     }
 
+    /// Recreate the path bind group (needed when the path uniforms buffer is resized).
+    fn rebind_path_bind_group(&mut self) {
+        self.bind_groups.path = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Path Bind Group (rebound)"),
+            layout: &self.bind_group_layouts.path,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &self.buffers.path_uniforms,
+                        offset: 0,
+                        size: wgpu::BufferSize::new(PATH_UNIFORM_SIZE),
+                    }),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&self.gradient_texture_cache.view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&self.gradient_texture_cache.sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: wgpu::BindingResource::TextureView(
+                        &self._placeholder_path_image_view,
+                    ),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: wgpu::BindingResource::Sampler(&self.path_image_sampler),
+                },
+                // Backdrop texture placeholder (binding 5). The glass path pass creates
+                // a dedicated bind group when a real backdrop is required.
+                wgpu::BindGroupEntry {
+                    binding: 5,
+                    resource: wgpu::BindingResource::TextureView(
+                        &self._placeholder_path_image_view,
+                    ),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 6,
+                    resource: wgpu::BindingResource::Sampler(&self.path_image_sampler),
+                },
+            ],
+        });
+    }
+
     /// Update path vertex and index buffers
-    fn update_path_buffers(&mut self, batch: &PrimitiveBatch) {
+    fn update_path_buffers(&mut self, paths: &crate::primitives::PathBatch) {
         // Upload gradient texture if needed for multi-stop gradients
-        if batch.paths.use_gradient_texture {
-            if let Some(ref stops) = batch.paths.gradient_stops {
+        if paths.use_gradient_texture {
+            if let Some(ref stops) = paths.gradient_stops {
                 self.gradient_texture_cache.upload_stops(
                     &self.queue,
                     stops,
@@ -3693,32 +3926,60 @@ impl GpuRenderer {
             }
         }
 
-        // Update path uniforms with clip data and brush metadata from batch
-        let path_uniforms = PathUniforms {
-            viewport_size: [self.viewport_size.0 as f32, self.viewport_size.1 as f32],
-            clip_bounds: batch.paths.clip_bounds,
-            clip_radius: batch.paths.clip_radius,
-            clip_type: batch.paths.clip_type,
-            use_gradient_texture: if batch.paths.use_gradient_texture {
-                1
-            } else {
-                0
-            },
-            use_image_texture: if batch.paths.use_image_texture { 1 } else { 0 },
-            use_glass_effect: if batch.paths.use_glass_effect { 1 } else { 0 },
-            image_uv_bounds: batch.paths.image_uv_bounds,
-            glass_params: batch.paths.glass_params,
-            glass_tint: batch.paths.glass_tint,
-            ..PathUniforms::default()
-        };
-        self.queue.write_buffer(
-            &self.buffers.path_uniforms,
-            0,
-            bytemuck::bytes_of(&path_uniforms),
-        );
+        // Ensure uniforms buffer can hold all per-draw clip states.
+        let draw_count = paths.draws.len().max(1) as u64;
+        let required_uniform_bytes = PATH_UNIFORM_STRIDE.saturating_mul(draw_count);
+        if self.buffers.path_uniforms.size() < required_uniform_bytes {
+            self.buffers.path_uniforms = self.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("Path Uniforms Buffer (resized)"),
+                size: required_uniform_bytes,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            self.rebind_path_bind_group();
+        }
+
+        // Pack per-draw uniforms at 256-byte aligned offsets.
+        let mut packed = vec![0u8; required_uniform_bytes as usize];
+        if paths.draws.is_empty() {
+            // Backward-compatible fallback: a single draw with default uniforms.
+            let u = PathUniforms {
+                viewport_size: [self.viewport_size.0 as f32, self.viewport_size.1 as f32],
+                use_gradient_texture: if paths.use_gradient_texture { 1 } else { 0 },
+                use_image_texture: if paths.use_image_texture { 1 } else { 0 },
+                use_glass_effect: if paths.use_glass_effect { 1 } else { 0 },
+                image_uv_bounds: paths.image_uv_bounds,
+                glass_params: paths.glass_params,
+                glass_tint: paths.glass_tint,
+                ..PathUniforms::default()
+            };
+            let bytes = bytemuck::bytes_of(&u);
+            packed[0..bytes.len()].copy_from_slice(bytes);
+        } else {
+            for (i, d) in paths.draws.iter().enumerate() {
+                let u = PathUniforms {
+                    viewport_size: [self.viewport_size.0 as f32, self.viewport_size.1 as f32],
+                    clip_bounds: d.clip_bounds,
+                    clip_radius: d.clip_radius,
+                    clip_type: d.clip_type,
+                    use_gradient_texture: if paths.use_gradient_texture { 1 } else { 0 },
+                    use_image_texture: if paths.use_image_texture { 1 } else { 0 },
+                    use_glass_effect: if paths.use_glass_effect { 1 } else { 0 },
+                    image_uv_bounds: paths.image_uv_bounds,
+                    glass_params: paths.glass_params,
+                    glass_tint: paths.glass_tint,
+                    ..PathUniforms::default()
+                };
+                let offset = (PATH_UNIFORM_STRIDE * i as u64) as usize;
+                let bytes = bytemuck::bytes_of(&u);
+                packed[offset..offset + bytes.len()].copy_from_slice(bytes);
+            }
+        }
+        self.queue
+            .write_buffer(&self.buffers.path_uniforms, 0, &packed);
 
         // Create or recreate vertex buffer if needed
-        let vertex_size = (std::mem::size_of::<PathVertex>() * batch.paths.vertices.len()) as u64;
+        let vertex_size = (std::mem::size_of::<PathVertex>() * paths.vertices.len()) as u64;
         let need_new_vertex_buffer = match &self.buffers.path_vertices {
             Some(buf) => buf.size() < vertex_size,
             None => true,
@@ -3735,11 +3996,11 @@ impl GpuRenderer {
 
         if let Some(vb) = &self.buffers.path_vertices {
             self.queue
-                .write_buffer(vb, 0, bytemuck::cast_slice(&batch.paths.vertices));
+                .write_buffer(vb, 0, bytemuck::cast_slice(&paths.vertices));
         }
 
         // Create or recreate index buffer if needed
-        let index_size = (std::mem::size_of::<u32>() * batch.paths.indices.len()) as u64;
+        let index_size = (std::mem::size_of::<u32>() * paths.indices.len()) as u64;
         let need_new_index_buffer = match &self.buffers.path_indices {
             Some(buf) => buf.size() < index_size,
             None => true,
@@ -3756,7 +4017,45 @@ impl GpuRenderer {
 
         if let Some(ib) = &self.buffers.path_indices {
             self.queue
-                .write_buffer(ib, 0, bytemuck::cast_slice(&batch.paths.indices));
+                .write_buffer(ib, 0, bytemuck::cast_slice(&paths.indices));
+        }
+    }
+
+    fn draw_path_batch(
+        &self,
+        render_pass: &mut wgpu::RenderPass<'_>,
+        paths: &crate::primitives::PathBatch,
+        bind_group: &wgpu::BindGroup,
+    ) {
+        if paths.vertices.is_empty() || paths.indices.is_empty() {
+            return;
+        }
+        let Some(vb) = &self.buffers.path_vertices else {
+            return;
+        };
+        let Some(ib) = &self.buffers.path_indices else {
+            return;
+        };
+
+        render_pass.set_vertex_buffer(0, vb.slice(..));
+        render_pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
+
+        if paths.draws.is_empty() {
+            // Backward-compatible fallback: treat as a single draw with offset 0.
+            render_pass.set_bind_group(0, bind_group, &[0]);
+            render_pass.draw_indexed(0..paths.indices.len() as u32, 0, 0..1);
+            return;
+        }
+
+        for (i, d) in paths.draws.iter().enumerate() {
+            if d.index_count == 0 {
+                continue;
+            }
+            let start = d.index_start;
+            let end = d.index_start.saturating_add(d.index_count);
+            let offset = (PATH_UNIFORM_STRIDE.saturating_mul(i as u64)) as u32;
+            render_pass.set_bind_group(0, bind_group, &[offset]);
+            render_pass.draw_indexed(start..end, 0, 0..1);
         }
     }
 
@@ -3783,12 +4082,13 @@ impl GpuRenderer {
             .write_buffer(&self.buffers.uniforms, 0, bytemuck::bytes_of(&uniforms));
 
         // Update primitives buffer (using safe write to prevent overflow)
-        self.write_primitives_safe(&batch.primitives);
+        let prim_count = self.write_primitives_safe(&batch.primitives);
 
-        // Update path buffers if we have path geometry
-        let has_paths = !batch.paths.vertices.is_empty() && !batch.paths.indices.is_empty();
+        // Update path buffers if we have background path geometry.
+        let has_paths = has_path_geometry(&batch.paths);
+        let has_foreground_paths = has_path_geometry(&batch.foreground_paths);
         if has_paths {
-            self.update_path_buffers(batch);
+            self.update_path_buffers(&batch.paths);
         }
 
         // Create command encoder
@@ -3821,24 +4121,44 @@ impl GpuRenderer {
             });
 
             // Render SDF primitives
-            if !batch.primitives.is_empty() {
+            if prim_count > 0 {
                 render_pass.set_pipeline(&self.pipelines.sdf);
                 render_pass.set_bind_group(0, &self.bind_groups.sdf, &[]);
-                render_pass.draw(0..6, 0..batch.primitives.len() as u32);
+                render_pass.draw(0..6, 0..prim_count as u32);
             }
 
             // Render paths
             if has_paths {
-                if let (Some(vb), Some(ib)) =
-                    (&self.buffers.path_vertices, &self.buffers.path_indices)
-                {
-                    render_pass.set_pipeline(&self.pipelines.path);
-                    render_pass.set_bind_group(0, &self.bind_groups.path, &[]);
-                    render_pass.set_vertex_buffer(0, vb.slice(..));
-                    render_pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
-                    render_pass.draw_indexed(0..batch.paths.indices.len() as u32, 0, 0..1);
-                }
+                render_pass.set_pipeline(&self.pipelines.path);
+                self.draw_path_batch(&mut render_pass, &batch.paths, &self.bind_groups.path);
             }
+        }
+
+        // Foreground paths: preserve layered rendering semantics in MSAA path too.
+        if has_foreground_paths {
+            self.update_path_buffers(&batch.foreground_paths);
+
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Blinc MSAA Foreground Path Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: msaa_target,
+                    resolve_target: Some(resolve_target),
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+
+            render_pass.set_pipeline(&self.pipelines.path);
+            self.draw_path_batch(
+                &mut render_pass,
+                &batch.foreground_paths,
+                &self.bind_groups.path,
+            );
         }
 
         // Submit commands
@@ -4044,7 +4364,7 @@ impl GpuRenderer {
         );
 
         // Update buffers
-        self.write_primitives_safe(&batch.primitives);
+        let prim_count = self.write_primitives_safe(&batch.primitives);
         let line_count = self.write_line_segments_safe(&batch.line_segments);
 
         // Create command encoder
@@ -4071,10 +4391,10 @@ impl GpuRenderer {
                 occlusion_query_set: None,
             });
 
-            if !batch.primitives.is_empty() {
+            if prim_count > 0 {
                 render_pass.set_pipeline(&self.pipelines.sdf);
                 render_pass.set_bind_group(0, &self.bind_groups.sdf, &[]);
-                render_pass.draw(0..6, 0..batch.primitives.len() as u32);
+                render_pass.draw(0..6, 0..prim_count as u32);
             }
 
             if line_count > 0 {
@@ -4114,7 +4434,7 @@ impl GpuRenderer {
         self.update_aux_data_buffer(batch);
 
         // Update primitives buffer
-        self.write_primitives_safe(&batch.primitives);
+        let bg_prim_count = self.write_primitives_safe(&batch.primitives);
         let bg_line_count = self.write_line_segments_safe(&batch.line_segments);
 
         // Split glass primitives into simple and liquid for separate rendering
@@ -4244,10 +4564,10 @@ impl GpuRenderer {
                 occlusion_query_set: None,
             });
 
-            if !batch.primitives.is_empty() {
+            if bg_prim_count > 0 {
                 render_pass.set_pipeline(&self.pipelines.sdf);
                 render_pass.set_bind_group(0, &self.bind_groups.sdf, &[]);
-                render_pass.draw(0..6, 0..batch.primitives.len() as u32);
+                render_pass.draw(0..6, 0..bg_prim_count as u32);
             }
 
             if bg_line_count > 0 {
@@ -4280,10 +4600,10 @@ impl GpuRenderer {
                 occlusion_query_set: None,
             });
 
-            if !batch.primitives.is_empty() {
+            if bg_prim_count > 0 {
                 render_pass.set_pipeline(&self.pipelines.sdf);
                 render_pass.set_bind_group(0, &self.bind_groups.sdf, &[]);
-                render_pass.draw(0..6, 0..batch.primitives.len() as u32);
+                render_pass.draw(0..6, 0..bg_prim_count as u32);
             }
 
             if bg_line_count > 0 {
@@ -4343,7 +4663,7 @@ impl GpuRenderer {
         // This requires a separate submission because we need to overwrite the primitives buffer
         if !batch.foreground_primitives.is_empty() || !batch.foreground_line_segments.is_empty() {
             // Upload foreground primitives/lines to the buffers
-            self.write_primitives_safe(&batch.foreground_primitives);
+            let fg_prim_count = self.write_primitives_safe(&batch.foreground_primitives);
             let fg_line_count = self.write_line_segments_safe(&batch.foreground_line_segments);
 
             let mut encoder = self
@@ -4367,10 +4687,10 @@ impl GpuRenderer {
                 occlusion_query_set: None,
             });
 
-            if !batch.foreground_primitives.is_empty() {
+            if fg_prim_count > 0 {
                 render_pass.set_pipeline(&self.pipelines.sdf);
                 render_pass.set_bind_group(0, &self.bind_groups.sdf, &[]);
-                render_pass.draw(0..6, 0..batch.foreground_primitives.len() as u32);
+                render_pass.draw(0..6, 0..fg_prim_count as u32);
             }
 
             if fg_line_count > 0 {
@@ -4385,20 +4705,17 @@ impl GpuRenderer {
 
         // Pass 5: Render paths (SVGs) on top of glass
         // Paths are tessellated geometry that need their own pipeline
-        let has_paths = !batch.paths.vertices.is_empty() && !batch.paths.indices.is_empty();
-        if has_paths {
-            // Update path buffers (creates/resizes as needed)
-            self.update_path_buffers(batch);
+        let has_paths = has_path_geometry(&batch.paths);
+        let has_foreground_paths = has_path_geometry(&batch.foreground_paths);
+        if has_paths || has_foreground_paths {
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("Blinc Glass Path Encoder"),
+                });
 
-            // Render paths
-            if let (Some(vb), Some(ib)) = (&self.buffers.path_vertices, &self.buffers.path_indices)
-            {
-                let mut encoder =
-                    self.device
-                        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                            label: Some("Blinc Glass Path Encoder"),
-                        });
-
+            if has_paths {
+                self.update_path_buffers(&batch.paths);
                 let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                     label: Some("Glass Path Render Pass"),
                     color_attachments: &[Some(wgpu::RenderPassColorAttachment {
@@ -4416,14 +4733,35 @@ impl GpuRenderer {
 
                 // Use overlay path pipeline (1x sampled, no MSAA)
                 render_pass.set_pipeline(&self.pipelines.path_overlay);
-                render_pass.set_bind_group(0, &self.bind_groups.path, &[]);
-                render_pass.set_vertex_buffer(0, vb.slice(..));
-                render_pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
-                render_pass.draw_indexed(0..batch.paths.indices.len() as u32, 0, 0..1);
-
-                drop(render_pass);
-                self.queue.submit(std::iter::once(encoder.finish()));
+                self.draw_path_batch(&mut render_pass, &batch.paths, &self.bind_groups.path);
             }
+
+            if has_foreground_paths {
+                self.update_path_buffers(&batch.foreground_paths);
+                let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("Glass Foreground Path Render Pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: target,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Load,
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+
+                render_pass.set_pipeline(&self.pipelines.path_overlay);
+                self.draw_path_batch(
+                    &mut render_pass,
+                    &batch.foreground_paths,
+                    &self.bind_groups.path,
+                );
+            }
+
+            self.queue.submit(std::iter::once(encoder.finish()));
         }
     }
 
@@ -4464,22 +4802,17 @@ impl GpuRenderer {
         // Update auxiliary data buffer
         self.update_aux_data_buffer(batch);
 
-        // Update primitives buffer
-        if !batch.primitives.is_empty() {
-            self.queue.write_buffer(
-                &self.buffers.primitives,
-                0,
-                bytemuck::cast_slice(&batch.primitives),
-            );
-        }
+        // Update primitives buffer (bounded by buffer capacity)
+        let prim_count = self.write_primitives_safe(&batch.primitives);
 
         // Update line segments buffer
         let line_count = self.write_line_segments_safe(&batch.line_segments);
 
-        // Update path buffers if we have path geometry
-        let has_paths = !batch.paths.vertices.is_empty() && !batch.paths.indices.is_empty();
+        // Update path buffers if we have background path geometry.
+        let has_paths = has_path_geometry(&batch.paths);
+        let has_foreground_paths = has_path_geometry(&batch.foreground_paths);
         if has_paths {
-            self.update_path_buffers(batch);
+            self.update_path_buffers(&batch.paths);
         }
 
         // Create command encoder
@@ -4508,15 +4841,8 @@ impl GpuRenderer {
 
             // Render paths first (they're typically backgrounds)
             if has_paths {
-                if let (Some(vb), Some(ib)) =
-                    (&self.buffers.path_vertices, &self.buffers.path_indices)
-                {
-                    render_pass.set_pipeline(&self.pipelines.path_overlay);
-                    render_pass.set_bind_group(0, &self.bind_groups.path, &[]);
-                    render_pass.set_vertex_buffer(0, vb.slice(..));
-                    render_pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
-                    render_pass.draw_indexed(0..batch.paths.indices.len() as u32, 0, 0..1);
-                }
+                render_pass.set_pipeline(&self.pipelines.path_overlay);
+                self.draw_path_batch(&mut render_pass, &batch.paths, &self.bind_groups.path);
             }
 
             // Render compact line segments
@@ -4527,11 +4853,38 @@ impl GpuRenderer {
             }
 
             // Render SDF primitives using overlay pipeline
-            if !batch.primitives.is_empty() {
+            if prim_count > 0 {
                 render_pass.set_pipeline(&self.pipelines.sdf_overlay);
                 render_pass.set_bind_group(0, &self.bind_groups.sdf, &[]);
-                render_pass.draw(0..6, 0..batch.primitives.len() as u32);
+                render_pass.draw(0..6, 0..prim_count as u32);
             }
+        }
+
+        // Foreground paths (rendered after the main overlay pass).
+        if has_foreground_paths {
+            self.update_path_buffers(&batch.foreground_paths);
+
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Blinc Foreground Path Overlay Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: target,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+
+            render_pass.set_pipeline(&self.pipelines.path_overlay);
+            self.draw_path_batch(
+                &mut render_pass,
+                &batch.foreground_paths,
+                &self.bind_groups.path,
+            );
         }
 
         // Submit commands
@@ -4635,22 +4988,17 @@ impl GpuRenderer {
         self.queue
             .write_buffer(&self.buffers.uniforms, 0, bytemuck::bytes_of(&uniforms));
 
-        // Update primitives buffer
-        if !batch.primitives.is_empty() {
-            self.queue.write_buffer(
-                &self.buffers.primitives,
-                0,
-                bytemuck::cast_slice(&batch.primitives),
-            );
-        }
+        // Update primitives buffer (bounded by buffer capacity)
+        let prim_count = self.write_primitives_safe(&batch.primitives);
 
         // Update line segments buffer
         let line_count = self.write_line_segments_safe(&batch.line_segments);
 
-        // Update path buffers if we have path geometry
-        let has_paths = !batch.paths.vertices.is_empty() && !batch.paths.indices.is_empty();
+        // Update path buffers if we have background path geometry.
+        let has_paths = has_path_geometry(&batch.paths);
+        let has_foreground_paths = has_path_geometry(&batch.foreground_paths);
         if has_paths {
-            self.update_path_buffers(batch);
+            self.update_path_buffers(&batch.paths);
         }
 
         // Create command encoder
@@ -4679,15 +5027,8 @@ impl GpuRenderer {
 
             // Render paths first
             if has_paths {
-                if let (Some(vb), Some(ib)) =
-                    (&self.buffers.path_vertices, &self.buffers.path_indices)
-                {
-                    render_pass.set_pipeline(&self.pipelines.path_overlay);
-                    render_pass.set_bind_group(0, &self.bind_groups.path, &[]);
-                    render_pass.set_vertex_buffer(0, vb.slice(..));
-                    render_pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
-                    render_pass.draw_indexed(0..batch.paths.indices.len() as u32, 0, 0..1);
-                }
+                render_pass.set_pipeline(&self.pipelines.path_overlay);
+                self.draw_path_batch(&mut render_pass, &batch.paths, &self.bind_groups.path);
             }
 
             // Render compact line segments
@@ -4698,11 +5039,38 @@ impl GpuRenderer {
             }
 
             // Render SDF primitives
-            if !batch.primitives.is_empty() {
+            if prim_count > 0 {
                 render_pass.set_pipeline(&self.pipelines.sdf_overlay);
                 render_pass.set_bind_group(0, &self.bind_groups.sdf, &[]);
-                render_pass.draw(0..6, 0..batch.primitives.len() as u32);
+                render_pass.draw(0..6, 0..prim_count as u32);
             }
+        }
+
+        // Foreground paths (rendered after the main overlay pass).
+        if has_foreground_paths {
+            self.update_path_buffers(&batch.foreground_paths);
+
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Blinc Foreground Path Overlay Simple Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: target,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+
+            render_pass.set_pipeline(&self.pipelines.path_overlay);
+            self.draw_path_batch(
+                &mut render_pass,
+                &batch.foreground_paths,
+                &self.bind_groups.path,
+            );
         }
 
         // Submit commands
@@ -4732,12 +5100,8 @@ impl GpuRenderer {
         self.queue
             .write_buffer(&self.buffers.uniforms, 0, bytemuck::bytes_of(&uniforms));
 
-        // Update primitives buffer
-        self.queue.write_buffer(
-            &self.buffers.primitives,
-            0,
-            bytemuck::cast_slice(primitives),
-        );
+        // Update primitives buffer (bounded by buffer capacity)
+        let prim_count = self.write_primitives_safe(primitives);
 
         // Create command encoder
         let mut encoder = self
@@ -4766,7 +5130,7 @@ impl GpuRenderer {
             // Render SDF primitives
             render_pass.set_pipeline(&self.pipelines.sdf_overlay);
             render_pass.set_bind_group(0, &self.bind_groups.sdf, &[]);
-            render_pass.draw(0..6, 0..primitives.len() as u32);
+            render_pass.draw(0..6, 0..prim_count as u32);
         }
 
         // Submit commands
@@ -4844,21 +5208,21 @@ impl GpuRenderer {
     /// This renders paths on top of existing content without clearing.
     /// Used for z-layered rendering where paths need to be rendered separately.
     pub fn render_paths_overlay(&mut self, target: &wgpu::TextureView, batch: &PrimitiveBatch) {
-        let has_paths = !batch.paths.vertices.is_empty() && !batch.paths.indices.is_empty();
-        if !has_paths {
+        let has_paths = has_path_geometry(&batch.paths);
+        let has_foreground_paths = has_path_geometry(&batch.foreground_paths);
+        if !has_paths && !has_foreground_paths {
             return;
         }
 
-        // Update path buffers
-        self.update_path_buffers(batch);
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Blinc Paths Overlay Encoder"),
+            });
 
-        // Render paths
-        if let (Some(vb), Some(ib)) = (&self.buffers.path_vertices, &self.buffers.path_indices) {
-            let mut encoder = self
-                .device
-                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                    label: Some("Blinc Paths Overlay Encoder"),
-                });
+        // Background paths
+        if has_paths {
+            self.update_path_buffers(&batch.paths);
 
             let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Paths Overlay Pass"),
@@ -4877,14 +5241,37 @@ impl GpuRenderer {
 
             // Use overlay path pipeline (1x sampled)
             render_pass.set_pipeline(&self.pipelines.path_overlay);
-            render_pass.set_bind_group(0, &self.bind_groups.path, &[]);
-            render_pass.set_vertex_buffer(0, vb.slice(..));
-            render_pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
-            render_pass.draw_indexed(0..batch.paths.indices.len() as u32, 0, 0..1);
-
-            drop(render_pass);
-            self.queue.submit(std::iter::once(encoder.finish()));
+            self.draw_path_batch(&mut render_pass, &batch.paths, &self.bind_groups.path);
         }
+
+        // Foreground paths
+        if has_foreground_paths {
+            self.update_path_buffers(&batch.foreground_paths);
+
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Foreground Paths Overlay Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: target,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+
+            render_pass.set_pipeline(&self.pipelines.path_overlay);
+            self.draw_path_batch(
+                &mut render_pass,
+                &batch.foreground_paths,
+                &self.bind_groups.path,
+            );
+        }
+
+        self.queue.submit(std::iter::once(encoder.finish()));
     }
 
     /// Render SDF primitives with unified text rendering (text as primitives)
@@ -4921,6 +5308,7 @@ impl GpuRenderer {
         sample_count: u32,
     ) {
         if batch.paths.vertices.is_empty()
+            && batch.foreground_paths.vertices.is_empty()
             && batch.primitives.is_empty()
             && batch.line_segments.is_empty()
         {
@@ -5060,23 +5448,15 @@ impl GpuRenderer {
         self.queue
             .write_buffer(&self.buffers.uniforms, 0, bytemuck::bytes_of(&uniforms));
 
-        // Update primitives buffer
-        if !batch.primitives.is_empty() {
-            self.queue.write_buffer(
-                &self.buffers.primitives,
-                0,
-                bytemuck::cast_slice(&batch.primitives),
-            );
-        }
+        // Update primitives buffer (bounded by buffer capacity)
+        let prim_count = self.write_primitives_safe(&batch.primitives);
 
-        // Update path buffers
-        let has_paths = !batch.paths.vertices.is_empty() && !batch.paths.indices.is_empty();
+        // Update path buffers (background only; foreground may be rendered in a second MSAA pass).
+        let has_paths = has_path_geometry(&batch.paths);
+        let has_foreground_paths = has_path_geometry(&batch.foreground_paths);
         if has_paths {
-            self.update_path_buffers(batch);
+            self.update_path_buffers(&batch.paths);
         }
-
-        // Get references to the cached textures (after mutable borrows are done)
-        let cached = self.cached_msaa.as_ref().unwrap();
 
         let mut encoder = self
             .device
@@ -5087,6 +5467,7 @@ impl GpuRenderer {
         // Pass 1: Render to MSAA texture with resolve
         // Use cached MSAA pipelines for sample_count > 1, otherwise fall back to base pipelines
         {
+            let cached = self.cached_msaa.as_ref().unwrap();
             let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Overlay MSAA Render Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
@@ -5116,27 +5497,21 @@ impl GpuRenderer {
 
             // Render paths using MSAA pipeline
             if has_paths {
-                if let (Some(vb), Some(ib)) =
-                    (&self.buffers.path_vertices, &self.buffers.path_indices)
-                {
-                    render_pass.set_pipeline(path_pipeline);
-                    render_pass.set_bind_group(0, &self.bind_groups.path, &[]);
-                    render_pass.set_vertex_buffer(0, vb.slice(..));
-                    render_pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
-                    render_pass.draw_indexed(0..batch.paths.indices.len() as u32, 0, 0..1);
-                }
+                render_pass.set_pipeline(path_pipeline);
+                self.draw_path_batch(&mut render_pass, &batch.paths, &self.bind_groups.path);
             }
 
             // Render SDF primitives using MSAA pipeline
-            if !batch.primitives.is_empty() {
+            if prim_count > 0 {
                 render_pass.set_pipeline(sdf_pipeline);
                 render_pass.set_bind_group(0, &self.bind_groups.sdf, &[]);
-                render_pass.draw(0..6, 0..batch.primitives.len() as u32);
+                render_pass.draw(0..6, 0..prim_count as u32);
             }
         }
 
         // Pass 2: Blend resolved texture onto target using cached resources
         {
+            let cached = self.cached_msaa.as_ref().unwrap();
             let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Overlay Blend Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
@@ -5155,6 +5530,70 @@ impl GpuRenderer {
             render_pass.set_pipeline(&self.pipelines.composite_overlay);
             render_pass.set_bind_group(0, &cached.composite_bind_group, &[]);
             render_pass.draw(0..3, 0..1); // Fullscreen triangle
+        }
+
+        // Optional: Foreground paths rendered in a separate MSAA+composite pass so they land on top.
+        if has_foreground_paths {
+            self.update_path_buffers(&batch.foreground_paths);
+
+            // Pass 3: MSAA render foreground paths to resolve texture
+            {
+                let cached = self.cached_msaa.as_ref().unwrap();
+                let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("Overlay MSAA Foreground Paths Render Pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &cached.msaa_view,
+                        resolve_target: Some(&cached.resolve_view),
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                            store: wgpu::StoreOp::Discard,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+
+                let path_pipeline = if sample_count > 1 {
+                    if let Some(ref msaa) = self.msaa_pipelines {
+                        &msaa.path
+                    } else {
+                        &self.pipelines.path
+                    }
+                } else {
+                    &self.pipelines.path
+                };
+
+                render_pass.set_pipeline(path_pipeline);
+                self.draw_path_batch(
+                    &mut render_pass,
+                    &batch.foreground_paths,
+                    &self.bind_groups.path,
+                );
+            }
+
+            // Pass 4: Composite (load existing target, blend foreground on top)
+            {
+                let cached = self.cached_msaa.as_ref().unwrap();
+                let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("Overlay Foreground Blend Pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: target,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Load,
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+
+                render_pass.set_pipeline(&self.pipelines.composite_overlay);
+                render_pass.set_bind_group(0, &cached.composite_bind_group, &[]);
+                render_pass.draw(0..3, 0..1);
+            }
         }
 
         self.queue.submit(std::iter::once(encoder.finish()));
@@ -5176,9 +5615,10 @@ impl GpuRenderer {
         batch: &PrimitiveBatch,
         sample_count: u32,
     ) {
-        if batch.paths.vertices.is_empty() || batch.paths.indices.is_empty() {
+        let merged = Self::merged_paths_for_msaa(&batch.paths, &batch.foreground_paths);
+        let Some(merged) = merged else {
             return;
-        }
+        };
 
         // Ensure we have MSAA pipelines for this sample count
         let need_new_pipelines = match &self.msaa_pipelines {
@@ -5314,7 +5754,7 @@ impl GpuRenderer {
             .write_buffer(&self.buffers.uniforms, 0, bytemuck::bytes_of(&uniforms));
 
         // Update path buffers
-        self.update_path_buffers(batch);
+        self.update_path_buffers(&merged);
 
         // Get references to the cached textures
         let cached = self.cached_msaa.as_ref().unwrap();
@@ -5353,14 +5793,8 @@ impl GpuRenderer {
                 &self.pipelines.path
             };
 
-            if let (Some(vb), Some(ib)) = (&self.buffers.path_vertices, &self.buffers.path_indices)
-            {
-                render_pass.set_pipeline(path_pipeline);
-                render_pass.set_bind_group(0, &self.bind_groups.path, &[]);
-                render_pass.set_vertex_buffer(0, vb.slice(..));
-                render_pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
-                render_pass.draw_indexed(0..batch.paths.indices.len() as u32, 0, 0..1);
-            }
+            render_pass.set_pipeline(path_pipeline);
+            self.draw_path_batch(&mut render_pass, &merged, &self.bind_groups.path);
         }
 
         // Pass 2: Blend resolved texture onto target
@@ -6788,7 +7222,6 @@ impl GpuRenderer {
         }
 
         // Extract the primitive range
-        let primitive_count = end_idx - start_idx;
         let primitives = &batch.primitives[start_idx..end_idx];
 
         if primitives.is_empty() {
@@ -6803,12 +7236,11 @@ impl GpuRenderer {
         self.queue
             .write_buffer(&self.buffers.uniforms, 0, bytemuck::bytes_of(&uniforms));
 
-        // Write primitive range to buffer
-        self.queue.write_buffer(
-            &self.buffers.primitives,
-            0,
-            bytemuck::cast_slice(primitives),
-        );
+        // Write primitive range to buffer (bounded by buffer capacity)
+        let primitive_count = self.write_primitives_safe(primitives) as u32;
+        if primitive_count == 0 {
+            return;
+        }
 
         // Create command encoder
         let mut encoder = self
@@ -6841,7 +7273,7 @@ impl GpuRenderer {
 
             render_pass.set_pipeline(&self.pipelines.sdf);
             render_pass.set_bind_group(0, &self.bind_groups.sdf, &[]);
-            render_pass.draw(0..6, 0..primitive_count as u32);
+            render_pass.draw(0..6, 0..primitive_count);
         }
 
         self.queue.submit(std::iter::once(encoder.finish()));
@@ -6926,12 +7358,10 @@ impl GpuRenderer {
             .write_buffer(&self.buffers.uniforms, 0, bytemuck::bytes_of(&uniforms));
 
         // Write offset primitives to buffer and capture count for draw call
-        let primitive_count = offset_primitives.len() as u32;
-        self.queue.write_buffer(
-            &self.buffers.primitives,
-            0,
-            bytemuck::cast_slice(&offset_primitives),
-        );
+        let primitive_count = self.write_primitives_safe(&offset_primitives) as u32;
+        if primitive_count == 0 {
+            return (layer_texture, content_size);
+        }
         drop(offset_primitives); // Free Vec immediately - data is now on GPU
 
         // Create command encoder

--- a/scripts/e2e_macos_charts_gallery.sh
+++ b/scripts/e2e_macos_charts_gallery.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# High-signal macOS e2e for the charts gallery demo.
+#
+# Requires: Hammerspoon CLI (`hs`) with IPC enabled in ~/.hammerspoon/init.lua:
+#   require("hs.ipc")
+#
+# What this checks:
+# - Line chart actually contains a blue-ish line (not just the grid)
+# - Heatmap renders without panicking and shows non-grid colors
+# - App behaves under a smaller window (responsive layout path)
+#
+# Output artifacts:
+# - /tmp/blinc-e2e-<case>-<WxH>.png
+# - /tmp/blinc-e2e-<case>-<WxH>.log
+
+if ! command -v hs >/dev/null 2>&1; then
+  echo "error: missing 'hs' (Hammerspoon CLI). Install Hammerspoon and enable hs.ipc." >&2
+  exit 2
+fi
+
+example="charts_gallery_demo"
+title="blinc_charts: Gallery"
+
+export BLINC_CHARTS_N="${BLINC_CHARTS_N:-2000}"
+
+cd "$(dirname "$0")/.."
+
+# Build once (keeps per-case runtime stable).
+cargo build -p blinc_app --example "${example}" --features windowed >/dev/null
+
+run_case() {
+  local case_name="$1" # e.g. line|heatmap
+  local selected="$2"  # index into ITEMS
+  local size="$3"      # WxH, e.g. 1200x840
+
+  local w="${size%x*}"
+  local h="${size#*x}"
+
+  local out_png="${TMPDIR:-/tmp}/blinc-e2e-${case_name}-${w}x${h}.png"
+  local out_log="${TMPDIR:-/tmp}/blinc-e2e-${case_name}-${w}x${h}.log"
+
+  (
+    RUST_BACKTRACE=1 \
+    BLINC_GALLERY_SELECTED="${selected}" \
+    cargo run -p blinc_app --example "${example}" --features windowed >"${out_log}" 2>&1
+  ) &
+  local pid=$!
+
+  cleanup() {
+    kill "${pid}" >/dev/null 2>&1 || true
+    wait "${pid}" >/dev/null 2>&1 || true
+  }
+  trap cleanup EXIT
+
+  hs -A -t 180 -c "
+    local expected = [[${title}]]
+    local case_name = [[${case_name}]]
+    local out_png = [[${out_png}]]
+    local w = ${w}
+    local h = ${h}
+
+    local function find_window()
+      for _, win in ipairs(hs.window.allWindows()) do
+        local t = win:title() or ''
+        if string.find(t, expected, 1, true) then
+          return win
+        end
+      end
+      return nil
+    end
+
+    -- Close any leftover windows from a previous failed run (best-effort).
+    for _, win in ipairs(hs.window.allWindows()) do
+      local t = win:title() or ''
+      if string.find(t, expected, 1, true) then
+        win:close()
+      end
+    end
+
+    -- Wait for the window to appear.
+    local win = nil
+    for _ = 1, 240 do -- ~120s
+      win = find_window()
+      if win ~= nil then break end
+      hs.timer.usleep(500000)
+    end
+    if win == nil then
+      io.stderr:write('error: window not detected: ' .. expected .. '\n')
+      os.exit(1)
+    end
+
+    win:focus()
+
+    -- Resize and center on screen.
+    local screen = win:screen() or hs.screen.mainScreen()
+    local sf = screen:frame()
+    local fx = math.floor(sf.x + (sf.w - w) / 2)
+    local fy = math.floor(sf.y + (sf.h - h) / 2)
+    win:setFrame(hs.geometry.rect(fx, fy, w, h))
+
+    hs.timer.usleep(800000) -- let one frame render after resize
+
+    -- Snapshot just the window region.
+    local frame = win:frame()
+    local img = screen:snapshot(frame)
+    if img == nil then
+      io.stderr:write('error: snapshot failed\n')
+      os.exit(1)
+    end
+
+    if not img:saveToFile(out_png) then
+      io.stderr:write('error: failed to save png: ' .. out_png .. '\n')
+      os.exit(1)
+    end
+
+    local sz = img:size()
+    local iw = sz.w or 0
+    local ih = sz.h or 0
+
+    -- Choose a sampling rect that avoids the sidebar/tabs.
+    local narrow = (iw < 900)
+    local x0 = narrow and math.floor(iw * 0.08) or math.floor(iw * 0.35)
+    local x1 = math.floor(iw * 0.96)
+    local y0 = math.floor(ih * 0.22)
+    local y1 = math.floor(ih * 0.92)
+
+    local function is_blueish(c)
+      if c == nil then return false end
+      local r = c.red or 0
+      local g = c.green or 0
+      local b = c.blue or 0
+      local a = c.alpha or 1
+      if a < 0.8 then return false end
+      local mx = math.max(r, g)
+      return (b > 0.35) and ((b - mx) > 0.12) and (g > 0.20)
+    end
+
+    local function is_warm(c)
+      if c == nil then return false end
+      local r = c.red or 0
+      local g = c.green or 0
+      local b = c.blue or 0
+      local a = c.alpha or 1
+      if a < 0.8 then return false end
+      return (r > 0.55) and (g > 0.25) and (b < 0.55)
+    end
+
+    local step_x = math.max(4, math.floor((x1 - x0) / 120))
+    local step_y = math.max(4, math.floor((y1 - y0) / 80))
+
+    local blue = 0
+    local warm = 0
+    local total = 0
+    for y = y0, y1, step_y do
+      for x = x0, x1, step_x do
+        total = total + 1
+        local c = img:colorAt(hs.geometry.point(x, y))
+        if is_blueish(c) then blue = blue + 1 end
+        if is_warm(c) then warm = warm + 1 end
+      end
+    end
+
+    if case_name == 'line' or case_name == 'multi' then
+      if blue < 6 then
+        io.stderr:write(string.format('error: expected blue-ish line pixels, got=%d (total=%d) png=%s\n', blue, total, out_png))
+        os.exit(1)
+      end
+    elseif case_name == 'heatmap' then
+      if warm < 10 then
+        io.stderr:write(string.format('error: expected warm heatmap pixels, got=%d (total=%d) png=%s\n', warm, total, out_png))
+        os.exit(1)
+      end
+    end
+
+    print(string.format('ok: case=%s size=%dx%d blue=%d warm=%d png=%s', case_name, w, h, blue, warm, out_png))
+  "
+
+  cleanup
+  trap - EXIT
+}
+
+run_case "line" 0 "1200x840"
+run_case "line" 0 "640x520"
+run_case "multi" 1 "1200x840"
+run_case "heatmap" 7 "1200x840"
+run_case "heatmap" 7 "640x520"
+
+echo "ok: charts gallery e2e finished"

--- a/scripts/e2e_macos_windowed_example.sh
+++ b/scripts/e2e_macos_windowed_example.sh
@@ -29,6 +29,17 @@ export BLINC_CHARTS_N="${BLINC_CHARTS_N:-5000}"
 
 log_file="${TMPDIR:-/tmp}/blinc-e2e-${example}.log"
 
+# Best-effort: close any existing window first to avoid ending up with two.
+hs -A -t 20 -c "
+  local expected = [[${expected_title}]]
+  for _, w in ipairs(hs.window.allWindows()) do
+    local t = w:title() or ''
+    if string.find(t, expected, 1, true) then
+      w:close()
+    end
+  end
+" >/dev/null 2>&1 || true
+
 (
   cd "$(dirname "$0")/.."
   cargo run -p blinc_app --example "${example}" --features windowed >"${log_file}" 2>&1
@@ -43,18 +54,18 @@ trap cleanup EXIT
 
 found="0"
 for _ in $(seq 1 60); do
-  if BLINC_E2E_TITLE="${expected_title}" hs -c '
-    local expected = os.getenv("BLINC_E2E_TITLE") or ""
+  if hs -A -t 20 -c "
+    local expected = [[${expected_title}]]
     local wins = hs.window.allWindows()
     for _, w in ipairs(wins) do
-      local t = w:title() or ""
+      local t = w:title() or ''
       if string.find(t, expected, 1, true) then
-        print("FOUND")
+        print('FOUND')
         return
       end
     end
-    print("NO")
-  ' | grep -q "^FOUND$"; then
+    print('NO')
+  " | grep -q "^FOUND$"; then
     found="1"
     break
   fi
@@ -68,16 +79,16 @@ if [[ "${found}" != "1" ]]; then
 fi
 
 # Best-effort: close the window if we can find it.
-BLINC_E2E_TITLE="${expected_title}" hs -c '
-  local expected = os.getenv("BLINC_E2E_TITLE") or ""
+hs -A -t 20 -c "
+  local expected = [[${expected_title}]]
   for _, w in ipairs(hs.window.allWindows()) do
-    local t = w:title() or ""
+    local t = w:title() or ''
     if string.find(t, expected, 1, true) then
       w:focus()
       w:close()
       return
     end
   end
-' >/dev/null 2>&1 || true
+" >/dev/null 2>&1 || true
 
 echo "ok: detected window for ${example} (${expected_title})"

--- a/scripts/e2e_macos_windowed_example.sh
+++ b/scripts/e2e_macos_windowed_example.sh
@@ -25,6 +25,12 @@ if ! command -v hs >/dev/null 2>&1; then
   exit 2
 fi
 
+if ! hs -c 'print("hs_ok")' >/dev/null 2>&1; then
+  echo "error: Hammerspoon IPC is not available." >&2
+  echo "Fix: add 'require(\"hs.ipc\")' to ~/.hammerspoon/init.lua and reload Hammerspoon once." >&2
+  exit 2
+fi
+
 export BLINC_CHARTS_N="${BLINC_CHARTS_N:-5000}"
 
 log_file="${TMPDIR:-/tmp}/blinc-e2e-${example}.log"

--- a/scripts/e2e_macos_windowed_example.sh
+++ b/scripts/e2e_macos_windowed_example.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Minimal macOS "e2e smoke" for a windowed blinc_app example.
+# Requires: Hammerspoon CLI (`hs`) with IPC enabled in ~/.hammerspoon/init.lua:
+#   require("hs.ipc")
+#
+# Usage:
+#   scripts/e2e_macos_windowed_example.sh charts_gallery_demo "blinc_charts: Gallery"
+#
+# Notes:
+# - We intentionally keep N small to avoid long startup times.
+# - The example is terminated after the window is detected.
+
+example="${1:-charts_gallery_demo}"
+expected_title="${2:-}"
+
+if [[ -z "${expected_title}" ]]; then
+  echo "error: expected window title argument is required" >&2
+  exit 2
+fi
+
+if ! command -v hs >/dev/null 2>&1; then
+  echo "error: missing 'hs' (Hammerspoon CLI). Install Hammerspoon and enable hs.ipc." >&2
+  exit 2
+fi
+
+export BLINC_CHARTS_N="${BLINC_CHARTS_N:-5000}"
+
+log_file="${TMPDIR:-/tmp}/blinc-e2e-${example}.log"
+
+(
+  cd "$(dirname "$0")/.."
+  cargo run -p blinc_app --example "${example}" --features windowed >"${log_file}" 2>&1
+) &
+pid=$!
+
+cleanup() {
+  kill "${pid}" >/dev/null 2>&1 || true
+  wait "${pid}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+found="0"
+for _ in $(seq 1 60); do
+  if BLINC_E2E_TITLE="${expected_title}" hs -c '
+    local expected = os.getenv("BLINC_E2E_TITLE") or ""
+    local wins = hs.window.allWindows()
+    for _, w in ipairs(wins) do
+      local t = w:title() or ""
+      if string.find(t, expected, 1, true) then
+        print("FOUND")
+        return
+      end
+    end
+    print("NO")
+  ' | grep -q "^FOUND$"; then
+    found="1"
+    break
+  fi
+  sleep 0.5
+done
+
+if [[ "${found}" != "1" ]]; then
+  echo "error: window not detected: ${expected_title}" >&2
+  echo "log: ${log_file}" >&2
+  exit 1
+fi
+
+# Best-effort: close the window if we can find it.
+BLINC_E2E_TITLE="${expected_title}" hs -c '
+  local expected = os.getenv("BLINC_E2E_TITLE") or ""
+  for _, w in ipairs(hs.window.allWindows()) do
+    local t = w:title() or ""
+    if string.find(t, expected, 1, true) then
+      w:focus()
+      w:close()
+      return
+    end
+  end
+' >/dev/null 2>&1 || true
+
+echo "ok: detected window for ${example} (${expected_title})"


### PR DESCRIPTION
Adds several new chart types (area/bar/scatter/candlestick/heatmap/histogram) plus a gallery example (charts_gallery_demo) that includes one section per candidate (placeholders for remaining). Also introduces ChartLink + Shift+Drag brush selection for linking interactions.