### PR TITLE
feat(blinc_cn): add responsive breakpoints and adaptive scroll defaults

### DIFF
--- a/crates/blinc_cn/src/components/mod.rs
+++ b/crates/blinc_cn/src/components/mod.rs
@@ -35,6 +35,7 @@ pub mod popover;
 pub mod progress;
 pub mod radio;
 pub mod resizable;
+pub mod responsive;
 pub mod scroll_area;
 pub mod select;
 pub mod separator;
@@ -101,6 +102,9 @@ pub use radio::{radio_group, RadioGroup, RadioGroupBuilder, RadioLayout, RadioSi
 pub use resizable::{
     resizable_group, resizable_panel, ResizableGroup, ResizableGroupBuilder, ResizablePanelBuilder,
     ResizeDirection,
+};
+pub use responsive::{
+    current_device_class, device_class_for_width, DeviceClass, TailwindBreakpoints,
 };
 pub use select::{select, Select, SelectBuilder, SelectOption, SelectSize};
 pub use separator::{separator, Separator, SeparatorOrientation};

--- a/crates/blinc_cn/src/components/responsive.rs
+++ b/crates/blinc_cn/src/components/responsive.rs
@@ -48,12 +48,10 @@ pub enum DeviceClass {
 /// Classify device width into mobile/tablet/desktop using Tailwind defaults.
 pub fn device_class_for_width(width: f32) -> DeviceClass {
     let bp = TailwindBreakpoints::DEFAULT;
-    if width < bp.md {
-        DeviceClass::Mobile
-    } else if width < bp.lg {
-        DeviceClass::Tablet
-    } else {
-        DeviceClass::Desktop
+    match width {
+        w if w < bp.md => DeviceClass::Mobile,
+        w if w < bp.lg => DeviceClass::Tablet,
+        _ => DeviceClass::Desktop,
     }
 }
 

--- a/crates/blinc_cn/src/components/responsive.rs
+++ b/crates/blinc_cn/src/components/responsive.rs
@@ -17,15 +17,20 @@ pub struct TailwindBreakpoints {
     pub xxl: f32,
 }
 
+impl TailwindBreakpoints {
+    /// Default Tailwind breakpoints (`sm`/`md`/`lg`/`xl`/`2xl`).
+    pub const DEFAULT: Self = Self {
+        sm: 640.0,
+        md: 768.0,
+        lg: 1024.0,
+        xl: 1280.0,
+        xxl: 1536.0,
+    };
+}
+
 impl Default for TailwindBreakpoints {
     fn default() -> Self {
-        Self {
-            sm: 640.0,
-            md: 768.0,
-            lg: 1024.0,
-            xl: 1280.0,
-            xxl: 1536.0,
-        }
+        Self::DEFAULT
     }
 }
 
@@ -42,7 +47,7 @@ pub enum DeviceClass {
 
 /// Classify device width into mobile/tablet/desktop using Tailwind defaults.
 pub fn device_class_for_width(width: f32) -> DeviceClass {
-    let bp = TailwindBreakpoints::default();
+    let bp = TailwindBreakpoints::DEFAULT;
     if width < bp.md {
         DeviceClass::Mobile
     } else if width < bp.lg {
@@ -59,6 +64,6 @@ pub fn current_device_class() -> DeviceClass {
     let width = BlincContextState::try_get()
         .map(|ctx| ctx.viewport_size().0)
         .filter(|w| *w > 0.0)
-        .unwrap_or(TailwindBreakpoints::default().lg);
+        .unwrap_or(TailwindBreakpoints::DEFAULT.lg);
     device_class_for_width(width)
 }

--- a/crates/blinc_cn/src/components/responsive.rs
+++ b/crates/blinc_cn/src/components/responsive.rs
@@ -1,0 +1,64 @@
+//! Responsive helpers for Tailwind-style breakpoints in `blinc_cn`.
+
+use blinc_core::context_state::BlincContextState;
+
+/// Tailwind-compatible breakpoint widths in logical pixels.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TailwindBreakpoints {
+    /// Small breakpoint (`sm`) - 640px
+    pub sm: f32,
+    /// Medium breakpoint (`md`) - 768px
+    pub md: f32,
+    /// Large breakpoint (`lg`) - 1024px
+    pub lg: f32,
+    /// Extra large breakpoint (`xl`) - 1280px
+    pub xl: f32,
+    /// 2x large breakpoint (`2xl`) - 1536px
+    pub xxl: f32,
+}
+
+impl Default for TailwindBreakpoints {
+    fn default() -> Self {
+        Self {
+            sm: 640.0,
+            md: 768.0,
+            lg: 1024.0,
+            xl: 1280.0,
+            xxl: 1536.0,
+        }
+    }
+}
+
+/// Device-class abstraction derived from Tailwind breakpoints.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeviceClass {
+    /// Width < `md` (768px)
+    Mobile,
+    /// `md` <= width < `lg` (1024px)
+    Tablet,
+    /// width >= `lg` (1024px)
+    Desktop,
+}
+
+/// Classify device width into mobile/tablet/desktop using Tailwind defaults.
+pub fn device_class_for_width(width: f32) -> DeviceClass {
+    let bp = TailwindBreakpoints::default();
+    if width < bp.md {
+        DeviceClass::Mobile
+    } else if width < bp.lg {
+        DeviceClass::Tablet
+    } else {
+        DeviceClass::Desktop
+    }
+}
+
+/// Return current device class from global viewport when available.
+///
+/// If viewport is not initialized yet, defaults to `Desktop`.
+pub fn current_device_class() -> DeviceClass {
+    let width = BlincContextState::try_get()
+        .map(|ctx| ctx.viewport_size().0)
+        .filter(|w| *w > 0.0)
+        .unwrap_or(TailwindBreakpoints::default().lg);
+    device_class_for_width(width)
+}

--- a/crates/blinc_cn/src/components/responsive.rs
+++ b/crates/blinc_cn/src/components/responsive.rs
@@ -61,9 +61,24 @@ pub fn device_class_for_width(width: f32) -> DeviceClass {
 ///
 /// If viewport is not initialized yet, defaults to `Desktop`.
 pub fn current_device_class() -> DeviceClass {
-    let width = BlincContextState::try_get()
+    BlincContextState::try_get()
         .map(|ctx| ctx.viewport_size().0)
         .filter(|w| *w > 0.0)
-        .unwrap_or(TailwindBreakpoints::DEFAULT.lg);
-    device_class_for_width(width)
+        .map(device_class_for_width)
+        .unwrap_or(DeviceClass::Desktop)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{device_class_for_width, DeviceClass};
+
+    #[test]
+    fn test_tailwind_device_class_breakpoints() {
+        assert_eq!(device_class_for_width(375.0), DeviceClass::Mobile);
+        assert_eq!(device_class_for_width(767.0), DeviceClass::Mobile);
+        assert_eq!(device_class_for_width(768.0), DeviceClass::Tablet);
+        assert_eq!(device_class_for_width(1023.0), DeviceClass::Tablet);
+        assert_eq!(device_class_for_width(1024.0), DeviceClass::Desktop);
+        assert_eq!(device_class_for_width(1440.0), DeviceClass::Desktop);
+    }
 }

--- a/crates/blinc_cn/src/components/scroll_area.rs
+++ b/crates/blinc_cn/src/components/scroll_area.rs
@@ -188,26 +188,30 @@ impl BuiltScrollArea {
 
         // Apply viewport dimensions.
         // Responsive mode follows parent container when width/height are not explicitly set.
-        scroll_widget = match (config.responsive, config.width) {
-            (_, Some(width)) => scroll_widget.w(width),
-            (true, None) => scroll_widget.w_full(),
-            (false, None) => scroll_widget.w(LEGACY_FALLBACK_WIDTH),
+        scroll_widget = if let Some(width) = config.width {
+            scroll_widget.w(width)
+        } else if config.responsive {
+            scroll_widget.w_full()
+        } else {
+            scroll_widget.w(LEGACY_FALLBACK_WIDTH)
         };
-        scroll_widget = match (config.responsive, config.height) {
-            (_, Some(height)) => scroll_widget.h(height),
-            (true, None) => scroll_widget.h_full(),
-            (false, None) => scroll_widget.h(LEGACY_FALLBACK_HEIGHT),
+        scroll_widget = if let Some(height) = config.height {
+            scroll_widget.h(height)
+        } else if config.responsive {
+            scroll_widget.h_full()
+        } else {
+            scroll_widget.h(LEGACY_FALLBACK_HEIGHT)
         };
 
         // Apply scrollbar width
         if let Some(width) = config.scrollbar_width {
             scroll_widget = scroll_widget.scrollbar_width(width);
         } else {
-            let scrollbar_size = if config.responsive && config.size == ScrollAreaSize::Medium {
-                match current_device_class() {
-                    DeviceClass::Mobile => ScrollbarSize::Thin,
-                    DeviceClass::Tablet | DeviceClass::Desktop => ScrollbarSize::Normal,
-                }
+            let scrollbar_size = if config.responsive
+                && config.size == ScrollAreaSize::Medium
+                && current_device_class() == DeviceClass::Mobile
+            {
+                ScrollbarSize::Thin
             } else {
                 config.size.to_layout()
             };

--- a/crates/blinc_cn/src/components/scroll_area.rs
+++ b/crates/blinc_cn/src/components/scroll_area.rs
@@ -483,22 +483,44 @@ mod tests {
     }
 
     #[test]
-    fn test_tailwind_device_class_breakpoints() {
-        use crate::components::responsive::{device_class_for_width, DeviceClass};
-
-        assert_eq!(device_class_for_width(375.0), DeviceClass::Mobile);
-        assert_eq!(device_class_for_width(767.0), DeviceClass::Mobile);
-        assert_eq!(device_class_for_width(768.0), DeviceClass::Tablet);
-        assert_eq!(device_class_for_width(1023.0), DeviceClass::Tablet);
-        assert_eq!(device_class_for_width(1024.0), DeviceClass::Desktop);
-        assert_eq!(device_class_for_width(1440.0), DeviceClass::Desktop);
-    }
-
-    #[test]
     fn test_scroll_area_is_responsive_by_default() {
         init_theme();
         let builder = scroll_area();
         let config = builder.config.borrow();
         assert!(config.responsive);
+    }
+
+    #[test]
+    fn test_scroll_area_non_responsive_uses_legacy_fallback_size() {
+        init_theme();
+
+        let config = ScrollAreaConfig {
+            responsive: false,
+            ..Default::default()
+        };
+        let built = BuiltScrollArea::from_config(config);
+        let physics = built.inner.physics();
+        let physics = physics.lock().unwrap();
+
+        assert_eq!(physics.viewport_width, 300.0);
+        assert_eq!(physics.viewport_height, 400.0);
+    }
+
+    #[test]
+    fn test_scroll_area_explicit_size_takes_precedence_over_responsive_default() {
+        init_theme();
+
+        let config = ScrollAreaConfig {
+            responsive: true,
+            width: Some(320.0),
+            height: Some(240.0),
+            ..Default::default()
+        };
+        let built = BuiltScrollArea::from_config(config);
+        let physics = built.inner.physics();
+        let physics = physics.lock().unwrap();
+
+        assert_eq!(physics.viewport_width, 320.0);
+        assert_eq!(physics.viewport_height, 240.0);
     }
 }

--- a/crates/blinc_cn/src/lib.rs
+++ b/crates/blinc_cn/src/lib.rs
@@ -77,6 +77,9 @@ pub mod cn {
     pub use crate::components::progress::{progress, progress_animated};
     pub use crate::components::radio::radio_group;
     pub use crate::components::resizable::{resizable_group, resizable_panel};
+    pub use crate::components::responsive::{
+        current_device_class, device_class_for_width, DeviceClass, TailwindBreakpoints,
+    };
     pub use crate::components::select::select;
     pub use crate::components::separator::separator;
     pub use crate::components::sheet::{sheet, sheet_bottom, sheet_left, sheet_right, sheet_top};
@@ -180,6 +183,9 @@ pub mod prelude {
     pub use crate::components::resizable::{
         resizable_group, resizable_panel, ResizableGroup, ResizableGroupBuilder,
         ResizablePanelBuilder, ResizeDirection,
+    };
+    pub use crate::components::responsive::{
+        current_device_class, device_class_for_width, DeviceClass, TailwindBreakpoints,
     };
     pub use crate::components::select::{select, Select, SelectBuilder, SelectOption, SelectSize};
     pub use crate::components::separator::{separator, Separator, SeparatorOrientation};


### PR DESCRIPTION
## Summary
- add Tailwind-style responsive breakpoint helpers to `blinc_cn` (`640/768/1024/1280/1536`)
- expose `DeviceClass` helpers through `components`, `cn`, and `prelude`
- make `scroll_area` responsive by default (parent-following size when width/height are not set)
- adapt default scrollbar thickness by device class while keeping explicit overrides

## Test Plan
- cargo fmt --all
- cargo fmt --all -- --check
- cargo test -p blinc_cn
