### PR TITLE
feat(blinc_platform_desktop): synthesize scroll end after inactivity

### DIFF
--- a/extensions/blinc_platform_desktop/src/event_loop.rs
+++ b/extensions/blinc_platform_desktop/src/event_loop.rs
@@ -343,7 +343,8 @@ where
             return;
         }
 
-        if let Some(deadline) = scroll_end_deadline(self.scroll_end_pending, self.last_scroll_event_at)
+        if let Some(deadline) =
+            scroll_end_deadline(self.scroll_end_pending, self.last_scroll_event_at)
         {
             event_loop.set_control_flow(WinitControlFlow::WaitUntil(deadline));
         }
@@ -363,9 +364,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        scroll_end_deadline, should_emit_synthetic_scroll_end, SCROLL_END_DEBOUNCE,
-    };
+    use super::{scroll_end_deadline, should_emit_synthetic_scroll_end, SCROLL_END_DEBOUNCE};
     use std::time::{Duration, Instant};
 
     #[test]


### PR DESCRIPTION
## Summary
- add a short inactivity debounce window for wheel/trackpad scroll end
- emit synthetic `ScrollEnd` in `about_to_wait` when no end phase arrives
- clear pending state when real `TouchPhase::Ended/Cancelled` is received
- add unit test for debounce threshold logic

## Why
Some platforms/drivers delay or skip `TouchPhase::Ended` for wheel/trackpad gestures, which leaves scroll interactions in a stuck-active state. This change keeps scroll UX responsive while preserving existing pinch gesture behavior and macOS activation policy handling.

## Test
- `cargo test -p blinc_platform_desktop`
