### PR TITLE
fix(app): resolve Android and iOS layout context field access

### DIFF
--- a/crates/blinc_app/src/android.rs
+++ b/crates/blinc_app/src/android.rs
@@ -966,7 +966,9 @@ impl AndroidApp {
                         needs_redraw_next_frame = true;
                         // Apply animated layout properties and recompute layout if needed
                         if tree.apply_animated_layout_props() {
-                            tree.compute_layout(ctx.width, ctx.height);
+                            if let Some(ref windowed_ctx) = ctx {
+                                tree.compute_layout(windowed_ctx.width, windowed_ctx.height);
+                            }
                         }
                     }
                 }

--- a/crates/blinc_app/src/ios.rs
+++ b/crates/blinc_app/src/ios.rs
@@ -488,7 +488,7 @@ impl IOSRenderContext {
                 tree.apply_all_css_animation_props();
                 tree.apply_all_css_transition_props();
                 if tree.apply_animated_layout_props() {
-                    tree.compute_layout(self.width, self.height);
+                    tree.compute_layout(self.windowed_ctx.width, self.windowed_ctx.height);
                 }
             }
             self.last_frame_time_ms = current_time;
@@ -1128,7 +1128,7 @@ pub extern "C" fn blinc_tick_animations(ctx: *mut IOSRenderContext) -> bool {
                 tree.apply_all_css_animation_props();
                 tree.apply_all_css_transition_props();
                 if tree.apply_animated_layout_props() {
-                    tree.compute_layout(ctx.width, ctx.height);
+                    tree.compute_layout(ctx.windowed_ctx.width, ctx.windowed_ctx.height);
                 }
             }
             ctx.last_frame_time_ms = current_time;


### PR DESCRIPTION
## Summary
- fix Android compile error in `crates/blinc_app/src/android.rs` where `ctx` (`Option<WindowedContext>`) was accessed directly
- fix iOS compile errors in `crates/blinc_app/src/ios.rs` by using `windowed_ctx.width/height` from `IOSRenderContext`
- keep behavior unchanged while removing invalid field access that caused `E0609`

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo check -p blinc_app --features android --target aarch64-linux-android`
- `cargo check -p blinc_app --no-default-features --features ios --target aarch64-apple-ios`
