### PR TITLE
refactor(blinc_charts): unify x-interaction stack and caching

### DIFF
--- a/crates/blinc_charts/src/area.rs
+++ b/crates/blinc_charts/src/area.rs
@@ -1,8 +1,6 @@
 use std::sync::{Arc, Mutex};
 
 use blinc_core::{Brush, Color, DrawContext, Path, Point, Rect, Stroke, TextStyle};
-use blinc_layout::canvas::canvas;
-use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
 use crate::brush::BrushX;
@@ -11,6 +9,7 @@ use crate::link::ChartLinkHandle;
 use crate::lod::{downsample_min_max, DownsampleParams};
 use crate::time_series::TimeSeriesF32;
 use crate::view::{ChartView, Domain1D, Domain2D};
+use crate::xy_stack::InteractiveXChartModel;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct SampleKey {
@@ -324,6 +323,68 @@ impl AreaChartModel {
     }
 }
 
+impl InteractiveXChartModel for AreaChartModel {
+    fn on_mouse_move(&mut self, local_x: f32, local_y: f32, w: f32, h: f32) {
+        AreaChartModel::on_mouse_move(self, local_x, local_y, w, h);
+    }
+
+    fn on_mouse_down(&mut self, brush_modifier: bool, local_x: f32, w: f32, h: f32) {
+        AreaChartModel::on_mouse_down(self, brush_modifier, local_x, w, h);
+    }
+
+    fn on_scroll(&mut self, delta_y: f32, cursor_x_px: f32, w: f32, h: f32) {
+        AreaChartModel::on_scroll(self, delta_y, cursor_x_px, w, h);
+    }
+
+    fn on_pinch(&mut self, scale_delta: f32, cursor_x_px: f32, w: f32, h: f32) {
+        AreaChartModel::on_pinch(self, scale_delta, cursor_x_px, w, h);
+    }
+
+    fn on_drag_pan_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        AreaChartModel::on_drag_pan_total(self, drag_total_dx, w, h);
+    }
+
+    fn on_drag_brush_x_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        AreaChartModel::on_drag_brush_x_total(self, drag_total_dx, w, h);
+    }
+
+    fn on_mouse_up_finish_brush_x(&mut self, w: f32, h: f32) -> Option<(f32, f32)> {
+        AreaChartModel::on_mouse_up_finish_brush_x(self, w, h)
+    }
+
+    fn on_drag_end(&mut self) {
+        AreaChartModel::on_drag_end(self);
+    }
+
+    fn render_plot(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        AreaChartModel::render_plot(self, ctx, w, h);
+    }
+
+    fn render_overlay(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        AreaChartModel::render_overlay(self, ctx, w, h);
+    }
+
+    fn plot_rect(&self, w: f32, h: f32) -> (f32, f32, f32, f32) {
+        self.view.plot_rect(w, h)
+    }
+
+    fn view(&self) -> &ChartView {
+        &self.view
+    }
+
+    fn view_mut(&mut self) -> &mut ChartView {
+        &mut self.view
+    }
+
+    fn crosshair_x_mut(&mut self) -> &mut Option<f32> {
+        &mut self.crosshair_x
+    }
+
+    fn is_brushing(&self) -> bool {
+        self.brush_x.is_active()
+    }
+}
+
 #[derive(Clone)]
 pub struct AreaChartHandle(pub Arc<Mutex<AreaChartModel>>);
 
@@ -334,198 +395,24 @@ impl AreaChartHandle {
 }
 
 pub fn area_chart(handle: AreaChartHandle) -> impl ElementBuilder {
-    let model_plot = handle.0.clone();
-    let model_overlay = handle.0.clone();
+    area_chart_with_bindings(handle, crate::ChartInputBindings::default())
+}
 
-    let model_move = handle.0.clone();
-    let model_scroll = handle.0.clone();
-    let model_pinch = handle.0.clone();
-    let model_down = handle.0.clone();
-    let model_drag = handle.0.clone();
-    let model_up = handle.0.clone();
-    let model_drag_end = handle.0.clone();
-
-    stack()
-        .w_full()
-        .h_full()
-        .overflow_clip()
-        .cursor(blinc_layout::element::CursorStyle::Crosshair)
-        .on_mouse_move(move |e| {
-            if let Ok(mut m) = model_move.lock() {
-                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_down(move |e| {
-            if let Ok(mut m) = model_down.lock() {
-                m.on_mouse_down(e.shift, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_scroll(move |e| {
-            if let Ok(mut m) = model_scroll.lock() {
-                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_pinch(move |e| {
-            if let Ok(mut m) = model_pinch.lock() {
-                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag(move |e| {
-            if let Ok(mut m) = model_drag.lock() {
-                if e.shift {
-                    m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                } else {
-                    m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_up(move |e| {
-            if let Ok(mut m) = model_up.lock() {
-                let _ = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height);
-                m.on_drag_end();
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag_end(move |_e| {
-            if let Ok(mut m) = model_drag_end.lock() {
-                m.on_drag_end();
-            }
-        })
-        .child(
-            canvas(move |ctx, bounds| {
-                if let Ok(mut m) = model_plot.lock() {
-                    m.render_plot(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full(),
-        )
-        .child(
-            canvas(move |ctx, bounds| {
-                if let Ok(mut m) = model_overlay.lock() {
-                    m.render_overlay(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full()
-            .foreground(),
-        )
+pub fn area_chart_with_bindings(
+    handle: AreaChartHandle,
+    bindings: crate::ChartInputBindings,
+) -> impl ElementBuilder {
+    crate::xy_stack::x_chart(handle.0, bindings)
 }
 
 pub fn linked_area_chart(handle: AreaChartHandle, link: ChartLinkHandle) -> impl ElementBuilder {
-    let model_plot = handle.0.clone();
-    let model_overlay = handle.0.clone();
+    linked_area_chart_with_bindings(handle, link, crate::ChartInputBindings::default())
+}
 
-    let model_move = handle.0.clone();
-    let model_scroll = handle.0.clone();
-    let model_pinch = handle.0.clone();
-    let model_down = handle.0.clone();
-    let model_drag = handle.0.clone();
-    let model_up = handle.0.clone();
-    let model_drag_end = handle.0.clone();
-
-    let link_move = link.clone();
-    let link_scroll = link.clone();
-    let link_pinch = link.clone();
-    let link_down = link.clone();
-    let link_drag = link.clone();
-    let link_up = link.clone();
-    let link_plot = link.clone();
-    let link_overlay = link.clone();
-
-    stack()
-        .w_full()
-        .h_full()
-        .overflow_clip()
-        .cursor(blinc_layout::element::CursorStyle::Crosshair)
-        .on_mouse_move(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_move.lock(), model_move.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
-
-                let (px, _py, pw, _ph) = m.plot_rect(e.bounds_width, e.bounds_height);
-                if pw > 0.0 && m.crosshair_x.is_some() {
-                    let x = m.view.px_to_x(e.local_x.clamp(px, px + pw), px, pw);
-                    l.set_hover_x(Some(x));
-                } else {
-                    l.set_hover_x(None);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_down(move |e| {
-            if let (Ok(_l), Ok(mut m)) = (link_down.lock(), model_down.lock()) {
-                m.on_mouse_down(e.shift, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_scroll(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_scroll.lock(), model_scroll.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
-                l.set_x_domain(m.view.domain.x);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_pinch(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_pinch.lock(), model_pinch.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
-                l.set_x_domain(m.view.domain.x);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_drag.lock(), model_drag.lock()) {
-                m.view.domain.x = l.x_domain;
-                if e.shift {
-                    m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                } else {
-                    m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                    l.set_x_domain(m.view.domain.x);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_up(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_up.lock(), model_up.lock()) {
-                if let Some((a, b)) = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height)
-                {
-                    l.set_selection_x(Some((a, b)));
-                }
-                m.on_drag_end();
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag_end(move |_e| {
-            if let Ok(mut m) = model_drag_end.lock() {
-                m.on_drag_end();
-            }
-        })
-        .child(
-            canvas(move |ctx, bounds| {
-                if let (Ok(l), Ok(mut m)) = (link_plot.lock(), model_plot.lock()) {
-                    m.view.domain.x = l.x_domain;
-                    m.render_plot(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full(),
-        )
-        .child(
-            canvas(move |ctx, bounds| {
-                if let (Ok(l), Ok(mut m)) = (link_overlay.lock(), model_overlay.lock()) {
-                    m.view.domain.x = l.x_domain;
-                    m.render_overlay(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full()
-            .foreground(),
-        )
+pub fn linked_area_chart_with_bindings(
+    handle: AreaChartHandle,
+    link: ChartLinkHandle,
+    bindings: crate::ChartInputBindings,
+) -> impl ElementBuilder {
+    crate::xy_stack::linked_x_chart(handle.0, link, bindings)
 }

--- a/crates/blinc_charts/src/bar.rs
+++ b/crates/blinc_charts/src/bar.rs
@@ -1,8 +1,6 @@
 use std::sync::{Arc, Mutex};
 
 use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextStyle};
-use blinc_layout::canvas::canvas;
-use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
 use crate::brush::BrushX;
@@ -10,6 +8,7 @@ use crate::common::{draw_grid, fill_bg};
 use crate::link::ChartLinkHandle;
 use crate::time_series::TimeSeriesF32;
 use crate::view::{ChartView, Domain1D, Domain2D};
+use crate::xy_stack::InteractiveXChartModel;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct BinKey {
@@ -73,6 +72,7 @@ pub struct BarChartModel {
     pub hover_x: Option<f32>,
 
     bins: Vec<f32>, // bins_n * series_n
+    counts: Vec<u32>,
     bins_n: usize,
     last_bin_key: Option<BinKey>,
 
@@ -123,6 +123,7 @@ impl BarChartModel {
             crosshair_x: None,
             hover_x: None,
             bins: Vec::new(),
+            counts: Vec::new(),
             bins_n: 0,
             last_bin_key: None,
             last_drag_total_x: None,
@@ -275,6 +276,8 @@ impl BarChartModel {
         self.bins_n = bins_n;
         self.bins.clear();
         self.bins.resize(bins_n * series_n, 0.0);
+        self.counts.clear();
+        self.counts.resize(bins_n, 0);
 
         let x0 = self.view.domain.x.min;
         let x1 = self.view.domain.x.max;
@@ -284,7 +287,7 @@ impl BarChartModel {
         for (s_idx, s) in self.series.iter().take(series_n).enumerate() {
             let i0 = s.lower_bound_x(x0).min(s.len());
             let i1 = s.upper_bound_x(x1).min(s.len());
-            let mut counts: Vec<u32> = vec![0; bins_n];
+            self.counts.fill(0);
 
             for i in i0..i1 {
                 let x = s.x[i];
@@ -296,12 +299,12 @@ impl BarChartModel {
                 let bin = (t * bins_n as f32) as usize;
                 let idx = s_idx * bins_n + bin;
                 self.bins[idx] += y;
-                counts[bin] += 1;
+                self.counts[bin] = self.counts[bin].saturating_add(1);
             }
 
             // Convert sum->mean to keep values bounded.
             for bin in 0..bins_n {
-                let c = counts[bin].max(1) as f32;
+                let c = self.counts[bin].max(1) as f32;
                 self.bins[s_idx * bins_n + bin] /= c;
             }
         }
@@ -421,6 +424,68 @@ impl BarChartModel {
     }
 }
 
+impl InteractiveXChartModel for BarChartModel {
+    fn on_mouse_move(&mut self, local_x: f32, local_y: f32, w: f32, h: f32) {
+        BarChartModel::on_mouse_move(self, local_x, local_y, w, h);
+    }
+
+    fn on_mouse_down(&mut self, brush_modifier: bool, local_x: f32, w: f32, h: f32) {
+        BarChartModel::on_mouse_down(self, brush_modifier, local_x, w, h);
+    }
+
+    fn on_scroll(&mut self, delta_y: f32, cursor_x_px: f32, w: f32, h: f32) {
+        BarChartModel::on_scroll(self, delta_y, cursor_x_px, w, h);
+    }
+
+    fn on_pinch(&mut self, scale_delta: f32, cursor_x_px: f32, w: f32, h: f32) {
+        BarChartModel::on_pinch(self, scale_delta, cursor_x_px, w, h);
+    }
+
+    fn on_drag_pan_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        BarChartModel::on_drag_pan_total(self, drag_total_dx, w, h);
+    }
+
+    fn on_drag_brush_x_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        BarChartModel::on_drag_brush_x_total(self, drag_total_dx, w, h);
+    }
+
+    fn on_mouse_up_finish_brush_x(&mut self, w: f32, h: f32) -> Option<(f32, f32)> {
+        BarChartModel::on_mouse_up_finish_brush_x(self, w, h)
+    }
+
+    fn on_drag_end(&mut self) {
+        BarChartModel::on_drag_end(self);
+    }
+
+    fn render_plot(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        BarChartModel::render_plot(self, ctx, w, h);
+    }
+
+    fn render_overlay(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        BarChartModel::render_overlay(self, ctx, w, h);
+    }
+
+    fn plot_rect(&self, w: f32, h: f32) -> (f32, f32, f32, f32) {
+        self.view.plot_rect(w, h)
+    }
+
+    fn view(&self) -> &ChartView {
+        &self.view
+    }
+
+    fn view_mut(&mut self) -> &mut ChartView {
+        &mut self.view
+    }
+
+    fn crosshair_x_mut(&mut self) -> &mut Option<f32> {
+        &mut self.crosshair_x
+    }
+
+    fn is_brushing(&self) -> bool {
+        self.brush_x.is_active()
+    }
+}
+
 #[derive(Clone)]
 pub struct BarChartHandle(pub Arc<Mutex<BarChartModel>>);
 
@@ -431,195 +496,24 @@ impl BarChartHandle {
 }
 
 pub fn bar_chart(handle: BarChartHandle) -> impl ElementBuilder {
-    let model_plot = handle.0.clone();
-    let model_overlay = handle.0.clone();
+    bar_chart_with_bindings(handle, crate::ChartInputBindings::default())
+}
 
-    let model_move = handle.0.clone();
-    let model_scroll = handle.0.clone();
-    let model_pinch = handle.0.clone();
-    let model_down = handle.0.clone();
-    let model_drag = handle.0.clone();
-    let model_up = handle.0.clone();
-    let model_drag_end = handle.0.clone();
-
-    stack()
-        .w_full()
-        .h_full()
-        .overflow_clip()
-        .cursor(blinc_layout::element::CursorStyle::Crosshair)
-        .on_mouse_move(move |e| {
-            if let Ok(mut m) = model_move.lock() {
-                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_down(move |e| {
-            if let Ok(mut m) = model_down.lock() {
-                m.on_mouse_down(e.shift, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_scroll(move |e| {
-            if let Ok(mut m) = model_scroll.lock() {
-                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_pinch(move |e| {
-            if let Ok(mut m) = model_pinch.lock() {
-                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag(move |e| {
-            if let Ok(mut m) = model_drag.lock() {
-                if e.shift {
-                    m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                } else {
-                    m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_up(move |e| {
-            if let Ok(mut m) = model_up.lock() {
-                let _ = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height);
-                m.on_drag_end();
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag_end(move |_e| {
-            if let Ok(mut m) = model_drag_end.lock() {
-                m.on_drag_end();
-            }
-        })
-        .child(
-            canvas(move |ctx, bounds| {
-                if let Ok(mut m) = model_plot.lock() {
-                    m.render_plot(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full(),
-        )
-        .child(
-            canvas(move |ctx, bounds| {
-                if let Ok(mut m) = model_overlay.lock() {
-                    m.render_overlay(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full()
-            .foreground(),
-        )
+pub fn bar_chart_with_bindings(
+    handle: BarChartHandle,
+    bindings: crate::ChartInputBindings,
+) -> impl ElementBuilder {
+    crate::xy_stack::x_chart(handle.0, bindings)
 }
 
 pub fn linked_bar_chart(handle: BarChartHandle, link: ChartLinkHandle) -> impl ElementBuilder {
-    let model_plot = handle.0.clone();
-    let model_overlay = handle.0.clone();
+    linked_bar_chart_with_bindings(handle, link, crate::ChartInputBindings::default())
+}
 
-    let model_move = handle.0.clone();
-    let model_scroll = handle.0.clone();
-    let model_pinch = handle.0.clone();
-    let model_down = handle.0.clone();
-    let model_drag = handle.0.clone();
-    let model_up = handle.0.clone();
-    let model_drag_end = handle.0.clone();
-
-    let link_move = link.clone();
-    let link_scroll = link.clone();
-    let link_pinch = link.clone();
-    let link_down = link.clone();
-    let link_drag = link.clone();
-    let link_up = link.clone();
-    let link_plot = link.clone();
-    let link_overlay = link.clone();
-
-    stack()
-        .w_full()
-        .h_full()
-        .overflow_clip()
-        .cursor(blinc_layout::element::CursorStyle::Crosshair)
-        .on_mouse_move(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_move.lock(), model_move.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
-                if let Some(x) = m.hover_x {
-                    l.set_hover_x(Some(x));
-                } else {
-                    l.set_hover_x(None);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_down(move |e| {
-            if let (Ok(_l), Ok(mut m)) = (link_down.lock(), model_down.lock()) {
-                m.on_mouse_down(e.shift, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_scroll(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_scroll.lock(), model_scroll.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
-                l.set_x_domain(m.view.domain.x);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_pinch(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_pinch.lock(), model_pinch.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
-                l.set_x_domain(m.view.domain.x);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_drag.lock(), model_drag.lock()) {
-                m.view.domain.x = l.x_domain;
-                if e.shift {
-                    m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                } else {
-                    m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                    l.set_x_domain(m.view.domain.x);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_up(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_up.lock(), model_up.lock()) {
-                if let Some((a, b)) = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height)
-                {
-                    l.set_selection_x(Some((a, b)));
-                }
-                m.on_drag_end();
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag_end(move |_e| {
-            if let Ok(mut m) = model_drag_end.lock() {
-                m.on_drag_end();
-            }
-        })
-        .child(
-            canvas(move |ctx, bounds| {
-                if let (Ok(l), Ok(mut m)) = (link_plot.lock(), model_plot.lock()) {
-                    m.view.domain.x = l.x_domain;
-                    m.render_plot(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full(),
-        )
-        .child(
-            canvas(move |ctx, bounds| {
-                if let (Ok(l), Ok(mut m)) = (link_overlay.lock(), model_overlay.lock()) {
-                    m.view.domain.x = l.x_domain;
-                    m.render_overlay(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full()
-            .foreground(),
-        )
+pub fn linked_bar_chart_with_bindings(
+    handle: BarChartHandle,
+    link: ChartLinkHandle,
+    bindings: crate::ChartInputBindings,
+) -> impl ElementBuilder {
+    crate::xy_stack::linked_x_chart(handle.0, link, bindings)
 }

--- a/crates/blinc_charts/src/brush.rs
+++ b/crates/blinc_charts/src/brush.rs
@@ -54,6 +54,66 @@ impl BrushX {
     }
 }
 
+/// Minimal 2D brush state (rectangle), in local pixel coordinates.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct BrushRect {
+    active: bool,
+    start_x: f32,
+    start_y: f32,
+    cur_x: f32,
+    cur_y: f32,
+}
+
+impl BrushRect {
+    pub(crate) fn is_active(&self) -> bool {
+        self.active
+    }
+
+    pub(crate) fn anchor_px(&self) -> Option<(f32, f32)> {
+        if self.active {
+            Some((self.start_x, self.start_y))
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn begin(&mut self, x_px: f32, y_px: f32) {
+        self.active = true;
+        self.start_x = x_px;
+        self.start_y = y_px;
+        self.cur_x = x_px;
+        self.cur_y = y_px;
+    }
+
+    pub(crate) fn update(&mut self, x_px: f32, y_px: f32) {
+        if self.active {
+            self.cur_x = x_px;
+            self.cur_y = y_px;
+        }
+    }
+
+    pub(crate) fn cancel(&mut self) {
+        self.active = false;
+    }
+
+    pub(crate) fn rect_px(&self) -> Option<(f32, f32, f32, f32)> {
+        if !self.active {
+            return None;
+        }
+        let x0 = self.start_x.min(self.cur_x);
+        let x1 = self.start_x.max(self.cur_x);
+        let y0 = self.start_y.min(self.cur_y);
+        let y1 = self.start_y.max(self.cur_y);
+        Some((x0, y0, x1, y1))
+    }
+
+    pub(crate) fn take_final_px(&mut self) -> Option<(f32, f32, f32, f32)> {
+        let r = self.rect_px();
+        self.active = false;
+        r
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,5 +128,17 @@ mod tests {
         assert_eq!(b.range_px(), Some((3.0, 10.0)));
         assert_eq!(b.take_final_px(), Some((3.0, 10.0)));
         assert_eq!(b.range_px(), None);
+    }
+
+    #[test]
+    fn brush_rect_tracks_rect() {
+        let mut b = BrushRect::default();
+        assert_eq!(b.rect_px(), None);
+        b.begin(10.0, 5.0);
+        assert_eq!(b.rect_px(), Some((10.0, 5.0, 10.0, 5.0)));
+        b.update(3.0, 8.0);
+        assert_eq!(b.rect_px(), Some((3.0, 5.0, 10.0, 8.0)));
+        assert_eq!(b.take_final_px(), Some((3.0, 5.0, 10.0, 8.0)));
+        assert_eq!(b.rect_px(), None);
     }
 }

--- a/crates/blinc_charts/src/contour.rs
+++ b/crates/blinc_charts/src/contour.rs
@@ -5,6 +5,7 @@ use blinc_layout::canvas::canvas;
 use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
+use crate::brush::BrushRect;
 use crate::common::{draw_grid, fill_bg};
 use crate::view::{ChartView, Domain1D, Domain2D};
 
@@ -21,57 +22,6 @@ fn levels_hash(levels: &[f32]) -> u64 {
         h = h.wrapping_mul(0x0000_0100_0000_01b3);
     }
     h
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-struct BrushRect {
-    active: bool,
-    start_x: f32,
-    start_y: f32,
-    cur_x: f32,
-    cur_y: f32,
-}
-
-impl BrushRect {
-    fn is_active(&self) -> bool {
-        self.active
-    }
-
-    fn begin(&mut self, x_px: f32, y_px: f32) {
-        self.active = true;
-        self.start_x = x_px;
-        self.start_y = y_px;
-        self.cur_x = x_px;
-        self.cur_y = y_px;
-    }
-
-    fn update(&mut self, x_px: f32, y_px: f32) {
-        if self.active {
-            self.cur_x = x_px;
-            self.cur_y = y_px;
-        }
-    }
-
-    fn cancel(&mut self) {
-        self.active = false;
-    }
-
-    fn rect_px(&self) -> Option<(f32, f32, f32, f32)> {
-        if !self.active {
-            return None;
-        }
-        let x0 = self.start_x.min(self.cur_x);
-        let x1 = self.start_x.max(self.cur_x);
-        let y0 = self.start_y.min(self.cur_y);
-        let y1 = self.start_y.max(self.cur_y);
-        Some((x0, y0, x1, y1))
-    }
-
-    fn take_final_px(&mut self) -> Option<(f32, f32, f32, f32)> {
-        let r = self.rect_px();
-        self.active = false;
-        r
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -277,9 +227,12 @@ impl ContourChartModel {
         if pw <= 0.0 || ph <= 0.0 {
             return;
         }
+        let Some((anchor_x, anchor_y)) = self.brush.anchor_px() else {
+            return;
+        };
         self.brush.update(
-            (self.brush.start_x + drag_total_dx).clamp(px, px + pw),
-            (self.brush.start_y + drag_total_dy).clamp(py, py + ph),
+            (anchor_x + drag_total_dx).clamp(px, px + pw),
+            (anchor_y + drag_total_dy).clamp(py, py + ph),
         );
     }
 

--- a/crates/blinc_charts/src/contour.rs
+++ b/crates/blinc_charts/src/contour.rs
@@ -5,6 +5,7 @@ use blinc_layout::canvas::canvas;
 use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
+use crate::brush::BrushRect;
 use crate::common::{draw_grid, fill_bg};
 use crate::view::{ChartView, Domain1D, Domain2D};
 
@@ -21,57 +22,6 @@ fn levels_hash(levels: &[f32]) -> u64 {
         h = h.wrapping_mul(0x0000_0100_0000_01b3);
     }
     h
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-struct BrushRect {
-    active: bool,
-    start_x: f32,
-    start_y: f32,
-    cur_x: f32,
-    cur_y: f32,
-}
-
-impl BrushRect {
-    fn is_active(&self) -> bool {
-        self.active
-    }
-
-    fn begin(&mut self, x_px: f32, y_px: f32) {
-        self.active = true;
-        self.start_x = x_px;
-        self.start_y = y_px;
-        self.cur_x = x_px;
-        self.cur_y = y_px;
-    }
-
-    fn update(&mut self, x_px: f32, y_px: f32) {
-        if self.active {
-            self.cur_x = x_px;
-            self.cur_y = y_px;
-        }
-    }
-
-    fn cancel(&mut self) {
-        self.active = false;
-    }
-
-    fn rect_px(&self) -> Option<(f32, f32, f32, f32)> {
-        if !self.active {
-            return None;
-        }
-        let x0 = self.start_x.min(self.cur_x);
-        let x1 = self.start_x.max(self.cur_x);
-        let y0 = self.start_y.min(self.cur_y);
-        let y1 = self.start_y.max(self.cur_y);
-        Some((x0, y0, x1, y1))
-    }
-
-    fn take_final_px(&mut self) -> Option<(f32, f32, f32, f32)> {
-        let r = self.rect_px();
-        self.active = false;
-        r
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -276,9 +226,12 @@ impl ContourChartModel {
         if pw <= 0.0 || ph <= 0.0 {
             return;
         }
+        let Some((anchor_x, anchor_y)) = self.brush.anchor_px() else {
+            return;
+        };
         self.brush.update(
-            (self.brush.start_x + drag_total_dx).clamp(px, px + pw),
-            (self.brush.start_y + drag_total_dy).clamp(py, py + ph),
+            (anchor_x + drag_total_dx).clamp(px, px + pw),
+            (anchor_y + drag_total_dy).clamp(py, py + ph),
         );
     }
 

--- a/crates/blinc_charts/src/density_map.rs
+++ b/crates/blinc_charts/src/density_map.rs
@@ -5,6 +5,7 @@ use blinc_layout::canvas::canvas;
 use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
+use crate::brush::BrushRect;
 use crate::common::{draw_grid, fill_bg};
 use crate::view::{ChartView, Domain1D, Domain2D};
 
@@ -28,57 +29,6 @@ impl BinKey {
             bins_w: bins_w as u32,
             bins_h: bins_h as u32,
         }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-struct BrushRect {
-    active: bool,
-    start_x: f32,
-    start_y: f32,
-    cur_x: f32,
-    cur_y: f32,
-}
-
-impl BrushRect {
-    fn is_active(&self) -> bool {
-        self.active
-    }
-
-    fn begin(&mut self, x_px: f32, y_px: f32) {
-        self.active = true;
-        self.start_x = x_px;
-        self.start_y = y_px;
-        self.cur_x = x_px;
-        self.cur_y = y_px;
-    }
-
-    fn update(&mut self, x_px: f32, y_px: f32) {
-        if self.active {
-            self.cur_x = x_px;
-            self.cur_y = y_px;
-        }
-    }
-
-    fn cancel(&mut self) {
-        self.active = false;
-    }
-
-    fn rect_px(&self) -> Option<(f32, f32, f32, f32)> {
-        if !self.active {
-            return None;
-        }
-        let x0 = self.start_x.min(self.cur_x);
-        let x1 = self.start_x.max(self.cur_x);
-        let y0 = self.start_y.min(self.cur_y);
-        let y1 = self.start_y.max(self.cur_y);
-        Some((x0, y0, x1, y1))
-    }
-
-    fn take_final_px(&mut self) -> Option<(f32, f32, f32, f32)> {
-        let r = self.rect_px();
-        self.active = false;
-        r
     }
 }
 
@@ -308,10 +258,13 @@ impl DensityMapChartModel {
         if pw <= 0.0 || ph <= 0.0 {
             return;
         }
+        let Some((anchor_x, anchor_y)) = self.brush.anchor_px() else {
+            return;
+        };
         // DRAG provides delta-from-start, so infer current from anchor.
         self.brush.update(
-            (self.brush.start_x + drag_total_dx).clamp(px, px + pw),
-            (self.brush.start_y + drag_total_dy).clamp(py, py + ph),
+            (anchor_x + drag_total_dx).clamp(px, px + pw),
+            (anchor_y + drag_total_dy).clamp(py, py + ph),
         );
     }
 

--- a/crates/blinc_charts/src/input.rs
+++ b/crates/blinc_charts/src/input.rs
@@ -27,10 +27,7 @@ impl ModifiersReq {
     }
 
     pub fn matches(&self, shift: bool, ctrl: bool, alt: bool, meta: bool) -> bool {
-        (!self.shift || shift)
-            && (!self.ctrl || ctrl)
-            && (!self.alt || alt)
-            && (!self.meta || meta)
+        (!self.shift || shift) && (!self.ctrl || ctrl) && (!self.alt || alt) && (!self.meta || meta)
     }
 }
 
@@ -93,4 +90,3 @@ mod tests {
         assert!(!r.matches(false, true, false, false));
     }
 }
-

--- a/crates/blinc_charts/src/lib.rs
+++ b/crates/blinc_charts/src/lib.rs
@@ -9,11 +9,13 @@
 
 mod brush;
 mod common;
+pub mod input;
 mod link;
 mod lod;
 mod segments;
 mod time_series;
 mod view;
+mod xy_stack;
 
 pub mod area;
 pub mod bar;
@@ -35,6 +37,7 @@ pub mod statistics;
 
 pub use brush::BrushX;
 pub use candlestick::{Candle, CandleSeries};
+pub use input::{ChartInputBindings, DragAction, DragBinding, ModifiersReq};
 pub use link::{chart_link, ChartLink, ChartLinkHandle};
 pub use lod::{downsample_min_max, DownsampleParams};
 pub use segments::runs_by_gap;
@@ -44,13 +47,16 @@ pub use view::{ChartView, Domain1D, Domain2D};
 /// Common imports for chart users.
 pub mod prelude {
     pub use crate::area::{
-        area_chart, linked_area_chart, AreaChartHandle, AreaChartModel, AreaChartStyle,
+        area_chart, area_chart_with_bindings, linked_area_chart, linked_area_chart_with_bindings,
+        AreaChartHandle, AreaChartModel, AreaChartStyle,
     };
     pub use crate::bar::{
-        bar_chart, linked_bar_chart, BarChartHandle, BarChartModel, BarChartStyle,
+        bar_chart, bar_chart_with_bindings, linked_bar_chart, linked_bar_chart_with_bindings,
+        BarChartHandle, BarChartModel, BarChartStyle,
     };
     pub use crate::candlestick::{
-        candlestick_chart, linked_candlestick_chart, Candle, CandleSeries, CandlestickChartHandle,
+        candlestick_chart, candlestick_chart_with_bindings, linked_candlestick_chart,
+        linked_candlestick_chart_with_bindings, Candle, CandleSeries, CandlestickChartHandle,
         CandlestickChartModel, CandlestickChartStyle,
     };
     pub use crate::contour::{contour_chart, ContourChartHandle, ContourChartModel, ContourChartStyle};
@@ -67,14 +73,17 @@ pub mod prelude {
         HierarchyNode, HierarchyMode,
     };
     pub use crate::histogram::{
-        histogram_chart, HistogramChartHandle, HistogramChartModel, HistogramChartStyle,
+        histogram_chart, histogram_chart_with_bindings, HistogramChartHandle, HistogramChartModel,
+        HistogramChartStyle,
     };
     pub use crate::line::{
-        line_chart, linked_line_chart, LineChartHandle, LineChartModel, LineChartStyle,
+        line_chart, line_chart_with_bindings, linked_line_chart, linked_line_chart_with_bindings,
+        LineChartHandle, LineChartModel, LineChartStyle,
     };
     pub use crate::link::{chart_link, ChartLink, ChartLinkHandle};
     pub use crate::multi_line::{
-        linked_multi_line_chart, multi_line_chart, MultiLineChartHandle, MultiLineChartModel,
+        linked_multi_line_chart, linked_multi_line_chart_with_bindings, multi_line_chart,
+        multi_line_chart_with_bindings, MultiLineChartHandle, MultiLineChartModel,
         MultiLineChartStyle,
     };
     pub use crate::network::{
@@ -82,16 +91,19 @@ pub mod prelude {
     };
     pub use crate::polar::{polar_chart, PolarChartHandle, PolarChartModel, PolarChartMode, PolarChartStyle};
     pub use crate::scatter::{
-        linked_scatter_chart, scatter_chart, ScatterChartHandle, ScatterChartModel,
-        ScatterChartStyle,
+        linked_scatter_chart, linked_scatter_chart_with_bindings, scatter_chart,
+        scatter_chart_with_bindings, ScatterChartHandle, ScatterChartModel, ScatterChartStyle,
     };
     pub use crate::stacked_area::{
-        linked_stacked_area_chart, stacked_area_chart, StackedAreaChartHandle,
-        StackedAreaChartModel, StackedAreaChartStyle, StackedAreaMode,
+        linked_stacked_area_chart, linked_stacked_area_chart_with_bindings, stacked_area_chart,
+        stacked_area_chart_with_bindings, StackedAreaChartHandle, StackedAreaChartModel,
+        StackedAreaChartStyle, StackedAreaMode,
     };
     pub use crate::statistics::{
-        statistics_chart, StatisticsChartHandle, StatisticsChartModel, StatisticsChartStyle,
+        statistics_chart, statistics_chart_with_bindings, StatisticsChartHandle,
+        StatisticsChartModel, StatisticsChartStyle,
     };
     pub use crate::time_series::TimeSeriesF32;
     pub use crate::view::{ChartView, Domain1D, Domain2D};
+    pub use crate::{ChartInputBindings, DragAction, DragBinding, ModifiersReq};
 }

--- a/crates/blinc_charts/src/lib.rs
+++ b/crates/blinc_charts/src/lib.rs
@@ -9,11 +9,13 @@
 
 mod brush;
 mod common;
+pub mod input;
 mod link;
 mod lod;
 mod segments;
 mod time_series;
 mod view;
+mod xy_stack;
 
 pub mod area;
 pub mod bar;
@@ -35,6 +37,7 @@ pub mod statistics;
 
 pub use brush::BrushX;
 pub use candlestick::{Candle, CandleSeries};
+pub use input::{ChartInputBindings, DragAction, DragBinding, ModifiersReq};
 pub use link::{chart_link, ChartLink, ChartLinkHandle};
 pub use lod::{downsample_min_max, DownsampleParams};
 pub use segments::runs_by_gap;
@@ -44,13 +47,16 @@ pub use view::{ChartView, Domain1D, Domain2D};
 /// Common imports for chart users.
 pub mod prelude {
     pub use crate::area::{
-        area_chart, linked_area_chart, AreaChartHandle, AreaChartModel, AreaChartStyle,
+        area_chart, area_chart_with_bindings, linked_area_chart, linked_area_chart_with_bindings,
+        AreaChartHandle, AreaChartModel, AreaChartStyle,
     };
     pub use crate::bar::{
-        bar_chart, linked_bar_chart, BarChartHandle, BarChartModel, BarChartStyle,
+        bar_chart, bar_chart_with_bindings, linked_bar_chart, linked_bar_chart_with_bindings,
+        BarChartHandle, BarChartModel, BarChartStyle,
     };
     pub use crate::candlestick::{
-        candlestick_chart, linked_candlestick_chart, Candle, CandleSeries, CandlestickChartHandle,
+        candlestick_chart, candlestick_chart_with_bindings, linked_candlestick_chart,
+        linked_candlestick_chart_with_bindings, Candle, CandleSeries, CandlestickChartHandle,
         CandlestickChartModel, CandlestickChartStyle,
     };
     pub use crate::contour::{
@@ -72,14 +78,17 @@ pub mod prelude {
         HierarchyMode, HierarchyNode,
     };
     pub use crate::histogram::{
-        histogram_chart, HistogramChartHandle, HistogramChartModel, HistogramChartStyle,
+        histogram_chart, histogram_chart_with_bindings, HistogramChartHandle, HistogramChartModel,
+        HistogramChartStyle,
     };
     pub use crate::line::{
-        line_chart, linked_line_chart, LineChartHandle, LineChartModel, LineChartStyle,
+        line_chart, line_chart_with_bindings, linked_line_chart, linked_line_chart_with_bindings,
+        LineChartHandle, LineChartModel, LineChartStyle,
     };
     pub use crate::link::{chart_link, ChartLink, ChartLinkHandle};
     pub use crate::multi_line::{
-        linked_multi_line_chart, multi_line_chart, MultiLineChartHandle, MultiLineChartModel,
+        linked_multi_line_chart, linked_multi_line_chart_with_bindings, multi_line_chart,
+        multi_line_chart_with_bindings, MultiLineChartHandle, MultiLineChartModel,
         MultiLineChartStyle,
     };
     pub use crate::network::{
@@ -89,16 +98,19 @@ pub mod prelude {
         polar_chart, PolarChartHandle, PolarChartMode, PolarChartModel, PolarChartStyle,
     };
     pub use crate::scatter::{
-        linked_scatter_chart, scatter_chart, ScatterChartHandle, ScatterChartModel,
-        ScatterChartStyle,
+        linked_scatter_chart, linked_scatter_chart_with_bindings, scatter_chart,
+        scatter_chart_with_bindings, ScatterChartHandle, ScatterChartModel, ScatterChartStyle,
     };
     pub use crate::stacked_area::{
-        linked_stacked_area_chart, stacked_area_chart, StackedAreaChartHandle,
-        StackedAreaChartModel, StackedAreaChartStyle, StackedAreaMode,
+        linked_stacked_area_chart, linked_stacked_area_chart_with_bindings, stacked_area_chart,
+        stacked_area_chart_with_bindings, StackedAreaChartHandle, StackedAreaChartModel,
+        StackedAreaChartStyle, StackedAreaMode,
     };
     pub use crate::statistics::{
-        statistics_chart, StatisticsChartHandle, StatisticsChartModel, StatisticsChartStyle,
+        statistics_chart, statistics_chart_with_bindings, StatisticsChartHandle,
+        StatisticsChartModel, StatisticsChartStyle,
     };
     pub use crate::time_series::TimeSeriesF32;
     pub use crate::view::{ChartView, Domain1D, Domain2D};
+    pub use crate::{ChartInputBindings, DragAction, DragBinding, ModifiersReq};
 }

--- a/crates/blinc_charts/src/line.rs
+++ b/crates/blinc_charts/src/line.rs
@@ -1,8 +1,6 @@
 use std::sync::{Arc, Mutex};
 
 use blinc_core::{Brush, Color, CornerRadius, DrawContext, Point, Rect, Stroke, TextStyle};
-use blinc_layout::canvas::canvas;
-use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
 use crate::brush::BrushX;
@@ -10,6 +8,7 @@ use crate::link::ChartLinkHandle;
 use crate::lod::{downsample_min_max, DownsampleParams};
 use crate::time_series::TimeSeriesF32;
 use crate::view::{ChartView, Domain1D, Domain2D};
+use crate::xy_stack::InteractiveXChartModel;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct SampleKey {
@@ -362,6 +361,68 @@ impl LineChartModel {
     }
 }
 
+impl InteractiveXChartModel for LineChartModel {
+    fn on_mouse_move(&mut self, local_x: f32, local_y: f32, w: f32, h: f32) {
+        LineChartModel::on_mouse_move(self, local_x, local_y, w, h);
+    }
+
+    fn on_mouse_down(&mut self, brush_modifier: bool, local_x: f32, w: f32, h: f32) {
+        LineChartModel::on_mouse_down(self, brush_modifier, local_x, w, h);
+    }
+
+    fn on_scroll(&mut self, delta_y: f32, cursor_x_px: f32, w: f32, h: f32) {
+        LineChartModel::on_scroll(self, delta_y, cursor_x_px, w, h);
+    }
+
+    fn on_pinch(&mut self, scale_delta: f32, cursor_x_px: f32, w: f32, h: f32) {
+        LineChartModel::on_pinch(self, scale_delta, cursor_x_px, w, h);
+    }
+
+    fn on_drag_pan_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        LineChartModel::on_drag_pan_total(self, drag_total_dx, w, h);
+    }
+
+    fn on_drag_brush_x_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        LineChartModel::on_drag_brush_x_total(self, drag_total_dx, w, h);
+    }
+
+    fn on_mouse_up_finish_brush_x(&mut self, w: f32, h: f32) -> Option<(f32, f32)> {
+        LineChartModel::on_mouse_up_finish_brush_x(self, w, h)
+    }
+
+    fn on_drag_end(&mut self) {
+        LineChartModel::on_drag_end(self);
+    }
+
+    fn render_plot(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        LineChartModel::render_plot(self, ctx, w, h);
+    }
+
+    fn render_overlay(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        LineChartModel::render_overlay(self, ctx, w, h);
+    }
+
+    fn plot_rect(&self, w: f32, h: f32) -> (f32, f32, f32, f32) {
+        self.view.plot_rect(w, h)
+    }
+
+    fn view(&self) -> &ChartView {
+        &self.view
+    }
+
+    fn view_mut(&mut self) -> &mut ChartView {
+        &mut self.view
+    }
+
+    fn crosshair_x_mut(&mut self) -> &mut Option<f32> {
+        &mut self.crosshair_x
+    }
+
+    fn is_brushing(&self) -> bool {
+        self.brush_x.is_active()
+    }
+}
+
 /// Shared handle for a line chart model.
 #[derive(Clone)]
 pub struct LineChartHandle(pub Arc<Mutex<LineChartModel>>);
@@ -384,88 +445,14 @@ impl LineChartHandle {
 /// - `on_scroll` / `on_pinch`: zoom X about cursor
 /// - `on_drag`: pan X
 pub fn line_chart(handle: LineChartHandle) -> impl ElementBuilder {
-    let model_plot = handle.0.clone();
-    let model_overlay = handle.0.clone();
+    line_chart_with_bindings(handle, crate::ChartInputBindings::default())
+}
 
-    // Events mutate the shared model and request a redraw (no tree rebuild).
-    let model_move = handle.0.clone();
-    let model_scroll = handle.0.clone();
-    let model_pinch = handle.0.clone();
-    let model_down = handle.0.clone();
-    let model_drag = handle.0.clone();
-    let model_up = handle.0.clone();
-    let model_drag_end = handle.0.clone();
-
-    stack()
-        .w_full()
-        .h_full()
-        .overflow_clip()
-        .cursor(blinc_layout::element::CursorStyle::Crosshair)
-        .on_mouse_move(move |e| {
-            if let Ok(mut m) = model_move.lock() {
-                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_down(move |e| {
-            if let Ok(mut m) = model_down.lock() {
-                m.on_mouse_down(e.shift, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_scroll(move |e| {
-            if let Ok(mut m) = model_scroll.lock() {
-                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_pinch(move |e| {
-            if let Ok(mut m) = model_pinch.lock() {
-                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag(move |e| {
-            if let Ok(mut m) = model_drag.lock() {
-                if e.shift {
-                    m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                } else {
-                    m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_up(move |_e| {
-            if let Ok(mut m) = model_up.lock() {
-                let _ = m.on_mouse_up_finish_brush_x(_e.bounds_width, _e.bounds_height);
-                m.on_drag_end();
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag_end(move |_e| {
-            if let Ok(mut m) = model_drag_end.lock() {
-                m.on_drag_end();
-            }
-        })
-        .child(
-            canvas(move |ctx, bounds| {
-                if let Ok(mut m) = model_plot.lock() {
-                    m.render_plot(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full(),
-        )
-        .child(
-            canvas(move |ctx, bounds| {
-                if let Ok(mut m) = model_overlay.lock() {
-                    m.render_overlay(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full()
-            .foreground(),
-        )
+pub fn line_chart_with_bindings(
+    handle: LineChartHandle,
+    bindings: crate::ChartInputBindings,
+) -> impl ElementBuilder {
+    crate::xy_stack::x_chart(handle.0, bindings)
 }
 
 /// Create a linked line chart element.
@@ -475,138 +462,13 @@ pub fn line_chart(handle: LineChartHandle) -> impl ElementBuilder {
 /// - Hover is broadcast via `link.hover_x`.
 /// - Selection (brush) is created with Shift+Drag and stored in `link.selection_x`.
 pub fn linked_line_chart(handle: LineChartHandle, link: ChartLinkHandle) -> impl ElementBuilder {
-    let model_plot = handle.0.clone();
-    let model_overlay = handle.0.clone();
+    linked_line_chart_with_bindings(handle, link, crate::ChartInputBindings::default())
+}
 
-    let model_move = handle.0.clone();
-    let model_scroll = handle.0.clone();
-    let model_pinch = handle.0.clone();
-    let model_down = handle.0.clone();
-    let model_drag = handle.0.clone();
-    let model_up = handle.0.clone();
-    let model_drag_end = handle.0.clone();
-
-    let link_move = link.clone();
-    let link_scroll = link.clone();
-    let link_pinch = link.clone();
-    let link_down = link.clone();
-    let link_drag = link.clone();
-    let link_up = link.clone();
-    let link_plot = link.clone();
-    let link_overlay = link.clone();
-
-    stack()
-        .w_full()
-        .h_full()
-        .overflow_clip()
-        .cursor(blinc_layout::element::CursorStyle::Crosshair)
-        .on_mouse_move(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_move.lock(), model_move.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
-
-                // Publish hover x in domain units (or None when out of plot).
-                let (px, _py, pw, _ph) = m.plot_rect(e.bounds_width, e.bounds_height);
-                if pw > 0.0 && m.crosshair_x.is_some() {
-                    let x = m.view.px_to_x(e.local_x.clamp(px, px + pw), px, pw);
-                    l.set_hover_x(Some(x));
-                } else {
-                    l.set_hover_x(None);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_down(move |e| {
-            if let (Ok(_l), Ok(mut m)) = (link_down.lock(), model_down.lock()) {
-                m.on_mouse_down(e.shift, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_scroll(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_scroll.lock(), model_scroll.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
-                l.set_x_domain(m.view.domain.x);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_pinch(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_pinch.lock(), model_pinch.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
-                l.set_x_domain(m.view.domain.x);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_drag.lock(), model_drag.lock()) {
-                m.view.domain.x = l.x_domain;
-                if e.shift {
-                    m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                } else {
-                    m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                    l.set_x_domain(m.view.domain.x);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_up(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_up.lock(), model_up.lock()) {
-                m.view.domain.x = l.x_domain;
-                if let Some(sel) = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height) {
-                    l.set_selection_x(Some(sel));
-                }
-                m.on_drag_end();
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag_end(move |_e| {
-            if let Ok(mut m) = model_drag_end.lock() {
-                m.on_drag_end();
-            }
-        })
-        .child(
-            canvas(move |ctx, bounds| {
-                if let (Ok(l), Ok(mut m)) = (link_plot.lock(), model_plot.lock()) {
-                    m.view.domain.x = l.x_domain;
-                    m.render_plot(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full(),
-        )
-        .child(
-            canvas(move |ctx, bounds| {
-                if let (Ok(l), Ok(mut m)) = (link_overlay.lock(), model_overlay.lock()) {
-                    m.view.domain.x = l.x_domain;
-                    // Selection highlight (committed).
-                    if let Some((a, b)) = l.selection_x {
-                        let (px, py, pw, ph) = m.plot_rect(bounds.width, bounds.height);
-                        if pw > 0.0 && ph > 0.0 {
-                            let xa = m.view.x_to_px(a, px, pw);
-                            let xb = m.view.x_to_px(b, px, pw);
-                            let x0 = xa.min(xb).clamp(px, px + pw);
-                            let x1 = xa.max(xb).clamp(px, px + pw);
-                            ctx.fill_rect(
-                                Rect::new(x0, py, (x1 - x0).max(1.0), ph),
-                                0.0.into(),
-                                Brush::Solid(Color::rgba(1.0, 1.0, 1.0, 0.06)),
-                            );
-                        }
-                    }
-
-                    // Linked hover crosshair.
-                    if let Some(hx) = l.hover_x {
-                        let (px, _py, pw, _ph) = m.plot_rect(bounds.width, bounds.height);
-                        if pw > 0.0 {
-                            m.crosshair_x = Some(m.view.x_to_px(hx, px, pw));
-                        }
-                    }
-                    m.render_overlay(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full()
-            .foreground(),
-        )
+pub fn linked_line_chart_with_bindings(
+    handle: LineChartHandle,
+    link: ChartLinkHandle,
+    bindings: crate::ChartInputBindings,
+) -> impl ElementBuilder {
+    crate::xy_stack::linked_x_chart(handle.0, link, bindings)
 }

--- a/crates/blinc_charts/src/multi_line.rs
+++ b/crates/blinc_charts/src/multi_line.rs
@@ -412,7 +412,8 @@ impl MultiLineChartModel {
 
                 if end > a + 1 && end <= b {
                     let start_idx = self.cached_points_px.len();
-                    self.cached_points_px.extend_from_slice(&self.scratch_px[a..end]);
+                    self.cached_points_px
+                        .extend_from_slice(&self.scratch_px[a..end]);
                     let end_idx = self.cached_points_px.len();
                     self.cached_runs.push(CachedRun {
                         start: start_idx,

--- a/crates/blinc_charts/src/scatter.rs
+++ b/crates/blinc_charts/src/scatter.rs
@@ -1,8 +1,6 @@
 use std::sync::{Arc, Mutex};
 
 use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextStyle};
-use blinc_layout::canvas::canvas;
-use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
 use crate::brush::BrushX;
@@ -11,6 +9,7 @@ use crate::link::ChartLinkHandle;
 use crate::lod::{downsample_min_max, DownsampleParams};
 use crate::time_series::TimeSeriesF32;
 use crate::view::{ChartView, Domain1D, Domain2D};
+use crate::xy_stack::InteractiveXChartModel;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct SampleKey {
@@ -314,6 +313,68 @@ impl ScatterChartModel {
     }
 }
 
+impl InteractiveXChartModel for ScatterChartModel {
+    fn on_mouse_move(&mut self, local_x: f32, local_y: f32, w: f32, h: f32) {
+        ScatterChartModel::on_mouse_move(self, local_x, local_y, w, h);
+    }
+
+    fn on_mouse_down(&mut self, brush_modifier: bool, local_x: f32, w: f32, h: f32) {
+        ScatterChartModel::on_mouse_down(self, brush_modifier, local_x, w, h);
+    }
+
+    fn on_scroll(&mut self, delta_y: f32, cursor_x_px: f32, w: f32, h: f32) {
+        ScatterChartModel::on_scroll(self, delta_y, cursor_x_px, w, h);
+    }
+
+    fn on_pinch(&mut self, scale_delta: f32, cursor_x_px: f32, w: f32, h: f32) {
+        ScatterChartModel::on_pinch(self, scale_delta, cursor_x_px, w, h);
+    }
+
+    fn on_drag_pan_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        ScatterChartModel::on_drag_pan_total(self, drag_total_dx, w, h);
+    }
+
+    fn on_drag_brush_x_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        ScatterChartModel::on_drag_brush_x_total(self, drag_total_dx, w, h);
+    }
+
+    fn on_mouse_up_finish_brush_x(&mut self, w: f32, h: f32) -> Option<(f32, f32)> {
+        ScatterChartModel::on_mouse_up_finish_brush_x(self, w, h)
+    }
+
+    fn on_drag_end(&mut self) {
+        ScatterChartModel::on_drag_end(self);
+    }
+
+    fn render_plot(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        ScatterChartModel::render_plot(self, ctx, w, h);
+    }
+
+    fn render_overlay(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        ScatterChartModel::render_overlay(self, ctx, w, h);
+    }
+
+    fn plot_rect(&self, w: f32, h: f32) -> (f32, f32, f32, f32) {
+        self.view.plot_rect(w, h)
+    }
+
+    fn view(&self) -> &ChartView {
+        &self.view
+    }
+
+    fn view_mut(&mut self) -> &mut ChartView {
+        &mut self.view
+    }
+
+    fn crosshair_x_mut(&mut self) -> &mut Option<f32> {
+        &mut self.crosshair_x
+    }
+
+    fn is_brushing(&self) -> bool {
+        self.brush_x.is_active()
+    }
+}
+
 #[derive(Clone)]
 pub struct ScatterChartHandle(pub Arc<Mutex<ScatterChartModel>>);
 
@@ -324,198 +385,27 @@ impl ScatterChartHandle {
 }
 
 pub fn scatter_chart(handle: ScatterChartHandle) -> impl ElementBuilder {
-    let model_plot = handle.0.clone();
-    let model_overlay = handle.0.clone();
+    scatter_chart_with_bindings(handle, crate::ChartInputBindings::default())
+}
 
-    let model_move = handle.0.clone();
-    let model_scroll = handle.0.clone();
-    let model_pinch = handle.0.clone();
-    let model_down = handle.0.clone();
-    let model_drag = handle.0.clone();
-    let model_up = handle.0.clone();
-    let model_drag_end = handle.0.clone();
-
-    stack()
-        .w_full()
-        .h_full()
-        .overflow_clip()
-        .cursor(blinc_layout::element::CursorStyle::Crosshair)
-        .on_mouse_move(move |e| {
-            if let Ok(mut m) = model_move.lock() {
-                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_down(move |e| {
-            if let Ok(mut m) = model_down.lock() {
-                m.on_mouse_down(e.shift, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_scroll(move |e| {
-            if let Ok(mut m) = model_scroll.lock() {
-                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_pinch(move |e| {
-            if let Ok(mut m) = model_pinch.lock() {
-                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag(move |e| {
-            if let Ok(mut m) = model_drag.lock() {
-                if e.shift {
-                    m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                } else {
-                    m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_up(move |e| {
-            if let Ok(mut m) = model_up.lock() {
-                let _ = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height);
-                m.on_drag_end();
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag_end(move |_e| {
-            if let Ok(mut m) = model_drag_end.lock() {
-                m.on_drag_end();
-            }
-        })
-        .child(
-            canvas(move |ctx, bounds| {
-                if let Ok(mut m) = model_plot.lock() {
-                    m.render_plot(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full(),
-        )
-        .child(
-            canvas(move |ctx, bounds| {
-                if let Ok(mut m) = model_overlay.lock() {
-                    m.render_overlay(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full()
-            .foreground(),
-        )
+pub fn scatter_chart_with_bindings(
+    handle: ScatterChartHandle,
+    bindings: crate::ChartInputBindings,
+) -> impl ElementBuilder {
+    crate::xy_stack::x_chart(handle.0, bindings)
 }
 
 pub fn linked_scatter_chart(
     handle: ScatterChartHandle,
     link: ChartLinkHandle,
 ) -> impl ElementBuilder {
-    let model_plot = handle.0.clone();
-    let model_overlay = handle.0.clone();
+    linked_scatter_chart_with_bindings(handle, link, crate::ChartInputBindings::default())
+}
 
-    let model_move = handle.0.clone();
-    let model_scroll = handle.0.clone();
-    let model_pinch = handle.0.clone();
-    let model_down = handle.0.clone();
-    let model_drag = handle.0.clone();
-    let model_up = handle.0.clone();
-    let model_drag_end = handle.0.clone();
-
-    let link_move = link.clone();
-    let link_scroll = link.clone();
-    let link_pinch = link.clone();
-    let link_down = link.clone();
-    let link_drag = link.clone();
-    let link_up = link.clone();
-    let link_plot = link.clone();
-    let link_overlay = link.clone();
-
-    stack()
-        .w_full()
-        .h_full()
-        .overflow_clip()
-        .cursor(blinc_layout::element::CursorStyle::Crosshair)
-        .on_mouse_move(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_move.lock(), model_move.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
-                if let Some(p) = m.hover_point {
-                    l.set_hover_x(Some(p.x));
-                } else {
-                    l.set_hover_x(None);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_down(move |e| {
-            if let (Ok(_l), Ok(mut m)) = (link_down.lock(), model_down.lock()) {
-                m.on_mouse_down(e.shift, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_scroll(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_scroll.lock(), model_scroll.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
-                l.set_x_domain(m.view.domain.x);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_pinch(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_pinch.lock(), model_pinch.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
-                l.set_x_domain(m.view.domain.x);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_drag.lock(), model_drag.lock()) {
-                m.view.domain.x = l.x_domain;
-                if e.shift {
-                    m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                } else {
-                    m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                    l.set_x_domain(m.view.domain.x);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_up(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_up.lock(), model_up.lock()) {
-                if let Some((a, b)) = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height)
-                {
-                    l.set_selection_x(Some((a, b)));
-                }
-                m.on_drag_end();
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag_end(move |_e| {
-            if let Ok(mut m) = model_drag_end.lock() {
-                m.on_drag_end();
-            }
-        })
-        .child(
-            canvas(move |ctx, bounds| {
-                if let (Ok(l), Ok(mut m)) = (link_plot.lock(), model_plot.lock()) {
-                    m.view.domain.x = l.x_domain;
-                    m.render_plot(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full(),
-        )
-        .child(
-            canvas(move |ctx, bounds| {
-                if let (Ok(l), Ok(mut m)) = (link_overlay.lock(), model_overlay.lock()) {
-                    m.view.domain.x = l.x_domain;
-                    m.render_overlay(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full()
-            .foreground(),
-        )
+pub fn linked_scatter_chart_with_bindings(
+    handle: ScatterChartHandle,
+    link: ChartLinkHandle,
+    bindings: crate::ChartInputBindings,
+) -> impl ElementBuilder {
+    crate::xy_stack::linked_x_chart(handle.0, link, bindings)
 }

--- a/crates/blinc_charts/src/stacked_area.rs
+++ b/crates/blinc_charts/src/stacked_area.rs
@@ -1,8 +1,6 @@
 use std::sync::{Arc, Mutex};
 
 use blinc_core::{Brush, Color, DrawContext, Point, Rect, Stroke, TextStyle};
-use blinc_layout::canvas::canvas;
-use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
 use crate::brush::BrushX;
@@ -10,6 +8,7 @@ use crate::common::{draw_grid, fill_bg};
 use crate::link::ChartLinkHandle;
 use crate::time_series::TimeSeriesF32;
 use crate::view::{ChartView, Domain1D, Domain2D};
+use crate::xy_stack::InteractiveXChartModel;
 
 fn series_color(i: usize) -> Color {
     let hues = [
@@ -64,6 +63,40 @@ impl Default for StackedAreaChartStyle {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CacheKey {
+    x_min: u32,
+    x_max: u32,
+    plot_x: u32,
+    plot_y: u32,
+    plot_w: u32,
+    plot_h: u32,
+    mode: u8,
+    series_n: u32,
+    total_y_max: u32,
+}
+
+impl CacheKey {
+    fn new(model: &StackedAreaChartModel, plot: (f32, f32, f32, f32), series_n: usize) -> Self {
+        let (px, py, pw, ph) = plot;
+        let mode = match model.style.mode {
+            StackedAreaMode::Stacked => 0,
+            StackedAreaMode::Streamgraph => 1,
+        };
+        Self {
+            x_min: model.view.domain.x.min.to_bits(),
+            x_max: model.view.domain.x.max.to_bits(),
+            plot_x: px.to_bits(),
+            plot_y: py.to_bits(),
+            plot_w: pw.to_bits(),
+            plot_h: ph.to_bits(),
+            mode,
+            series_n: series_n as u32,
+            total_y_max: model.total_y_max.to_bits(),
+        }
+    }
+}
+
 pub struct StackedAreaChartModel {
     pub series: Vec<TimeSeriesF32>,
     pub view: ChartView,
@@ -76,6 +109,15 @@ pub struct StackedAreaChartModel {
 
     last_drag_total_x: Option<f32>,
     brush_x: BrushX,
+
+    // Cached geometry (local px) for plot rendering.
+    cached_key: Option<CacheKey>,
+    cached_samples: Vec<usize>,
+    cached_bottoms: Vec<f32>, // [s*sample_n + k]
+    cached_tops: Vec<f32>,    // [s*sample_n + k]
+    cached_band_paths: Vec<blinc_core::Path>,
+    cached_top_pts: Vec<Vec<Point>>, // per-band polyline (px)
+    scratch_vals: Vec<f32>,
 }
 
 impl StackedAreaChartModel {
@@ -125,6 +167,13 @@ impl StackedAreaChartModel {
             total_y_max: y_max,
             last_drag_total_x: None,
             brush_x: BrushX::default(),
+            cached_key: None,
+            cached_samples: Vec::new(),
+            cached_bottoms: Vec::new(),
+            cached_tops: Vec::new(),
+            cached_band_paths: Vec::new(),
+            cached_top_pts: Vec::new(),
+            scratch_vals: Vec::new(),
         })
     }
 
@@ -246,89 +295,148 @@ impl StackedAreaChartModel {
             StackedAreaMode::Streamgraph => Domain1D::new(-y_max * 0.55, y_max * 0.55),
         };
 
+        self.ensure_cached_geometry(w, h);
+        if self.cached_band_paths.is_empty() {
+            return;
+        }
+
+        // Draw from bottom to top. Each band gets a deterministic color.
+        let outline = Stroke::new(self.style.stroke_width.max(0.8));
+        for (s, path) in self.cached_band_paths.iter().enumerate() {
+            let color = series_color(s);
+            let fill = Brush::Solid(Color::rgba(color.r, color.g, color.b, 0.35));
+            let Some(top_pts) = self.cached_top_pts.get(s) else {
+                continue;
+            };
+            if top_pts.len() < 2 {
+                continue;
+            }
+            ctx.fill_path(path, fill);
+            ctx.stroke_polyline(top_pts, &outline, Brush::Solid(color));
+        }
+    }
+
+    fn ensure_cached_geometry(&mut self, w: f32, h: f32) {
+        let plot = self.plot_rect(w, h);
+        let (px, py, pw, ph) = plot;
+        if pw <= 0.0 || ph <= 0.0 {
+            self.cached_key = None;
+            self.cached_samples.clear();
+            self.cached_bottoms.clear();
+            self.cached_tops.clear();
+            self.cached_band_paths.clear();
+            self.cached_top_pts.clear();
+            return;
+        }
+
+        let series_n = self.series.len().min(16);
+        let key = CacheKey::new(self, plot, series_n);
+        if self.cached_key == Some(key) {
+            return;
+        }
+
+        self.cached_samples.clear();
+        self.cached_band_paths.clear();
+
+        if self.cached_top_pts.len() < series_n {
+            self.cached_top_pts.resize_with(series_n, Vec::new);
+        } else {
+            self.cached_top_pts.truncate(series_n);
+        }
+        for top in &mut self.cached_top_pts {
+            top.clear();
+        }
+
         let Some(first) = self.series.first() else {
+            self.cached_key = Some(key);
             return;
         };
 
         let i0 = first.lower_bound_x(self.view.domain.x.min);
         let i1 = first.upper_bound_x(self.view.domain.x.max);
         let i1 = i1.max(i0 + 1).min(first.len());
+        if i1 <= i0 + 1 {
+            self.cached_key = Some(key);
+            return;
+        }
 
         // Sample at ~1-2 points per pixel for smooth fills.
         let max_samples = (pw.ceil() as usize).clamp(64, 2_000);
         let step = ((i1 - i0) / max_samples.max(1)).max(1);
 
-        let series_n = self.series.len().min(16);
-        let mut xs = Vec::new();
-        xs.reserve(((i1 - i0) / step).max(2));
+        self.cached_samples.reserve(((i1 - i0) / step).max(2) + 1);
         for i in (i0..i1).step_by(step) {
-            xs.push(i);
+            self.cached_samples.push(i);
         }
-        if xs.len() < 2 {
+        let last = i1 - 1;
+        if self.cached_samples.last().copied() != Some(last) {
+            self.cached_samples.push(last);
+        }
+        if self.cached_samples.len() < 2 {
+            self.cached_key = Some(key);
             return;
         }
 
-        // Precompute stacked bottoms/tops in data coords for each sampled x.
-        // tops[s][k] = y_top, bottoms[s][k] = y_bottom (data space).
-        let sample_n = xs.len();
-        let mut bottoms: Vec<Vec<f32>> = vec![vec![0.0; sample_n]; series_n];
-        let mut tops: Vec<Vec<f32>> = vec![vec![0.0; sample_n]; series_n];
+        let sample_n = self.cached_samples.len();
+        let needed = series_n * sample_n;
+        self.cached_bottoms.resize(needed, 0.0);
+        self.cached_tops.resize(needed, 0.0);
 
-        for (k, &i) in xs.iter().enumerate() {
-            let mut vals = vec![0.0f32; series_n];
+        self.scratch_vals.clear();
+        self.scratch_vals.resize(series_n, 0.0);
+
+        for (k, &i) in self.cached_samples.iter().enumerate() {
             let mut sum = 0.0f32;
             for s in 0..series_n {
                 let v = self.series[s].y[i];
                 let v = if v.is_finite() { v.max(0.0) } else { 0.0 };
-                vals[s] = v;
+                self.scratch_vals[s] = v;
                 sum += v;
             }
+
             let baseline = match self.style.mode {
                 StackedAreaMode::Stacked => 0.0,
                 StackedAreaMode::Streamgraph => -0.5 * sum,
             };
             let mut cur = baseline;
             for s in 0..series_n {
-                bottoms[s][k] = cur;
-                cur += vals[s];
-                tops[s][k] = cur;
+                self.cached_bottoms[s * sample_n + k] = cur;
+                cur += self.scratch_vals[s];
+                self.cached_tops[s * sample_n + k] = cur;
             }
         }
 
-        // Draw from bottom to top. Each band gets a deterministic color.
-        let outline = Stroke::new(self.style.stroke_width.max(0.8));
+        self.cached_band_paths.reserve(series_n);
         for s in 0..series_n {
-            let color = series_color(s);
-            let fill = Brush::Solid(Color::rgba(color.r, color.g, color.b, 0.35));
+            let top_pts = &mut self.cached_top_pts[s];
+            top_pts.reserve(sample_n);
 
-            let mut top_pts = Vec::with_capacity(sample_n);
-            let mut bot_pts = Vec::with_capacity(sample_n);
-            for (k, &i) in xs.iter().enumerate() {
+            let mut path: Option<blinc_core::Path> = None;
+            for (k, &i) in self.cached_samples.iter().enumerate() {
                 let x = first.x[i];
-                top_pts.push(
-                    self.view
-                        .data_to_px(Point::new(x, tops[s][k]), px, py, pw, ph),
-                );
-                bot_pts.push(
-                    self.view
-                        .data_to_px(Point::new(x, bottoms[s][k]), px, py, pw, ph),
-                );
-            }
-            if top_pts.len() < 2 {
-                continue;
+                let y = self.cached_tops[s * sample_n + k];
+                let p = self.view.data_to_px(Point::new(x, y), px, py, pw, ph);
+                top_pts.push(p);
+                path = Some(match path {
+                    None => blinc_core::Path::new().move_to(p.x, p.y),
+                    Some(prev) => prev.line_to(p.x, p.y),
+                });
             }
 
-            let mut path = blinc_core::Path::new().move_to(top_pts[0].x, top_pts[0].y);
-            for p in &top_pts[1..] {
-                path = path.line_to(p.x, p.y);
-            }
-            for p in bot_pts.iter().rev() {
+            let Some(mut path) = path else {
+                continue;
+            };
+            for (k, &i) in self.cached_samples.iter().enumerate().rev() {
+                let x = first.x[i];
+                let y = self.cached_bottoms[s * sample_n + k];
+                let p = self.view.data_to_px(Point::new(x, y), px, py, pw, ph);
                 path = path.line_to(p.x, p.y);
             }
             path = path.close();
-            ctx.fill_path(&path, fill);
-            ctx.stroke_polyline(&top_pts, &outline, Brush::Solid(color));
+            self.cached_band_paths.push(path);
         }
+
+        self.cached_key = Some(key);
     }
 
     pub fn render_overlay(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
@@ -364,6 +472,68 @@ impl StackedAreaChartModel {
     }
 }
 
+impl InteractiveXChartModel for StackedAreaChartModel {
+    fn on_mouse_move(&mut self, local_x: f32, local_y: f32, w: f32, h: f32) {
+        StackedAreaChartModel::on_mouse_move(self, local_x, local_y, w, h);
+    }
+
+    fn on_mouse_down(&mut self, brush_modifier: bool, local_x: f32, w: f32, h: f32) {
+        StackedAreaChartModel::on_mouse_down(self, brush_modifier, local_x, w, h);
+    }
+
+    fn on_scroll(&mut self, delta_y: f32, cursor_x_px: f32, w: f32, h: f32) {
+        StackedAreaChartModel::on_scroll(self, delta_y, cursor_x_px, w, h);
+    }
+
+    fn on_pinch(&mut self, scale_delta: f32, cursor_x_px: f32, w: f32, h: f32) {
+        StackedAreaChartModel::on_pinch(self, scale_delta, cursor_x_px, w, h);
+    }
+
+    fn on_drag_pan_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        StackedAreaChartModel::on_drag_pan_total(self, drag_total_dx, w, h);
+    }
+
+    fn on_drag_brush_x_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        StackedAreaChartModel::on_drag_brush_x_total(self, drag_total_dx, w, h);
+    }
+
+    fn on_mouse_up_finish_brush_x(&mut self, w: f32, h: f32) -> Option<(f32, f32)> {
+        StackedAreaChartModel::on_mouse_up_finish_brush_x(self, w, h)
+    }
+
+    fn on_drag_end(&mut self) {
+        StackedAreaChartModel::on_drag_end(self);
+    }
+
+    fn render_plot(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        StackedAreaChartModel::render_plot(self, ctx, w, h);
+    }
+
+    fn render_overlay(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        StackedAreaChartModel::render_overlay(self, ctx, w, h);
+    }
+
+    fn plot_rect(&self, w: f32, h: f32) -> (f32, f32, f32, f32) {
+        self.view.plot_rect(w, h)
+    }
+
+    fn view(&self) -> &ChartView {
+        &self.view
+    }
+
+    fn view_mut(&mut self) -> &mut ChartView {
+        &mut self.view
+    }
+
+    fn crosshair_x_mut(&mut self) -> &mut Option<f32> {
+        &mut self.crosshair_x
+    }
+
+    fn is_brushing(&self) -> bool {
+        self.brush_x.is_active()
+    }
+}
+
 #[derive(Clone)]
 pub struct StackedAreaChartHandle(pub Arc<Mutex<StackedAreaChartModel>>);
 
@@ -374,204 +544,27 @@ impl StackedAreaChartHandle {
 }
 
 pub fn stacked_area_chart(handle: StackedAreaChartHandle) -> impl ElementBuilder {
-    let model_plot = handle.0.clone();
-    let model_overlay = handle.0.clone();
+    stacked_area_chart_with_bindings(handle, crate::ChartInputBindings::default())
+}
 
-    let model_move = handle.0.clone();
-    let model_scroll = handle.0.clone();
-    let model_pinch = handle.0.clone();
-    let model_down = handle.0.clone();
-    let model_drag = handle.0.clone();
-    let model_up = handle.0.clone();
-    let model_drag_end = handle.0.clone();
-
-    stack()
-        .w_full()
-        .h_full()
-        .overflow_clip()
-        .cursor(blinc_layout::element::CursorStyle::Crosshair)
-        .on_mouse_move(move |e| {
-            if let Ok(mut m) = model_move.lock() {
-                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_down(move |e| {
-            if let Ok(mut m) = model_down.lock() {
-                m.on_mouse_down(e.shift, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_scroll(move |e| {
-            if let Ok(mut m) = model_scroll.lock() {
-                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_pinch(move |e| {
-            if let Ok(mut m) = model_pinch.lock() {
-                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag(move |e| {
-            if let Ok(mut m) = model_drag.lock() {
-                if e.shift {
-                    m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                } else {
-                    m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_up(move |e| {
-            if let Ok(mut m) = model_up.lock() {
-                let _ = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height);
-                m.on_drag_end();
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag_end(move |_e| {
-            if let Ok(mut m) = model_drag_end.lock() {
-                m.on_drag_end();
-            }
-        })
-        .child(
-            canvas(move |ctx, bounds| {
-                if let Ok(mut m) = model_plot.lock() {
-                    m.render_plot(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full(),
-        )
-        .child(
-            canvas(move |ctx, bounds| {
-                if let Ok(mut m) = model_overlay.lock() {
-                    m.render_overlay(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full()
-            .foreground(),
-        )
+pub fn stacked_area_chart_with_bindings(
+    handle: StackedAreaChartHandle,
+    bindings: crate::ChartInputBindings,
+) -> impl ElementBuilder {
+    crate::xy_stack::x_chart(handle.0, bindings)
 }
 
 pub fn linked_stacked_area_chart(
     handle: StackedAreaChartHandle,
     link: ChartLinkHandle,
 ) -> impl ElementBuilder {
-    let model_plot = handle.0.clone();
-    let model_overlay = handle.0.clone();
+    linked_stacked_area_chart_with_bindings(handle, link, crate::ChartInputBindings::default())
+}
 
-    let model_move = handle.0.clone();
-    let model_scroll = handle.0.clone();
-    let model_pinch = handle.0.clone();
-    let model_down = handle.0.clone();
-    let model_drag = handle.0.clone();
-    let model_up = handle.0.clone();
-    let model_drag_end = handle.0.clone();
-
-    let link_move = link.clone();
-    let link_scroll = link.clone();
-    let link_pinch = link.clone();
-    let link_down = link.clone();
-    let link_drag = link.clone();
-    let link_up = link.clone();
-    let link_plot = link.clone();
-    let link_overlay = link.clone();
-
-    stack()
-        .w_full()
-        .h_full()
-        .overflow_clip()
-        .cursor(blinc_layout::element::CursorStyle::Crosshair)
-        .on_mouse_move(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_move.lock(), model_move.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
-                if let Some(x) = m.hover_x {
-                    l.set_hover_x(Some(x));
-                } else {
-                    l.set_hover_x(None);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_down(move |e| {
-            if let (Ok(_l), Ok(mut m)) = (link_down.lock(), model_down.lock()) {
-                m.on_mouse_down(e.shift, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_scroll(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_scroll.lock(), model_scroll.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
-                l.set_x_domain(m.view.domain.x);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_pinch(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_pinch.lock(), model_pinch.lock()) {
-                m.view.domain.x = l.x_domain;
-                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
-                l.set_x_domain(m.view.domain.x);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_drag.lock(), model_drag.lock()) {
-                m.view.domain.x = l.x_domain;
-                if e.shift {
-                    m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                } else {
-                    m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                    l.set_x_domain(m.view.domain.x);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_up(move |e| {
-            if let (Ok(mut l), Ok(mut m)) = (link_up.lock(), model_up.lock()) {
-                if let Some((a, b)) = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height)
-                {
-                    l.set_selection_x(Some((a, b)));
-                }
-                m.on_drag_end();
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag_end(move |_e| {
-            if let Ok(mut m) = model_drag_end.lock() {
-                m.on_drag_end();
-            }
-        })
-        .child(
-            canvas(move |ctx, bounds| {
-                if let (Ok(l), Ok(mut m)) = (link_plot.lock(), model_plot.lock()) {
-                    m.view.domain.x = l.x_domain;
-                    m.render_plot(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full(),
-        )
-        .child(
-            canvas(move |ctx, bounds| {
-                if let (Ok(l), Ok(mut m)) = (link_overlay.lock(), model_overlay.lock()) {
-                    m.view.domain.x = l.x_domain;
-                    if let Some(hx) = l.hover_x {
-                        let (px, _py, pw, _ph) = m.plot_rect(bounds.width, bounds.height);
-                        if pw > 0.0 {
-                            m.crosshair_x = Some(m.view.x_to_px(hx, px, pw));
-                        }
-                    }
-                    m.render_overlay(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full()
-            .foreground(),
-        )
+pub fn linked_stacked_area_chart_with_bindings(
+    handle: StackedAreaChartHandle,
+    link: ChartLinkHandle,
+    bindings: crate::ChartInputBindings,
+) -> impl ElementBuilder {
+    crate::xy_stack::linked_x_chart(handle.0, link, bindings)
 }

--- a/crates/blinc_charts/src/statistics.rs
+++ b/crates/blinc_charts/src/statistics.rs
@@ -1,13 +1,12 @@
 use std::sync::{Arc, Mutex};
 
 use blinc_core::{Brush, Color, DrawContext, Point, Rect, Stroke, TextStyle};
-use blinc_layout::canvas::canvas;
-use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
 use crate::brush::BrushX;
 use crate::common::{draw_grid, fill_bg};
 use crate::view::{ChartView, Domain1D, Domain2D};
+use crate::xy_stack::InteractiveXChartModel;
 
 #[derive(Clone, Debug)]
 pub struct StatisticsChartStyle {
@@ -379,6 +378,68 @@ impl StatisticsChartModel {
     }
 }
 
+impl InteractiveXChartModel for StatisticsChartModel {
+    fn on_mouse_move(&mut self, local_x: f32, local_y: f32, w: f32, h: f32) {
+        StatisticsChartModel::on_mouse_move(self, local_x, local_y, w, h);
+    }
+
+    fn on_mouse_down(&mut self, brush_modifier: bool, local_x: f32, w: f32, h: f32) {
+        StatisticsChartModel::on_mouse_down(self, brush_modifier, local_x, w, h);
+    }
+
+    fn on_scroll(&mut self, delta_y: f32, cursor_x_px: f32, w: f32, h: f32) {
+        StatisticsChartModel::on_scroll(self, delta_y, cursor_x_px, w, h);
+    }
+
+    fn on_pinch(&mut self, scale_delta: f32, cursor_x_px: f32, w: f32, h: f32) {
+        StatisticsChartModel::on_pinch(self, scale_delta, cursor_x_px, w, h);
+    }
+
+    fn on_drag_pan_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        StatisticsChartModel::on_drag_pan_total(self, drag_total_dx, w, h);
+    }
+
+    fn on_drag_brush_x_total(&mut self, drag_total_dx: f32, w: f32, h: f32) {
+        StatisticsChartModel::on_drag_brush_x_total(self, drag_total_dx, w, h);
+    }
+
+    fn on_mouse_up_finish_brush_x(&mut self, w: f32, h: f32) -> Option<(f32, f32)> {
+        StatisticsChartModel::on_mouse_up_finish_brush_x(self, w, h)
+    }
+
+    fn on_drag_end(&mut self) {
+        StatisticsChartModel::on_drag_end(self);
+    }
+
+    fn render_plot(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        StatisticsChartModel::render_plot(self, ctx, w, h);
+    }
+
+    fn render_overlay(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+        StatisticsChartModel::render_overlay(self, ctx, w, h);
+    }
+
+    fn plot_rect(&self, w: f32, h: f32) -> (f32, f32, f32, f32) {
+        self.view.plot_rect(w, h)
+    }
+
+    fn view(&self) -> &ChartView {
+        &self.view
+    }
+
+    fn view_mut(&mut self) -> &mut ChartView {
+        &mut self.view
+    }
+
+    fn crosshair_x_mut(&mut self) -> &mut Option<f32> {
+        &mut self.crosshair_x
+    }
+
+    fn is_brushing(&self) -> bool {
+        self.brush_x.is_active()
+    }
+}
+
 #[derive(Clone)]
 pub struct StatisticsChartHandle(pub Arc<Mutex<StatisticsChartModel>>);
 
@@ -389,84 +450,12 @@ impl StatisticsChartHandle {
 }
 
 pub fn statistics_chart(handle: StatisticsChartHandle) -> impl ElementBuilder {
-    let model_plot = handle.0.clone();
-    let model_overlay = handle.0.clone();
-    let model_move = handle.0.clone();
-    let model_scroll = handle.0.clone();
-    let model_pinch = handle.0.clone();
-    let model_down = handle.0.clone();
-    let model_drag = handle.0.clone();
-    let model_up = handle.0.clone();
-    let model_drag_end = handle.0.clone();
+    statistics_chart_with_bindings(handle, crate::ChartInputBindings::default())
+}
 
-    stack()
-        .w_full()
-        .h_full()
-        .overflow_clip()
-        .cursor(blinc_layout::element::CursorStyle::Crosshair)
-        .on_mouse_move(move |e| {
-            if let Ok(mut m) = model_move.lock() {
-                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_down(move |e| {
-            if let Ok(mut m) = model_down.lock() {
-                m.on_mouse_down(e.shift, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_scroll(move |e| {
-            if let Ok(mut m) = model_scroll.lock() {
-                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_pinch(move |e| {
-            if let Ok(mut m) = model_pinch.lock() {
-                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag(move |e| {
-            if let Ok(mut m) = model_drag.lock() {
-                if e.shift {
-                    m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                } else {
-                    m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
-                }
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_mouse_up(move |e| {
-            if let Ok(mut m) = model_up.lock() {
-                let _ = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height);
-                m.on_drag_end();
-                blinc_layout::stateful::request_redraw();
-            }
-        })
-        .on_drag_end(move |_e| {
-            if let Ok(mut m) = model_drag_end.lock() {
-                m.on_drag_end();
-            }
-        })
-        .child(
-            canvas(move |ctx, bounds| {
-                if let Ok(m) = model_plot.lock() {
-                    m.render_plot(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full(),
-        )
-        .child(
-            canvas(move |ctx, bounds| {
-                if let Ok(m) = model_overlay.lock() {
-                    m.render_overlay(ctx, bounds.width, bounds.height);
-                }
-            })
-            .w_full()
-            .h_full()
-            .foreground(),
-        )
+pub fn statistics_chart_with_bindings(
+    handle: StatisticsChartHandle,
+    bindings: crate::ChartInputBindings,
+) -> impl ElementBuilder {
+    crate::xy_stack::x_chart(handle.0, bindings)
 }

--- a/crates/blinc_charts/src/xy_stack.rs
+++ b/crates/blinc_charts/src/xy_stack.rs
@@ -1,0 +1,324 @@
+use std::sync::{Arc, Mutex};
+
+use blinc_core::{Brush, Color, DrawContext, Rect};
+use blinc_layout::canvas::canvas;
+use blinc_layout::element::CursorStyle;
+use blinc_layout::stack::stack;
+use blinc_layout::ElementBuilder;
+
+use crate::input::{ChartInputBindings, DragAction};
+use crate::link::ChartLinkHandle;
+use crate::view::ChartView;
+
+/// Common behaviors for X-only interactive charts (time-series style).
+///
+/// This is intentionally close to d3rs's pattern: the interaction state is kept
+/// on the model, and UI events simply mutate model state + request a redraw.
+pub(crate) trait InteractiveXChartModel: Send + 'static {
+    fn on_mouse_move(&mut self, local_x: f32, local_y: f32, w: f32, h: f32);
+    fn on_mouse_down(&mut self, brush_modifier: bool, local_x: f32, w: f32, h: f32);
+    fn on_scroll(&mut self, delta_y: f32, cursor_x_px: f32, w: f32, h: f32);
+    fn on_pinch(&mut self, scale_delta: f32, cursor_x_px: f32, w: f32, h: f32);
+    fn on_drag_pan_total(&mut self, drag_total_dx: f32, w: f32, h: f32);
+    fn on_drag_brush_x_total(&mut self, drag_total_dx: f32, w: f32, h: f32);
+    fn on_mouse_up_finish_brush_x(&mut self, w: f32, h: f32) -> Option<(f32, f32)>;
+    fn on_drag_end(&mut self);
+
+    fn render_plot(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32);
+    fn render_overlay(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32);
+
+    fn plot_rect(&self, w: f32, h: f32) -> (f32, f32, f32, f32);
+    fn view(&self) -> &ChartView;
+    fn view_mut(&mut self) -> &mut ChartView;
+    fn crosshair_x_mut(&mut self) -> &mut Option<f32>;
+
+    fn is_brushing(&self) -> bool;
+}
+
+fn drag_action(bindings: ChartInputBindings, e: &blinc_layout::event_handler::EventContext) -> DragAction {
+    if bindings.brush_drag.required.matches(e.shift, e.ctrl, e.alt, e.meta) {
+        return bindings.brush_drag.action;
+    }
+    if bindings.pan_drag.required.matches(e.shift, e.ctrl, e.alt, e.meta) {
+        return bindings.pan_drag.action;
+    }
+    DragAction::None
+}
+
+fn draw_link_selection_x(
+    ctx: &mut dyn DrawContext,
+    view: &ChartView,
+    plot_rect: (f32, f32, f32, f32),
+    selection_x: (f32, f32),
+) {
+    let (px, py, pw, ph) = plot_rect;
+    if pw <= 0.0 || ph <= 0.0 {
+        return;
+    }
+
+    let (a, b) = selection_x;
+    let xa = view.x_to_px(a, px, pw);
+    let xb = view.x_to_px(b, px, pw);
+    let x0 = xa.min(xb).clamp(px, px + pw);
+    let x1 = xa.max(xb).clamp(px, px + pw);
+    ctx.fill_rect(
+        Rect::new(x0, py, (x1 - x0).max(1.0), ph),
+        0.0.into(),
+        Brush::Solid(Color::rgba(1.0, 1.0, 1.0, 0.06)),
+    );
+}
+
+fn apply_link_hover_x<M: InteractiveXChartModel>(
+    model: &mut M,
+    hover_x: Option<f32>,
+    w: f32,
+    h: f32,
+) {
+    let (px, _py, pw, _ph) = model.plot_rect(w, h);
+    if pw <= 0.0 {
+        *model.crosshair_x_mut() = None;
+        return;
+    }
+
+    if let Some(hx) = hover_x {
+        *model.crosshair_x_mut() = Some(model.view().x_to_px(hx, px, pw));
+    } else {
+        *model.crosshair_x_mut() = None;
+    }
+}
+
+pub(crate) fn x_chart<M: InteractiveXChartModel>(
+    handle: Arc<Mutex<M>>,
+    bindings: ChartInputBindings,
+) -> impl ElementBuilder {
+    let model_plot = handle.clone();
+    let model_overlay = handle.clone();
+
+    let model_move = handle.clone();
+    let model_scroll = handle.clone();
+    let model_pinch = handle.clone();
+    let model_down = handle.clone();
+    let model_drag = handle.clone();
+    let model_up = handle.clone();
+    let model_drag_end = handle.clone();
+
+    stack()
+        .w_full()
+        .h_full()
+        .overflow_clip()
+        .cursor(CursorStyle::Crosshair)
+        .on_mouse_move(move |e| {
+            if let Ok(mut m) = model_move.lock() {
+                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_mouse_down(move |e| {
+            if let Ok(mut m) = model_down.lock() {
+                let brush_mod = bindings
+                    .brush_drag
+                    .required
+                    .matches(e.shift, e.ctrl, e.alt, e.meta);
+                m.on_mouse_down(brush_mod, e.local_x, e.bounds_width, e.bounds_height);
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_scroll(move |e| {
+            if let Ok(mut m) = model_scroll.lock() {
+                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_pinch(move |e| {
+            if let Ok(mut m) = model_pinch.lock() {
+                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_drag(move |e| {
+            if let Ok(mut m) = model_drag.lock() {
+                let action = if m.is_brushing() {
+                    DragAction::BrushX
+                } else {
+                    drag_action(bindings, e)
+                };
+                match action {
+                    DragAction::None => {}
+                    DragAction::PanX => m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height),
+                    DragAction::BrushX => m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height),
+                }
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_mouse_up(move |e| {
+            if let Ok(mut m) = model_up.lock() {
+                let _ = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height);
+                m.on_drag_end();
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_drag_end(move |_e| {
+            if let Ok(mut m) = model_drag_end.lock() {
+                m.on_drag_end();
+            }
+        })
+        .child(
+            canvas(move |ctx, bounds| {
+                if let Ok(mut m) = model_plot.lock() {
+                    m.render_plot(ctx, bounds.width, bounds.height);
+                }
+            })
+            .w_full()
+            .h_full(),
+        )
+        .child(
+            canvas(move |ctx, bounds| {
+                if let Ok(mut m) = model_overlay.lock() {
+                    m.render_overlay(ctx, bounds.width, bounds.height);
+                }
+            })
+            .w_full()
+            .h_full()
+            .foreground(),
+        )
+}
+
+pub(crate) fn linked_x_chart<M: InteractiveXChartModel>(
+    handle: Arc<Mutex<M>>,
+    link: ChartLinkHandle,
+    bindings: ChartInputBindings,
+) -> impl ElementBuilder {
+    let model_plot = handle.clone();
+    let model_overlay = handle.clone();
+
+    let model_move = handle.clone();
+    let model_scroll = handle.clone();
+    let model_pinch = handle.clone();
+    let model_down = handle.clone();
+    let model_drag = handle.clone();
+    let model_up = handle.clone();
+    let model_drag_end = handle.clone();
+
+    let link_move = link.clone();
+    let link_scroll = link.clone();
+    let link_pinch = link.clone();
+    let link_down = link.clone();
+    let link_drag = link.clone();
+    let link_up = link.clone();
+    let link_plot = link.clone();
+    let link_overlay = link.clone();
+
+    stack()
+        .w_full()
+        .h_full()
+        .overflow_clip()
+        .cursor(CursorStyle::Crosshair)
+        .on_mouse_move(move |e| {
+            if let (Ok(mut l), Ok(mut m)) = (link_move.lock(), model_move.lock()) {
+                m.view_mut().domain.x = l.x_domain;
+                m.on_mouse_move(e.local_x, e.local_y, e.bounds_width, e.bounds_height);
+
+                // Publish hover x in domain units (or None when out of plot).
+                let (px, _py, pw, _ph) = m.plot_rect(e.bounds_width, e.bounds_height);
+                if pw > 0.0 && m.crosshair_x_mut().is_some() {
+                    let x = m.view().px_to_x(e.local_x.clamp(px, px + pw), px, pw);
+                    l.set_hover_x(Some(x));
+                } else {
+                    l.set_hover_x(None);
+                }
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_mouse_down(move |e| {
+            if let (Ok(_l), Ok(mut m)) = (link_down.lock(), model_down.lock()) {
+                let brush_mod = bindings
+                    .brush_drag
+                    .required
+                    .matches(e.shift, e.ctrl, e.alt, e.meta);
+                m.on_mouse_down(brush_mod, e.local_x, e.bounds_width, e.bounds_height);
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_scroll(move |e| {
+            if let (Ok(mut l), Ok(mut m)) = (link_scroll.lock(), model_scroll.lock()) {
+                m.view_mut().domain.x = l.x_domain;
+                m.on_scroll(e.scroll_delta_y, e.local_x, e.bounds_width, e.bounds_height);
+                l.set_x_domain(m.view().domain.x);
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_pinch(move |e| {
+            if let (Ok(mut l), Ok(mut m)) = (link_pinch.lock(), model_pinch.lock()) {
+                m.view_mut().domain.x = l.x_domain;
+                m.on_pinch(e.pinch_scale, e.local_x, e.bounds_width, e.bounds_height);
+                l.set_x_domain(m.view().domain.x);
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_drag(move |e| {
+            if let (Ok(mut l), Ok(mut m)) = (link_drag.lock(), model_drag.lock()) {
+                m.view_mut().domain.x = l.x_domain;
+                let action = if m.is_brushing() {
+                    DragAction::BrushX
+                } else {
+                    drag_action(bindings, e)
+                };
+
+                match action {
+                    DragAction::None => {}
+                    DragAction::PanX => {
+                        m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
+                        l.set_x_domain(m.view().domain.x);
+                    }
+                    DragAction::BrushX => {
+                        m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height);
+                    }
+                }
+
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_mouse_up(move |e| {
+            if let (Ok(mut l), Ok(mut m)) = (link_up.lock(), model_up.lock()) {
+                m.view_mut().domain.x = l.x_domain;
+                if let Some(sel) = m.on_mouse_up_finish_brush_x(e.bounds_width, e.bounds_height) {
+                    l.set_selection_x(Some(sel));
+                }
+                m.on_drag_end();
+                blinc_layout::stateful::request_redraw();
+            }
+        })
+        .on_drag_end(move |_e| {
+            if let Ok(mut m) = model_drag_end.lock() {
+                m.on_drag_end();
+            }
+        })
+        .child(
+            canvas(move |ctx, bounds| {
+                if let (Ok(l), Ok(mut m)) = (link_plot.lock(), model_plot.lock()) {
+                    m.view_mut().domain.x = l.x_domain;
+                    m.render_plot(ctx, bounds.width, bounds.height);
+                }
+            })
+            .w_full()
+            .h_full(),
+        )
+        .child(
+            canvas(move |ctx, bounds| {
+                if let (Ok(l), Ok(mut m)) = (link_overlay.lock(), model_overlay.lock()) {
+                    m.view_mut().domain.x = l.x_domain;
+
+                    if let Some(sel) = l.selection_x {
+                        draw_link_selection_x(ctx, m.view(), m.plot_rect(bounds.width, bounds.height), sel);
+                    }
+
+                    apply_link_hover_x(&mut *m, l.hover_x, bounds.width, bounds.height);
+                    m.render_overlay(ctx, bounds.width, bounds.height);
+                }
+            })
+            .w_full()
+            .h_full()
+            .foreground(),
+        )
+}
+

--- a/crates/blinc_charts/src/xy_stack.rs
+++ b/crates/blinc_charts/src/xy_stack.rs
@@ -35,11 +35,22 @@ pub(crate) trait InteractiveXChartModel: Send + 'static {
     fn is_brushing(&self) -> bool;
 }
 
-fn drag_action(bindings: ChartInputBindings, e: &blinc_layout::event_handler::EventContext) -> DragAction {
-    if bindings.brush_drag.required.matches(e.shift, e.ctrl, e.alt, e.meta) {
+fn drag_action(
+    bindings: ChartInputBindings,
+    e: &blinc_layout::event_handler::EventContext,
+) -> DragAction {
+    if bindings
+        .brush_drag
+        .required
+        .matches(e.shift, e.ctrl, e.alt, e.meta)
+    {
         return bindings.brush_drag.action;
     }
-    if bindings.pan_drag.required.matches(e.shift, e.ctrl, e.alt, e.meta) {
+    if bindings
+        .pan_drag
+        .required
+        .matches(e.shift, e.ctrl, e.alt, e.meta)
+    {
         return bindings.pan_drag.action;
     }
     DragAction::None
@@ -144,8 +155,12 @@ pub(crate) fn x_chart<M: InteractiveXChartModel>(
                 };
                 match action {
                     DragAction::None => {}
-                    DragAction::PanX => m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height),
-                    DragAction::BrushX => m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height),
+                    DragAction::PanX => {
+                        m.on_drag_pan_total(e.drag_delta_x, e.bounds_width, e.bounds_height)
+                    }
+                    DragAction::BrushX => {
+                        m.on_drag_brush_x_total(e.drag_delta_x, e.bounds_width, e.bounds_height)
+                    }
                 }
                 blinc_layout::stateful::request_redraw();
             }
@@ -309,7 +324,12 @@ pub(crate) fn linked_x_chart<M: InteractiveXChartModel>(
                     m.view_mut().domain.x = l.x_domain;
 
                     if let Some(sel) = l.selection_x {
-                        draw_link_selection_x(ctx, m.view(), m.plot_rect(bounds.width, bounds.height), sel);
+                        draw_link_selection_x(
+                            ctx,
+                            m.view(),
+                            m.plot_rect(bounds.width, bounds.height),
+                            sel,
+                        );
                     }
 
                     apply_link_hover_x(&mut *m, l.hover_x, bounds.width, bounds.height);
@@ -321,4 +341,3 @@ pub(crate) fn linked_x_chart<M: InteractiveXChartModel>(
             .foreground(),
         )
 }
-


### PR DESCRIPTION
## Summary\n- extract shared x-interaction stack builder for interactive time-series style charts\n- migrate line/area/scatter/bar/candlestick/multi-line/stacked-area/statistics/histogram to shared stack\n- expose configurable chart input bindings and add *_with_bindings constructors\n- improve rendering performance with geometry/scratch-buffer caching (multi-line, stacked-area, bar, candlestick)\n- make linked charts consistently render linked hover and x-selection overlays\n\n## Verification\n- cargo test -p blinc_charts