### PR TITLE
Fix recorder bridge and make blinc_debugger functional

### DIFF
--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -2737,7 +2737,13 @@ impl WindowedApp {
                                             }
 
                                             // Dispatch KEY_DOWN for all keys
-                                            router.on_key_down(key_code);
+                                            router.on_key_down_with_modifiers(
+                                                key_code,
+                                                mods.shift,
+                                                mods.ctrl,
+                                                mods.alt,
+                                                mods.meta,
+                                            );
 
                                             // For character-producing keys, dispatch TEXT_INPUT
                                             // We use broadcast dispatch so any focused text input can receive it
@@ -2772,7 +2778,13 @@ impl WindowedApp {
                                             }
                                         }
                                         KeyState::Released => {
-                                            router.on_key_up(key_code);
+                                            router.on_key_up_with_modifiers(
+                                                key_code,
+                                                mods.shift,
+                                                mods.ctrl,
+                                                mods.alt,
+                                                mods.meta,
+                                            );
                                         }
                                     }
                                 },

--- a/crates/blinc_debugger/README.md
+++ b/crates/blinc_debugger/README.md
@@ -40,9 +40,14 @@ blinc-debugger recording.json
 # Open a recording file (flag)
 blinc-debugger --file recording.json
 
-# Connect to a running debug server (Unix socket path or app name)
-blinc-debugger --connect /tmp/blinc/blinc_app.sock
+# Connect to a running debug server (default app socket mapping)
 blinc-debugger --connect blinc_app
+
+# Connect to an explicit Unix socket path
+blinc-debugger --connect unix:/tmp/blinc/blinc_app.sock
+
+# Connect to a TCP debug server
+blinc-debugger --connect tcp:127.0.0.1:7331
 
 # Or launch and open via UI
 blinc-debugger

--- a/crates/blinc_debugger/README.md
+++ b/crates/blinc_debugger/README.md
@@ -13,11 +13,11 @@ Visual debugger application for Blinc UI recordings.
 
 ## Features
 
-- **Element Tree**: Hierarchical view of UI elements with diff highlighting
-- **UI Preview**: Visual preview with debug overlays
-- **Inspector Panel**: Detailed element properties and styles
-- **Event Timeline**: Playback controls for recorded events
-- **State Viewer**: Track reactive state changes
+- **Element Tree**: Hierarchical view of recorded element trees with selection
+- **UI Preview**: Snapshot preview with cursor/bounds/zoom controls
+- **Inspector Panel**: Selected element properties and bounds
+- **Event Timeline**: Play/pause/step/seek/speed controls for recorded sessions
+- **Server Import**: Load recording export from a running debug server (`--connect`)
 
 ## Installation
 
@@ -84,10 +84,11 @@ blinc-debugger
 
 ### UI Preview
 
-- Zoom and pan
-- Debug overlays (bounds, padding, margins)
+- Zoom control
+- Cursor overlay
+- Bounds overlay
 - Element highlighting on selection
-- Snapshot comparison (before/after)
+- Snapshot metadata (size/element count)
 
 ### Inspector Panel
 
@@ -101,18 +102,7 @@ blinc-debugger
 
 - Play/pause/step through events
 - Jump to specific timestamp
-- Filter by event type
-- Event details on hover
-
-## Keyboard Shortcuts
-
-| Shortcut | Action |
-|----------|--------|
-| `Space` | Play/Pause |
-| `←` / `→` | Step backward/forward |
-| `Cmd/Ctrl + O` | Open recording |
-| `Cmd/Ctrl + F` | Search elements |
-| `Escape` | Deselect |
+- Change playback speed
 
 ## Recording Format
 
@@ -120,12 +110,14 @@ The debugger reads JSON files created by `blinc_recorder`:
 
 ```json
 {
-  "version": "1.0",
+  "config": {
+    "app_name": "my_app"
+  },
   "events": [...],
   "snapshots": [...],
-  "metadata": {
-    "app_name": "My App",
-    "recorded_at": "2024-01-01T00:00:00Z"
+  "stats": {
+    "total_events": 123,
+    "total_snapshots": 45
   }
 }
 ```

--- a/crates/blinc_debugger/README.md
+++ b/crates/blinc_debugger/README.md
@@ -34,8 +34,15 @@ cargo build -p blinc_debugger --release
 ## Usage
 
 ```bash
-# Open a recording file
+# Open a recording file (positional)
 blinc-debugger recording.json
+
+# Open a recording file (flag)
+blinc-debugger --file recording.json
+
+# Connect to a running debug server (Unix socket path or app name)
+blinc-debugger --connect /tmp/blinc/blinc_app.sock
+blinc-debugger --connect blinc_app
 
 # Or launch and open via UI
 blinc-debugger

--- a/crates/blinc_debugger/src/app.rs
+++ b/crates/blinc_debugger/src/app.rs
@@ -82,12 +82,14 @@ impl AppState {
                 let update = player.update();
                 self.apply_frame_update(update);
             } else {
-                self.current_snapshot = player
+                if let Some(snapshot) = player
                     .all_snapshots()
                     .iter()
                     .rfind(|s| s.timestamp <= player.position())
                     .cloned()
-                    .or_else(|| self.current_snapshot.take());
+                {
+                    self.current_snapshot = Some(snapshot);
+                }
             }
 
             self.timeline_state.position = player.position();
@@ -457,15 +459,15 @@ fn request_export_over_unix_socket(socket: &str) -> Result<RecordingExport> {
     use std::os::unix::net::UnixStream;
 
     let mut stream = UnixStream::connect(socket)?;
-    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
-    stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
     request_export_over_stream(&mut stream)
 }
 
 fn request_export_over_tcp(addr: &str) -> Result<RecordingExport> {
     let mut stream = std::net::TcpStream::connect(addr)?;
-    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
-    stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
     request_export_over_stream(&mut stream)
 }
 

--- a/crates/blinc_debugger/src/app.rs
+++ b/crates/blinc_debugger/src/app.rs
@@ -1,25 +1,22 @@
-//! Main application module for the debugger
-//!
-//! Handles window creation, event loop, and top-level state management.
-//! Layout matches the Phase 12 plan with four main panels:
-//! - Tree Panel (left): Element tree with diff
-//! - Preview Panel (center): UI preview
-//! - Inspector Panel (right): Element properties
-//! - Timeline Panel (bottom): Event timeline with scrubber
+//! Main application module for the debugger.
 
 use crate::panels::{
     InspectorPanel, PreviewConfig, PreviewPanel, TimelinePanel, TimelinePanelState, TreePanel,
     TreePanelState,
 };
 use crate::theme::DebuggerColors;
-use anyhow::Result;
+use anyhow::{anyhow, bail, Context, Result};
 use blinc_app::windowed::{WindowedApp, WindowedContext};
 use blinc_app::WindowConfig;
 use blinc_layout::prelude::*;
-use blinc_recorder::replay::{ReplayConfig, ReplayPlayer, ReplayState};
-use blinc_recorder::{ElementSnapshot, RecordingExport, TreeSnapshot};
+use blinc_recorder::replay::{
+    FrameUpdate, ReplayConfig, ReplayPlayer, ReplayState, SimulatedInput,
+};
+use blinc_recorder::{RecordingExport, Timestamp, TreeSnapshot};
+use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::Duration;
 
 /// Application state
 #[derive(Default)]
@@ -38,69 +35,207 @@ pub struct AppState {
     pub preview_config: PreviewConfig,
     /// Timeline state
     pub timeline_state: TimelinePanelState,
+    /// Last known cursor position from replay
+    pub cursor_position: Option<(f32, f32)>,
     /// Server address
     pub server_addr: Option<String>,
 }
 
 impl AppState {
-    /// Load a recording from file
+    /// Load a recording from file.
     pub fn load_recording(&mut self, path: &PathBuf) -> Result<()> {
         let contents = std::fs::read_to_string(path)?;
         let export: RecordingExport = serde_json::from_str(&contents)?;
-
-        let player = ReplayPlayer::new(export.clone(), ReplayConfig::interactive());
-
-        // Update timeline state with duration
-        self.timeline_state.duration = player.duration();
-        self.timeline_state.playback_state = ReplayState::Idle;
-
-        // Load initial snapshot if available
-        if let Some(snapshot) = export.snapshots.first() {
-            self.current_snapshot = Some(snapshot.clone());
-        }
-
-        self.recording = Some(export);
-        self.player = Some(Arc::new(Mutex::new(player)));
-
+        self.apply_recording(export);
         log::info!("Loaded recording from {}", path.display());
         Ok(())
     }
 
-    /// Get the selected element snapshot
-    pub fn selected_element(&self) -> Option<&ElementSnapshot> {
+    /// Load recording data received from server.
+    pub fn load_from_server(&mut self, addr: &str, export: RecordingExport) {
+        self.apply_recording(export);
+        self.server_addr = Some(addr.to_string());
+        log::info!("Loaded recording from server: {addr}");
+    }
+
+    /// Get the selected element snapshot.
+    pub fn selected_element(&self) -> Option<&blinc_recorder::ElementSnapshot> {
         let snapshot = self.current_snapshot.as_ref()?;
         let id = self.selected_element_id.as_ref()?;
         snapshot.elements.get(id)
     }
 
-    /// Get cursor position during replay
-    pub fn cursor_position(&self) -> Option<(f32, f32)> {
-        // TODO: Get from replay player's simulator
-        None
+    /// Tick replay state once per UI build.
+    pub fn tick(&mut self) {
+        let player_arc = self.player.clone();
+        if let Some(player_arc) = player_arc {
+            let mut player = match player_arc.lock() {
+                Ok(guard) => guard,
+                Err(_) => return,
+            };
+
+            if player.state() == ReplayState::Playing {
+                let update = player.update();
+                self.apply_frame_update(update);
+            } else {
+                self.current_snapshot = player
+                    .all_snapshots()
+                    .iter()
+                    .rfind(|s| s.timestamp <= player.position())
+                    .cloned()
+                    .or_else(|| self.current_snapshot.take());
+            }
+
+            self.timeline_state.position = player.position();
+            self.timeline_state.duration = player.duration();
+            self.timeline_state.playback_state = player.state();
+            self.timeline_state.speed = player.clock().speed();
+        }
+
+        self.ensure_selected_element_exists();
+    }
+
+    pub fn toggle_playback(&mut self) {
+        let player_arc = self.player.clone();
+        if let Some(player_arc) = player_arc {
+            if let Ok(mut player) = player_arc.lock() {
+                player.toggle();
+                self.timeline_state.playback_state = player.state();
+            }
+        }
+    }
+
+    pub fn step_back(&mut self) {
+        let player_arc = self.player.clone();
+        if let Some(player_arc) = player_arc {
+            if let Ok(mut player) = player_arc.lock() {
+                let update = player.step_back();
+                self.apply_frame_update(update);
+                self.timeline_state.position = player.position();
+                self.timeline_state.playback_state = player.state();
+            }
+        }
+    }
+
+    pub fn step_forward(&mut self) {
+        let player_arc = self.player.clone();
+        if let Some(player_arc) = player_arc {
+            if let Ok(mut player) = player_arc.lock() {
+                let update = player.step();
+                self.apply_frame_update(update);
+                self.timeline_state.position = player.position();
+                self.timeline_state.playback_state = player.state();
+            }
+        }
+    }
+
+    pub fn seek_normalized(&mut self, normalized: f32) {
+        let player_arc = self.player.clone();
+        if let Some(player_arc) = player_arc {
+            if let Ok(mut player) = player_arc.lock() {
+                let micros = (player.duration().as_micros() as f32 * normalized.clamp(0.0, 1.0))
+                    .round() as u64;
+                player.seek(Timestamp::from_micros(micros));
+                self.timeline_state.position = player.position();
+                self.timeline_state.playback_state = ReplayState::Paused;
+                self.current_snapshot = player
+                    .all_snapshots()
+                    .iter()
+                    .rfind(|s| s.timestamp <= player.position())
+                    .cloned();
+            }
+        }
+    }
+
+    pub fn set_playback_speed(&mut self, speed: f64) {
+        let player_arc = self.player.clone();
+        if let Some(player_arc) = player_arc {
+            if let Ok(mut player) = player_arc.lock() {
+                player.clock_mut().set_speed(speed);
+                self.timeline_state.speed = player.clock().speed();
+            }
+        }
+    }
+
+    fn apply_recording(&mut self, export: RecordingExport) {
+        let player = ReplayPlayer::new(export.clone(), ReplayConfig::interactive());
+        self.timeline_state.duration = player.duration();
+        self.timeline_state.position = Timestamp::zero();
+        self.timeline_state.playback_state = ReplayState::Idle;
+        self.timeline_state.speed = player.clock().speed();
+
+        self.current_snapshot = export.snapshots.first().cloned();
+        self.selected_element_id = self.current_snapshot.as_ref().and_then(|s| {
+            s.root_id
+                .clone()
+                .or_else(|| s.elements.keys().next().cloned())
+        });
+        self.cursor_position = None;
+
+        self.recording = Some(export);
+        self.player = Some(Arc::new(Mutex::new(player)));
+    }
+
+    fn apply_frame_update(&mut self, update: FrameUpdate) {
+        if let Some(snapshot) = update.snapshot {
+            self.current_snapshot = Some(snapshot);
+        }
+
+        for event in update.events {
+            match event {
+                SimulatedInput::Click { position, .. }
+                | SimulatedInput::DoubleClick { position, .. }
+                | SimulatedInput::MouseDown { position, .. }
+                | SimulatedInput::MouseUp { position, .. }
+                | SimulatedInput::MouseMove { position, .. }
+                | SimulatedInput::Scroll { position, .. }
+                | SimulatedInput::HoverEnter { position, .. }
+                | SimulatedInput::HoverLeave { position, .. } => {
+                    self.cursor_position = Some((position.x, position.y));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn ensure_selected_element_exists(&mut self) {
+        let Some(snapshot) = self.current_snapshot.as_ref() else {
+            self.selected_element_id = None;
+            return;
+        };
+
+        match self.selected_element_id.as_ref() {
+            Some(id) if snapshot.elements.contains_key(id) => {}
+            _ => {
+                self.selected_element_id = snapshot
+                    .root_id
+                    .clone()
+                    .or_else(|| snapshot.elements.keys().next().cloned());
+            }
+        }
     }
 }
 
-/// Shared application state for thread-safe access
+/// Shared application state for thread-safe access.
 pub type SharedAppState = Arc<RwLock<AppState>>;
 
-/// Run the debugger application
+/// Run the debugger application.
 pub fn run(width: u32, height: u32, file: Option<PathBuf>, connect: Option<String>) -> Result<()> {
-    // Create shared application state
     let app_state = Arc::new(RwLock::new(AppState::default()));
 
-    // Load recording if file path provided
     if let Some(ref path) = file {
         if let Err(e) = app_state.write().unwrap().load_recording(path) {
             log::warn!("Failed to load recording from {:?}: {}", path, e);
         }
     }
 
-    // Store server address for later connection
     if let Some(ref addr) = connect {
-        app_state.write().unwrap().server_addr = Some(addr.clone());
+        match request_export_from_server(addr) {
+            Ok(export) => app_state.write().unwrap().load_from_server(addr, export),
+            Err(e) => log::warn!("Failed to load recording from server {}: {}", addr, e),
+        }
     }
 
-    // Configure the window
     let config = WindowConfig {
         title: "Blinc Debugger".to_string(),
         width,
@@ -109,16 +244,97 @@ pub fn run(width: u32, height: u32, file: Option<PathBuf>, connect: Option<Strin
         ..Default::default()
     };
 
-    // Run the windowed application
     let state_for_ui = app_state.clone();
     Ok(WindowedApp::run(config, move |ctx| {
         build_debugger_ui(ctx, &state_for_ui)
     })?)
 }
 
-/// Build the debugger UI using WindowedContext
+/// Build the debugger UI.
 fn build_debugger_ui(ctx: &WindowedContext, app_state: &SharedAppState) -> impl ElementBuilder {
+    app_state.write().unwrap().tick();
     let state = app_state.read().unwrap();
+
+    let on_tree_select = {
+        let shared = app_state.clone();
+        Arc::new(move |id: String| {
+            if let Ok(mut state) = shared.write() {
+                state.selected_element_id = Some(id);
+            }
+        })
+    };
+
+    let on_toggle_bounds = {
+        let shared = app_state.clone();
+        Arc::new(move |value: bool| {
+            if let Ok(mut state) = shared.write() {
+                state.preview_config.show_bounds = value;
+            }
+        })
+    };
+
+    let on_toggle_cursor = {
+        let shared = app_state.clone();
+        Arc::new(move |value: bool| {
+            if let Ok(mut state) = shared.write() {
+                state.preview_config.show_cursor = value;
+            }
+        })
+    };
+
+    let on_zoom = {
+        let shared = app_state.clone();
+        Arc::new(move |value: f32| {
+            if let Ok(mut state) = shared.write() {
+                state.preview_config.zoom = value;
+            }
+        })
+    };
+
+    let on_step_back = {
+        let shared = app_state.clone();
+        Arc::new(move || {
+            if let Ok(mut state) = shared.write() {
+                state.step_back();
+            }
+        })
+    };
+
+    let on_play_pause = {
+        let shared = app_state.clone();
+        Arc::new(move || {
+            if let Ok(mut state) = shared.write() {
+                state.toggle_playback();
+            }
+        })
+    };
+
+    let on_step_forward = {
+        let shared = app_state.clone();
+        Arc::new(move || {
+            if let Ok(mut state) = shared.write() {
+                state.step_forward();
+            }
+        })
+    };
+
+    let on_seek = {
+        let shared = app_state.clone();
+        Arc::new(move |normalized: f32| {
+            if let Ok(mut state) = shared.write() {
+                state.seek_normalized(normalized);
+            }
+        })
+    };
+
+    let on_speed_change = {
+        let shared = app_state.clone();
+        Arc::new(move |speed: f64| {
+            if let Ok(mut state) = shared.write() {
+                state.set_playback_speed(speed);
+            }
+        })
+    };
 
     div()
         .w(ctx.width)
@@ -126,25 +342,25 @@ fn build_debugger_ui(ctx: &WindowedContext, app_state: &SharedAppState) -> impl 
         .bg(DebuggerColors::bg_base())
         .flex_col()
         .child(
-            // Main panel area (tree + preview + inspector)
             div()
                 .flex_grow()
                 .flex_row()
-                // Tree Panel (left)
                 .child(TreePanel::new(
                     state.current_snapshot.as_ref(),
+                    state.selected_element_id.as_ref(),
                     &state.tree_state,
+                    Some(on_tree_select),
                 ))
-                // Preview Panel (center)
                 .child(PreviewPanel::new(
                     state.current_snapshot.as_ref(),
                     &state.preview_config,
-                    state.cursor_position(),
+                    state.cursor_position,
+                    Some(on_toggle_bounds),
+                    Some(on_toggle_cursor),
+                    Some(on_zoom),
                 ))
-                // Inspector Panel (right)
                 .child(InspectorPanel::new(state.selected_element())),
         )
-        // Timeline Panel (bottom)
         .child(TimelinePanel::new(
             state
                 .recording
@@ -152,5 +368,87 @@ fn build_debugger_ui(ctx: &WindowedContext, app_state: &SharedAppState) -> impl 
                 .map(|r| r.events.as_slice())
                 .unwrap_or(&[]),
             &state.timeline_state,
+            Some(on_step_back),
+            Some(on_play_pause),
+            Some(on_step_forward),
+            Some(on_seek),
+            Some(on_speed_change),
         ))
+}
+
+fn read_len_prefixed<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    let mut len_buf = [0u8; 4];
+    reader.read_exact(&mut len_buf)?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    let mut payload = vec![0u8; len];
+    reader.read_exact(&mut payload)?;
+    Ok(payload)
+}
+
+fn write_len_prefixed<W: Write>(writer: &mut W, payload: &[u8]) -> Result<()> {
+    let len = payload.len() as u32;
+    writer.write_all(&len.to_le_bytes())?;
+    writer.write_all(payload)?;
+    Ok(())
+}
+
+fn request_export_from_server(addr: &str) -> Result<RecordingExport> {
+    #[cfg(unix)]
+    {
+        if !addr.contains(':') || addr.contains('/') {
+            let socket = if addr.contains('/') {
+                addr.to_string()
+            } else {
+                format!("/tmp/blinc/{addr}.sock")
+            };
+            use std::os::unix::net::UnixStream;
+            let mut stream = UnixStream::connect(&socket)
+                .with_context(|| format!("failed to connect to unix socket {socket}"))?;
+            stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+            stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
+            return request_export_over_stream(&mut stream);
+        }
+    }
+
+    let mut stream = std::net::TcpStream::connect(addr)
+        .with_context(|| format!("failed to connect to tcp server {addr}"))?;
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+    stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
+    request_export_over_stream(&mut stream)
+}
+
+fn request_export_over_stream<S: Read + Write>(stream: &mut S) -> Result<RecordingExport> {
+    let hello_payload = read_len_prefixed(stream)?;
+    let hello: serde_json::Value = serde_json::from_slice(&hello_payload)?;
+    if hello.get("type").and_then(|v| v.as_str()) != Some("hello") {
+        bail!("unexpected first server message: {hello}");
+    }
+
+    let request = serde_json::json!({ "type": "request_export" });
+    let bytes = serde_json::to_vec(&request)?;
+    write_len_prefixed(stream, &bytes)?;
+
+    for _ in 0..32 {
+        let payload = read_len_prefixed(stream)?;
+        let value: serde_json::Value = serde_json::from_slice(&payload)?;
+        match value.get("type").and_then(|v| v.as_str()) {
+            Some("export") => {
+                let export_value = value
+                    .get("export")
+                    .cloned()
+                    .ok_or_else(|| anyhow!("missing export field in server response"))?;
+                return serde_json::from_value(export_value).map_err(Into::into);
+            }
+            Some("error") => {
+                let message = value
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown server error");
+                bail!("server error: {message}");
+            }
+            _ => continue,
+        }
+    }
+
+    bail!("did not receive export payload from server")
 }

--- a/crates/blinc_debugger/src/main.rs
+++ b/crates/blinc_debugger/src/main.rs
@@ -25,12 +25,16 @@ use std::path::PathBuf;
 #[command(about = "Visual debugger for Blinc UI recordings")]
 #[command(version)]
 struct Args {
+    /// Recording file to open (positional)
+    #[arg(value_name = "FILE")]
+    input: Option<PathBuf>,
+
     /// Recording file to open (optional)
     #[arg(short, long)]
     file: Option<PathBuf>,
 
     /// Connect to debug server at address
-    #[arg(short, long, default_value = "127.0.0.1:9999")]
+    #[arg(short, long)]
     connect: Option<String>,
 
     /// Window width
@@ -51,10 +55,11 @@ fn main() -> Result<()> {
     ThemeState::get().set_scheme(ColorScheme::Dark);
 
     let args = Args::parse();
+    let file = args.file.or(args.input);
 
     log::info!("Starting Blinc Debugger");
 
-    if let Some(ref file) = args.file {
+    if let Some(ref file) = file {
         log::info!("Opening recording: {}", file.display());
     }
 
@@ -63,5 +68,5 @@ fn main() -> Result<()> {
     }
 
     // Run the app
-    app::run(args.width, args.height, args.file, args.connect)
+    app::run(args.width, args.height, file, args.connect)
 }

--- a/crates/blinc_debugger/src/main.rs
+++ b/crates/blinc_debugger/src/main.rs
@@ -33,7 +33,7 @@ struct Args {
     #[arg(short, long)]
     file: Option<PathBuf>,
 
-    /// Connect to debug server at address
+    /// Connect to debug server (`app_name`, `unix:/path.sock`, or `tcp:host:port`)
     #[arg(short, long)]
     connect: Option<String>,
 

--- a/crates/blinc_debugger/src/panels/timeline_panel.rs
+++ b/crates/blinc_debugger/src/panels/timeline_panel.rs
@@ -61,6 +61,9 @@ struct BuiltTimelinePanel {
 }
 
 impl BuiltTimelinePanel {
+    const TRACK_WIDTH: f32 = 740.0;
+    const EVENT_MARKER_WIDTH: f32 = 3.0;
+
     fn from_config(config: &TimelinePanelConfig) -> Self {
         let theme = ThemeState::get();
 
@@ -215,7 +218,7 @@ impl BuiltTimelinePanel {
                     .min(0.0)
                     .max(1.0)
                     .size(SliderSize::Small)
-                    .w(740.0)
+                    .w(Self::TRACK_WIDTH)
                     .on_change(move |value| {
                         if let Some(cb) = &on_seek {
                             cb(value.clamp(0.0, 1.0));
@@ -236,14 +239,17 @@ impl BuiltTimelinePanel {
             theme.color(ColorToken::Warning),
         ];
 
-        let mut track = div().w(740.0).h(16.0).relative();
+        let mut track = div().w(Self::TRACK_WIDTH).h(16.0).relative();
         for (idx, pos) in positions.iter().enumerate() {
             track = track.child(
                 div()
                     .absolute()
-                    .left((pos * 740.0).clamp(0.0, 737.0))
+                    .left(
+                        (pos * Self::TRACK_WIDTH)
+                            .clamp(0.0, Self::TRACK_WIDTH - Self::EVENT_MARKER_WIDTH),
+                    )
                     .top(2.0)
-                    .w(3.0)
+                    .w(Self::EVENT_MARKER_WIDTH)
                     .h(12.0)
                     .rounded(1.5)
                     .bg(colors[idx % colors.len()]),
@@ -255,7 +261,7 @@ impl BuiltTimelinePanel {
     fn time_labels(duration: Timestamp) -> Div {
         let theme = ThemeState::get();
         div()
-            .w(740.0)
+            .w(Self::TRACK_WIDTH)
             .h(14.0)
             .flex_row()
             .justify_between()

--- a/crates/blinc_debugger/src/panels/timeline_panel.rs
+++ b/crates/blinc_debugger/src/panels/timeline_panel.rs
@@ -1,6 +1,7 @@
-//! Timeline Panel - Event timeline with scrubber
+//! Timeline Panel - Event timeline with playback controls
 
 use std::cell::OnceCell;
+use std::sync::Arc;
 
 use blinc_cn::components::button::{button, ButtonSize, ButtonVariant};
 use blinc_cn::components::select::{select, SelectSize};
@@ -38,11 +39,21 @@ impl Default for TimelinePanelState {
     }
 }
 
+type VoidCallback = Arc<dyn Fn() + Send + Sync>;
+type SeekCallback = Arc<dyn Fn(f32) + Send + Sync>;
+type SpeedCallback = Arc<dyn Fn(f64) + Send + Sync>;
+
 struct TimelinePanelConfig {
     position: Timestamp,
     duration: Timestamp,
     playback_state: ReplayState,
     speed: f64,
+    event_positions: Vec<f32>,
+    on_step_back: Option<VoidCallback>,
+    on_play_pause: Option<VoidCallback>,
+    on_step_forward: Option<VoidCallback>,
+    on_seek: Option<SeekCallback>,
+    on_speed_change: Option<SpeedCallback>,
 }
 
 struct BuiltTimelinePanel {
@@ -76,10 +87,17 @@ impl BuiltTimelinePanel {
         let theme = ThemeState::get();
         let is_playing = config.playback_state == ReplayState::Playing;
 
-        // Get speed state from context
         let speed_str = format!("{:.1}", config.speed);
         let speed_state =
             BlincContextState::get().use_state_keyed("timeline_speed", || speed_str.clone());
+        if speed_state.get() != speed_str {
+            speed_state.set(speed_str.clone());
+        }
+
+        let on_step_back = config.on_step_back.clone();
+        let on_play_pause = config.on_play_pause.clone();
+        let on_step_forward = config.on_step_forward.clone();
+        let on_speed_change = config.on_speed_change.clone();
 
         div()
             .w_full()
@@ -90,7 +108,6 @@ impl BuiltTimelinePanel {
             .items_center()
             .justify_between()
             .child(
-                // Playback controls
                 div()
                     .flex_row()
                     .items_center()
@@ -99,7 +116,12 @@ impl BuiltTimelinePanel {
                         button("")
                             .variant(ButtonVariant::Ghost)
                             .size(ButtonSize::Icon)
-                            .icon(icons::SKIP_BACK),
+                            .icon(icons::SKIP_BACK)
+                            .on_click(move |_| {
+                                if let Some(cb) = &on_step_back {
+                                    cb();
+                                }
+                            }),
                     )
                     .child(
                         button("")
@@ -109,17 +131,26 @@ impl BuiltTimelinePanel {
                                 icons::PAUSE
                             } else {
                                 icons::PLAY
+                            })
+                            .on_click(move |_| {
+                                if let Some(cb) = &on_play_pause {
+                                    cb();
+                                }
                             }),
                     )
                     .child(
                         button("")
                             .variant(ButtonVariant::Ghost)
                             .size(ButtonSize::Icon)
-                            .icon(icons::SKIP_FORWARD),
+                            .icon(icons::SKIP_FORWARD)
+                            .on_click(move |_| {
+                                if let Some(cb) = &on_step_forward {
+                                    cb();
+                                }
+                            }),
                     ),
             )
             .child(
-                // Time display
                 div()
                     .flex_row()
                     .items_center()
@@ -141,50 +172,62 @@ impl BuiltTimelinePanel {
                     ),
             )
             .child(
-                // Speed selector
                 select(&speed_state)
                     .size(SelectSize::Small)
                     .w(80.0)
                     .option("0.5", "0.5x")
                     .option("1.0", "1.0x")
-                    .option("2.0", "2.0x"),
+                    .option("2.0", "2.0x")
+                    .on_change(move |value| {
+                        if let (Some(cb), Ok(speed)) = (&on_speed_change, value.parse::<f64>()) {
+                            cb(speed);
+                        }
+                    }),
             )
     }
 
     fn timeline_track(config: &TimelinePanelConfig) -> Div {
-        // Get position state from context (normalized 0.0-1.0)
         let position_norm = if config.duration.as_micros() > 0 {
             config.position.as_micros() as f32 / config.duration.as_micros() as f32
         } else {
             0.0
         };
+
         let position_state =
             BlincContextState::get().use_state_keyed("timeline_position", || position_norm);
+        if (position_state.get() - position_norm).abs() > 0.0005 {
+            position_state.set(position_norm);
+        }
+
+        let on_seek = config.on_seek.clone();
 
         div()
             .w_full()
             .padding_x_px(24.0)
             .py(4.0)
             .flex_col()
-            .bg_background()
             .gap_px(8.0)
             .items_center()
             .justify_center()
-            .child(Self::event_markers())
+            .child(Self::event_markers(&config.event_positions))
             .child(
                 slider(&position_state)
                     .min(0.0)
                     .max(1.0)
                     .size(SliderSize::Small)
                     .w(740.0)
+                    .on_change(move |value| {
+                        if let Some(cb) = &on_seek {
+                            cb(value.clamp(0.0, 1.0));
+                        }
+                    })
                     .build_final(),
             )
             .child(Self::time_labels(config.duration))
     }
 
-    fn event_markers() -> Div {
+    fn event_markers(positions: &[f32]) -> Div {
         let theme = ThemeState::get();
-
         let colors = [
             theme.color(ColorToken::Primary),
             theme.color(ColorToken::Info),
@@ -193,18 +236,18 @@ impl BuiltTimelinePanel {
             theme.color(ColorToken::Warning),
         ];
 
-        // Use flexbox to distribute markers evenly - match slider width
-        let mut track = div()
-            .id("timeline_track_id")
-            .w(740.0) // Match slider width
-            .h(16.0)
-            .flex_row()
-            .items_center()
-            .justify_between()
-            .px(4.0); // Small padding at edges
-
-        for i in 0..10 {
-            track = track.child(div().w(3.0).h(12.0).rounded(1.5).bg(colors[i % 5]));
+        let mut track = div().w(740.0).h(16.0).relative();
+        for (idx, pos) in positions.iter().enumerate() {
+            track = track.child(
+                div()
+                    .absolute()
+                    .left((pos * 740.0).clamp(0.0, 737.0))
+                    .top(2.0)
+                    .w(3.0)
+                    .h(12.0)
+                    .rounded(1.5)
+                    .bg(colors[idx % colors.len()]),
+            );
         }
         track
     }
@@ -212,7 +255,7 @@ impl BuiltTimelinePanel {
     fn time_labels(duration: Timestamp) -> Div {
         let theme = ThemeState::get();
         div()
-            .w(740.0) // Match slider width
+            .w(740.0)
             .h(14.0)
             .flex_row()
             .justify_between()
@@ -240,16 +283,45 @@ pub struct TimelinePanel {
 }
 
 impl TimelinePanel {
-    pub fn new(_events: &[TimestampedEvent], state: &TimelinePanelState) -> Self {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        events: &[TimestampedEvent],
+        state: &TimelinePanelState,
+        on_step_back: Option<VoidCallback>,
+        on_play_pause: Option<VoidCallback>,
+        on_step_forward: Option<VoidCallback>,
+        on_seek: Option<SeekCallback>,
+        on_speed_change: Option<SpeedCallback>,
+    ) -> Self {
         Self {
             config: TimelinePanelConfig {
                 position: state.position,
                 duration: state.duration,
                 playback_state: state.playback_state,
                 speed: state.speed,
+                event_positions: Self::sample_event_positions(events, state.duration),
+                on_step_back,
+                on_play_pause,
+                on_step_forward,
+                on_seek,
+                on_speed_change,
             },
             built: OnceCell::new(),
         }
+    }
+
+    fn sample_event_positions(events: &[TimestampedEvent], duration: Timestamp) -> Vec<f32> {
+        if events.is_empty() || duration.as_micros() == 0 {
+            return Vec::new();
+        }
+
+        let max_markers = 120usize;
+        let stride = (events.len() / max_markers).max(1);
+        events
+            .iter()
+            .step_by(stride)
+            .map(|e| (e.timestamp.as_micros() as f32 / duration.as_micros() as f32).clamp(0.0, 1.0))
+            .collect()
     }
 
     fn get_or_build(&self) -> &BuiltTimelinePanel {

--- a/crates/blinc_debugger/src/panels/tree_panel.rs
+++ b/crates/blinc_debugger/src/panels/tree_panel.rs
@@ -1,10 +1,11 @@
-//! Tree Panel - Element tree with diff visualization
+//! Tree Panel - Element tree with selection
 
 use std::cell::OnceCell;
+use std::sync::Arc;
 
 use blinc_cn::components::input::{input, InputSize};
 use blinc_cn::components::separator::separator;
-use blinc_cn::components::tree::{tree_view, TreeNodeDiff};
+use blinc_cn::components::tree::{tree_view, TreeNodeConfig};
 use blinc_layout::div::{Div, ElementBuilder};
 use blinc_layout::element::RenderProps;
 use blinc_layout::event_handler::EventHandlers;
@@ -20,8 +21,12 @@ use crate::theme::DebuggerTokens;
 #[derive(Default)]
 pub struct TreePanelState;
 
+type SelectCallback = Arc<dyn Fn(String) + Send + Sync>;
+
 struct TreePanelConfig {
-    has_snapshot: bool,
+    snapshot: Option<TreeSnapshot>,
+    selected_id: Option<String>,
+    on_select: Option<SelectCallback>,
 }
 
 struct BuiltTreePanel {
@@ -37,28 +42,35 @@ impl BuiltTreePanel {
             .h_full()
             .bg(theme.color(ColorToken::SurfaceElevated))
             .flex_col()
-            .child(Self::header())
+            .child(Self::header(config.snapshot.as_ref()))
             .child(separator())
             .child(Self::search_bar())
-            .child(Self::tree_content(config.has_snapshot))
+            .child(Self::tree_content(config))
             .child(separator());
 
         BuiltTreePanel { inner }
     }
 
-    fn header() -> Div {
+    fn header(snapshot: Option<&TreeSnapshot>) -> Div {
         let theme = ThemeState::get();
+        let count = snapshot.map(|s| s.elements.len()).unwrap_or(0);
         div()
             .h(44.0)
             .px(12.0)
             .py(2.0)
             .flex_row()
             .items_center()
+            .justify_between()
             .child(
                 text("Element Tree")
                     .size(13.0)
                     .color(theme.color(ColorToken::TextPrimary))
                     .weight(blinc_layout::div::FontWeight::SemiBold),
+            )
+            .child(
+                text(format!("{count}"))
+                    .size(11.0)
+                    .color(theme.color(ColorToken::TextTertiary)),
             )
     }
 
@@ -71,9 +83,13 @@ impl BuiltTreePanel {
         )
     }
 
-    fn tree_content(has_snapshot: bool) -> Scroll {
-        let content = if has_snapshot {
-            Self::render_tree_placeholder()
+    fn tree_content(config: &TreePanelConfig) -> Scroll {
+        let content = if let Some(snapshot) = config.snapshot.as_ref() {
+            Self::render_tree(
+                snapshot,
+                config.selected_id.as_ref(),
+                config.on_select.clone(),
+            )
         } else {
             Self::render_empty_state()
         };
@@ -81,23 +97,61 @@ impl BuiltTreePanel {
         scroll().flex_grow().child(content)
     }
 
-    fn render_tree_placeholder() -> Div {
-        div().child(
-            tree_view()
-                .indent(12.0)
-                .node("root", "root", |n| {
-                    n.expanded()
-                        .child("header", "header", |c| c)
-                        .child("main", "main", |c| {
-                            c.expanded()
-                                .diff(TreeNodeDiff::Modified)
-                                .child("sidebar", "sidebar", |c| c)
-                                .child("content", "content", |c| c.diff(TreeNodeDiff::Added))
-                        })
-                        .child("footer", "footer", |c| c)
-                })
-                .on_select(|_key| {}),
-        )
+    fn render_tree(
+        snapshot: &TreeSnapshot,
+        selected_id: Option<&String>,
+        on_select: Option<SelectCallback>,
+    ) -> Div {
+        let mut tree = tree_view().indent(12.0);
+
+        if let Some(selected) = selected_id {
+            tree = tree.selected(selected.clone());
+        }
+
+        if let Some(root_id) = snapshot.root_id.as_deref() {
+            if let Some(node) = Self::build_node(snapshot, root_id) {
+                tree = tree.add_node(node.expanded());
+            }
+        } else {
+            let mut roots: Vec<_> = snapshot
+                .elements
+                .values()
+                .filter(|e| e.parent.is_none())
+                .map(|e| e.id.as_str())
+                .collect();
+            roots.sort_unstable();
+            for root in roots {
+                if let Some(node) = Self::build_node(snapshot, root) {
+                    tree = tree.add_node(node.expanded());
+                }
+            }
+        }
+
+        if let Some(on_select_cb) = on_select {
+            tree = tree.on_select(move |key| on_select_cb(key.to_string()));
+        }
+
+        div().child(tree)
+    }
+
+    fn build_node(snapshot: &TreeSnapshot, id: &str) -> Option<TreeNodeConfig> {
+        let element = snapshot.elements.get(id)?;
+        let mut node = TreeNodeConfig::new(
+            id.to_string(),
+            format!("{} · {}", element.element_type, element.id),
+        );
+
+        if !element.children.is_empty() {
+            node = node.expanded();
+        }
+
+        for child in &element.children {
+            if let Some(child_node) = Self::build_node(snapshot, child) {
+                node.children.push(child_node);
+            }
+        }
+
+        Some(node)
     }
 
     fn render_empty_state() -> Div {
@@ -121,10 +175,17 @@ pub struct TreePanel {
 }
 
 impl TreePanel {
-    pub fn new(_snapshot: Option<&TreeSnapshot>, _state: &TreePanelState) -> Self {
+    pub fn new(
+        snapshot: Option<&TreeSnapshot>,
+        selected_id: Option<&String>,
+        _state: &TreePanelState,
+        on_select: Option<SelectCallback>,
+    ) -> Self {
         Self {
             config: TreePanelConfig {
-                has_snapshot: _snapshot.is_some(),
+                snapshot: snapshot.cloned(),
+                selected_id: selected_id.cloned(),
+                on_select,
             },
             built: OnceCell::new(),
         }

--- a/crates/blinc_layout/Cargo.toml
+++ b/crates/blinc_layout/Cargo.toml
@@ -14,13 +14,14 @@ crate-type = ["lib"]
 [features]
 default = []
 # Enable recorder integration for debugging/testing. Disable for production builds.
-recorder = []
+recorder = ["dep:blinc_recorder"]
 
 [dependencies]
 blinc_core = { path = "../blinc_core", version = "0.1.12" }
 blinc_animation = { path = "../blinc_animation", version = "0.1.12" }
 blinc_theme = { path = "../blinc_theme", version = "0.1.12" }
 blinc_i18n = { path = "../blinc_i18n", version = "0.1.12" }
+blinc_recorder = { path = "../blinc_recorder", version = "0.1.12", optional = true }
 
 # Layout
 taffy.workspace = true

--- a/crates/blinc_recorder/Cargo.toml
+++ b/crates/blinc_recorder/Cargo.toml
@@ -17,6 +17,7 @@ png = { version = "0.17", optional = true }
 blinc_core = { path = "../blinc_core", version = "0.1.12" }
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/blinc_recorder/README.md
+++ b/crates/blinc_recorder/README.md
@@ -71,7 +71,9 @@ let (_session, _server) = blinc_recorder::enable_debug_server!("my_app");
 ```bash
 blinc-debugger --connect my_app
 # or explicit socket path on Unix
-blinc-debugger --connect /tmp/blinc/my_app.sock
+blinc-debugger --connect unix:/tmp/blinc/my_app.sock
+# or explicit TCP endpoint
+blinc-debugger --connect tcp:127.0.0.1:7331
 ```
 
 ## Blinc Layout Integration

--- a/crates/blinc_recorder/README.md
+++ b/crates/blinc_recorder/README.md
@@ -5,138 +5,86 @@
 > This crate is a component of Blinc, a GPU-accelerated UI framework for Rust.
 > For full documentation and guides, visit the [Blinc documentation](https://project-blinc.github.io/Blinc).
 
-Recording and debugging infrastructure for Blinc applications.
+Recording, replay, and debug-server infrastructure for Blinc applications.
 
 ## Overview
 
-`blinc_recorder` provides tools for recording user interactions, capturing UI state, and enabling visual regression testing.
+`blinc_recorder` provides:
 
-## Features
+- user input/event recording
+- element tree snapshot capture
+- replay with virtual time controls
+- local debug server for debugger tooling
+- basic test helpers (headless/framebuffer/visual comparison)
 
-- **Event Recording**: Capture user interactions (clicks, keys, etc.)
-- **Tree Snapshots**: Capture UI element tree state
-- **Session Management**: Start/pause/stop recording lifecycle
-- **Replay**: Play back recorded sessions
-- **Visual Testing**: Screenshot comparison for regression testing
-- **Debug Server**: Live inspection of running applications
-
-## Recording Sessions
+## Quick Start
 
 ```rust
-use blinc_recorder::{SharedRecordingSession, RecordingConfig};
+use std::sync::Arc;
+use blinc_recorder::{install_recorder, RecordingConfig, SharedRecordingSession};
 
-// Create a recording session
-let session = SharedRecordingSession::new(RecordingConfig {
-    capture_events: true,
-    capture_snapshots: true,
-    snapshot_interval: Duration::from_millis(100),
-    ..Default::default()
-});
+let session = Arc::new(SharedRecordingSession::new(RecordingConfig::debug()));
+install_recorder(session.clone());
 
-// Start recording
 session.start();
-
-// ... application runs ...
-
-// Stop and get recorded data
+// ... run your app ...
 session.stop();
-let events = session.events();
-let snapshots = session.snapshots();
+
+let export = session.export();
+let json = serde_json::to_string_pretty(&export)?;
+std::fs::write("recording.json", json)?;
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-## Event Types
+## Loading + Replay
 
 ```rust
-use blinc_recorder::RecordedEvent;
+use blinc_recorder::{RecordingExport, ReplayConfig, ReplayPlayer};
 
-// Recorded events include:
-RecordedEvent::MouseMove { x, y, timestamp }
-RecordedEvent::MouseDown { x, y, button, timestamp }
-RecordedEvent::MouseUp { x, y, button, timestamp }
-RecordedEvent::Click { x, y, button, timestamp }
-RecordedEvent::KeyDown { key, modifiers, timestamp }
-RecordedEvent::KeyUp { key, modifiers, timestamp }
-RecordedEvent::Scroll { x, y, delta_x, delta_y, timestamp }
-RecordedEvent::TextInput { text, timestamp }
-```
+let json = std::fs::read_to_string("recording.json")?;
+let export: RecordingExport = serde_json::from_str(&json)?;
 
-## Tree Snapshots
-
-```rust
-use blinc_recorder::TreeSnapshot;
-
-// Snapshots capture the UI element tree
-let snapshot: TreeSnapshot = session.latest_snapshot();
-
-// Access element data
-for element in snapshot.elements() {
-    println!("Element: {} at ({}, {})",
-        element.type_name,
-        element.bounds.x,
-        element.bounds.y
-    );
-}
-```
-
-## Replay
-
-```rust
-use blinc_recorder::ReplayPlayer;
-
-// Load recorded session
-let session = SharedRecordingSession::load("recording.json")?;
-
-// Create replay player
-let player = ReplayPlayer::new(session);
-
-// Play back events
+let mut player = ReplayPlayer::new(export, ReplayConfig::interactive());
+player.clock_mut().set_speed(1.5);
 player.play();
 
-// Or step through manually
-player.step();
+let frame = player.update();
+if frame.has_snapshot() {
+    // inspect snapshot
+}
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-## Visual Testing
+## Debug Server Integration
 
 ```rust
-use blinc_recorder::{TestRunner, ScreenshotExporter};
-
-// Capture screenshot
-let frame = app.render(&ui);
-ScreenshotExporter::save_png(&frame, "screenshot.png")?;
-
-// Compare with baseline
-let runner = TestRunner::new("tests/visual");
-runner.compare("test_name", &frame)?;
+// Debug build convenience macro:
+// - creates a debug recording session
+// - installs recorder + hooks
+// - starts local debug server
+// - starts recording
+let (_session, _server) = blinc_recorder::enable_debug_server!("my_app");
 ```
 
-## Debug Server
+`blinc_debugger` can connect via:
 
-```rust
-use blinc_recorder::DebugServer;
+```bash
+blinc-debugger --connect my_app
+# or explicit socket path on Unix
+blinc-debugger --connect /tmp/blinc/my_app.sock
+```
 
-// Start debug server for live inspection
-let server = DebugServer::start(8080)?;
+## Blinc Layout Integration
 
-// Connect via browser at http://localhost:8080
-// View live element tree, events, and snapshots
+If your app uses `blinc_layout`, enable the `recorder` feature so layout-side recorder bridge code is active:
+
+```toml
+blinc_layout = { version = "0.1.12", features = ["recorder"] }
 ```
 
 ## Optional Features
 
-- `png` - Enable PNG screenshot export
-
-## Architecture
-
-```
-blinc_recorder
-├── session.rs        # Recording session management
-├── events.rs         # Event types and recording
-├── snapshot.rs       # Tree snapshot capture
-├── replay/           # Replay infrastructure
-├── testing/          # Visual testing utilities
-└── server.rs         # Debug server
-```
+- `png`: enable PNG exporting in framebuffer helpers
 
 ## License
 

--- a/crates/blinc_recorder/src/lib.rs
+++ b/crates/blinc_recorder/src/lib.rs
@@ -71,6 +71,8 @@ pub fn install_recorder(session: Arc<SharedRecordingSession>) {
     RECORDER.with(|r| {
         *r.write() = Some(session);
     });
+    // If context state already exists, wire hooks immediately.
+    install_hooks();
 }
 
 /// Remove the recorder session from the current thread.
@@ -223,6 +225,7 @@ macro_rules! enable_debug_recording {
                 $crate::RecordingConfig::debug(),
             ));
             $crate::install_recorder(session.clone());
+            $crate::install_hooks();
             session.start();
             session
         }
@@ -237,6 +240,7 @@ macro_rules! enable_debug_recording {
     ($config:expr) => {{
         let session = std::sync::Arc::new($crate::SharedRecordingSession::new($config));
         $crate::install_recorder(session.clone());
+        $crate::install_hooks();
         session.start();
         session
     }};

--- a/crates/blinc_recorder/src/replay/mod.rs
+++ b/crates/blinc_recorder/src/replay/mod.rs
@@ -14,13 +14,13 @@
 //! let mut player = ReplayPlayer::new(export, ReplayConfig::default());
 //!
 //! // Play at 2x speed
-//! player.set_playback_speed(2.0);
+//! player.clock_mut().set_speed(2.0);
 //! player.play();
 //!
 //! // Or step through frame by frame
 //! while player.has_next() {
-//!     let frame_events = player.step();
-//!     for event in frame_events {
+//!     let frame = player.step();
+//!     for event in frame.events {
 //!         // Process event...
 //!     }
 //! }

--- a/crates/blinc_recorder/src/server/local.rs
+++ b/crates/blinc_recorder/src/server/local.rs
@@ -432,7 +432,13 @@ impl ServerMessage {
             ServerMessage::Pong => json!({ "type": "pong" }),
         };
 
-        let bytes = serde_json::to_vec(&payload).unwrap_or_else(|_| b"{}".to_vec());
+        let bytes = match serde_json::to_vec(&payload) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                tracing::error!("failed to serialize ServerMessage payload: {}", e);
+                b"{\"type\":\"error\",\"message\":\"serialization failure\"}".to_vec()
+            }
+        };
         let len = bytes.len() as u32;
         let mut result = Vec::with_capacity(4 + bytes.len());
         result.extend_from_slice(&len.to_le_bytes());


### PR DESCRIPTION
## Summary
- fix recorder bridge type mismatch by converting layout recorder payloads into blinc_recorder events/snapshots and lazily installing hooks when needed
- ensure debug recording installs hooks so macro-based recording captures real events
- serialize full RecordingExport in debug server export responses and improve command parsing/hello app name handling
- wire blinc_debugger playback pipeline (play/pause/step/seek/speed), snapshot selection, tree selection, preview controls, and server export loading
- align CLI/docs by supporting positional recording file input and documenting connect usage

## Verification
- cargo fmt --all
- cargo fmt --all -- --check
- cargo test -p blinc_layout --features recorder recorder_bridge::tests
- cargo test -p blinc_recorder --lib
- cargo check -p blinc_debugger
