### PR TITLE
feat(webview): add desktop webview foundation and packaging smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,110 @@ jobs:
       - name: Run cargo check
         run: cargo check --workspace --all-features
 
+  desktop-feature-matrix:
+    name: Desktop Feature Matrix (${{ matrix.os }} / ${{ matrix.profile }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            profile: feature-off
+            cargo_features: windowed
+          - os: ubuntu-latest
+            profile: feature-on
+            cargo_features: "windowed webview"
+          - os: macos-latest
+            profile: feature-off
+            cargo_features: windowed
+          - os: macos-latest
+            profile: feature-on
+            cargo_features: "windowed webview"
+          - os: windows-latest
+            profile: feature-off
+            cargo_features: windowed
+          - os: windows-latest
+            profile: feature-on
+            cargo_features: "windowed webview"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libxkbcommon-dev \
+            libwayland-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxcursor-dev \
+            libxi-dev \
+            libgl1-mesa-dev \
+            libegl1-mesa-dev \
+            libvulkan-dev \
+            libfontconfig1-dev
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-${{ matrix.profile }}-cargo-desktop-matrix-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.profile }}-cargo-desktop-matrix-
+
+      - name: Run desktop feature check
+        run: cargo check -p blinc_app --locked --no-default-features --features "${{ matrix.cargo_features }}"
+
+  packaging-smoke:
+    name: Packaging Smoke (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [macos, windows, linux]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure package smoke script is executable
+        run: chmod +x scripts/package-smoke.sh
+
+      - name: Run package smoke dry-run
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .sisyphus/evidence
+          log_path=".sisyphus/evidence/package-smoke-${{ matrix.target }}.log"
+          scripts/package-smoke.sh --target "${{ matrix.target }}" --dry-run 2>&1 | tee "$log_path"
+
+      - name: Validate smoke log markers
+        shell: bash
+        run: |
+          set -euo pipefail
+          log_path=".sisyphus/evidence/package-smoke-${{ matrix.target }}.log"
+          if ! grep -q "expected_from_meta:" "$log_path"; then
+            echo "error: expected_from_meta marker missing in $log_path" >&2
+            exit 1
+          fi
+          if ! grep -q "mode: dry-run" "$log_path"; then
+            echo "error: dry-run marker missing in $log_path" >&2
+            exit 1
+          fi
+
+      - name: Upload package smoke logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-smoke-${{ matrix.target }}-logs
+          path: |
+            .sisyphus/evidence/package-smoke-${{ matrix.target }}.log
+            toolchain/targets/${{ matrix.target }}.toml
+
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/crates/blinc_app/Cargo.toml
+++ b/crates/blinc_app/Cargo.toml
@@ -80,6 +80,7 @@ blinc_charts = { path = "../blinc_charts", version = "0.1.12" }
 [features]
 default = ["windowed"]
 windowed = ["winit", "blinc_platform_desktop", "blinc_gpu/desktop"]
+webview = ["windowed", "blinc_platform/webview", "blinc_platform_desktop?/webview"]
 android = ["blinc_platform_android", "android-activity", "ndk", "jni", "android_logger", "log", "tracing-android", "tracing-subscriber", "blinc_gpu/android"]
 ios = ["blinc_platform_ios", "blinc_gpu/ios"]
 harmony = ["blinc_gpu/harmony"]  # blinc_platform_harmony when target is available

--- a/crates/blinc_platform/Cargo.toml
+++ b/crates/blinc_platform/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["lib"]
 
 [features]
 default = []
+webview = []
 
 [dependencies]
 thiserror.workspace = true

--- a/crates/blinc_platform/src/error.rs
+++ b/crates/blinc_platform/src/error.rs
@@ -25,6 +25,14 @@ pub enum PlatformError {
     #[error("Platform not supported: {0}")]
     Unsupported(String),
 
+    /// Failed to create WebView
+    #[error("WebView creation failed: {0}")]
+    WebViewCreation(String),
+
+    /// WebView operation failed
+    #[error("WebView operation failed: {0}")]
+    WebViewOperation(String),
+
     /// Generic platform error
     #[error("Platform error: {0}")]
     Other(String),

--- a/crates/blinc_platform/src/lib.rs
+++ b/crates/blinc_platform/src/lib.rs
@@ -47,6 +47,8 @@ mod error;
 mod event;
 mod input;
 mod platform;
+#[cfg(feature = "webview")]
+mod webview;
 mod window;
 
 // Re-export all public types
@@ -57,6 +59,12 @@ pub use input::{
     TouchEvent,
 };
 pub use platform::Platform;
+#[cfg(feature = "webview")]
+pub use webview::{
+    WebView, WebViewBounds, WebViewConfig, WebViewError, WebViewEvent, WebViewEventHandler,
+    WebViewHost, WebViewId, WebViewNavigationBlockReason, WebViewNavigationDecision,
+    WebViewNavigationPolicy,
+};
 pub use window::{Cursor, Window, WindowConfig};
 
 // Re-export commonly used asset types
@@ -74,5 +82,11 @@ pub mod prelude {
         TouchEvent,
     };
     pub use crate::platform::Platform;
+    #[cfg(feature = "webview")]
+    pub use crate::webview::{
+        WebView, WebViewBounds, WebViewConfig, WebViewError, WebViewEvent, WebViewEventHandler,
+        WebViewHost, WebViewId, WebViewNavigationBlockReason, WebViewNavigationDecision,
+        WebViewNavigationPolicy,
+    };
     pub use crate::window::{Cursor, Window, WindowConfig};
 }

--- a/crates/blinc_platform/src/webview.rs
+++ b/crates/blinc_platform/src/webview.rs
@@ -1,0 +1,411 @@
+//! WebView abstraction for embedded web content.
+
+use crate::error::Result;
+
+/// WebView bounds in logical pixels.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct WebViewBounds {
+    /// Left position relative to the host window.
+    pub x: f32,
+    /// Top position relative to the host window.
+    pub y: f32,
+    /// Width in logical pixels.
+    pub width: f32,
+    /// Height in logical pixels.
+    pub height: f32,
+}
+
+impl WebViewBounds {
+    /// Create a new set of bounds.
+    pub const fn new(x: f32, y: f32, width: f32, height: f32) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+}
+
+/// Why a navigation request was blocked by policy.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WebViewNavigationBlockReason {
+    /// URL could not be parsed into a valid origin.
+    MalformedUrl,
+    /// URL origin is not in the allowlist.
+    OriginNotAllowed,
+}
+
+/// Policy decision for a navigation request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WebViewNavigationDecision {
+    /// Navigation is allowed.
+    Allowed {
+        /// Original input URL.
+        url: String,
+        /// Canonical origin used for allowlist matching.
+        origin: String,
+    },
+    /// Navigation is blocked.
+    Blocked {
+        /// Original input URL.
+        url: String,
+        /// Parsed origin when available.
+        origin: Option<String>,
+        /// Why policy blocked the request.
+        reason: WebViewNavigationBlockReason,
+    },
+}
+
+/// Restrictive navigation policy for WebView URL loading.
+///
+/// Defaults to an explicit allowlist with no entries, which blocks all
+/// navigation until the host app opts in specific origins.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WebViewNavigationPolicy {
+    /// Canonical allowed origins (for example, `https://example.com`).
+    pub allowed_origins: Vec<String>,
+}
+
+impl Default for WebViewNavigationPolicy {
+    fn default() -> Self {
+        Self {
+            allowed_origins: Vec::new(),
+        }
+    }
+}
+
+impl WebViewNavigationPolicy {
+    /// Create a new restrictive policy.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add an allowed origin.
+    ///
+    /// Invalid origins are ignored to keep configuration deterministic.
+    pub fn allow_origin(mut self, origin: impl Into<String>) -> Self {
+        let raw = origin.into();
+        if let Some(canonical) = canonical_origin(&raw) {
+            if !self
+                .allowed_origins
+                .iter()
+                .any(|existing| existing == &canonical)
+            {
+                self.allowed_origins.push(canonical);
+            }
+        }
+        self
+    }
+
+    /// Add multiple allowed origins.
+    pub fn allow_origins<I, S>(mut self, origins: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for origin in origins {
+            self = self.allow_origin(origin);
+        }
+        self
+    }
+
+    /// Evaluate whether a URL should be allowed.
+    pub fn evaluate(&self, url: &str) -> WebViewNavigationDecision {
+        let input = url.trim().to_string();
+        let Some(origin) = canonical_origin(&input) else {
+            return WebViewNavigationDecision::Blocked {
+                url: input,
+                origin: None,
+                reason: WebViewNavigationBlockReason::MalformedUrl,
+            };
+        };
+
+        if self
+            .allowed_origins
+            .iter()
+            .any(|allowed| allowed == &origin)
+        {
+            WebViewNavigationDecision::Allowed { url: input, origin }
+        } else {
+            WebViewNavigationDecision::Blocked {
+                url: input,
+                origin: Some(origin),
+                reason: WebViewNavigationBlockReason::OriginNotAllowed,
+            }
+        }
+    }
+}
+
+fn canonical_origin(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let (scheme, remainder) = trimmed.split_once("://")?;
+    let scheme = scheme.to_ascii_lowercase();
+    if scheme != "http" && scheme != "https" {
+        return None;
+    }
+
+    let authority = remainder
+        .split(['/', '?', '#'])
+        .next()
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())?;
+    if authority.contains('@') || authority.contains(' ') {
+        return None;
+    }
+
+    let (host, port) = parse_host_and_port(authority)?;
+    Some(match port {
+        Some(port) => format!("{scheme}://{host}:{port}"),
+        None => format!("{scheme}://{host}"),
+    })
+}
+
+fn parse_host_and_port(authority: &str) -> Option<(String, Option<u16>)> {
+    if authority.starts_with('[') {
+        let end = authority.find(']')?;
+        let host = authority[..=end].to_ascii_lowercase();
+        if host.len() <= 2 {
+            return None;
+        }
+
+        let remainder = &authority[end + 1..];
+        if remainder.is_empty() {
+            return Some((host, None));
+        }
+
+        let port = remainder.strip_prefix(':')?.parse::<u16>().ok()?;
+        return Some((host, Some(port)));
+    }
+
+    let mut parts = authority.splitn(2, ':');
+    let host = parts.next()?.trim().to_ascii_lowercase();
+    if host.is_empty() {
+        return None;
+    }
+
+    let port = match parts.next() {
+        Some(raw_port) => {
+            if raw_port.is_empty() {
+                return None;
+            }
+            Some(raw_port.parse::<u16>().ok()?)
+        }
+        None => None,
+    };
+
+    Some((host, port))
+}
+
+/// WebView creation configuration.
+#[derive(Clone, Debug, PartialEq)]
+pub struct WebViewConfig {
+    /// Initial navigation target.
+    pub initial_url: Option<String>,
+    /// Initial embedded bounds.
+    pub bounds: WebViewBounds,
+    /// Navigation allowlist policy.
+    pub navigation_policy: WebViewNavigationPolicy,
+    /// Whether local file access is permitted.
+    pub allow_file_access: bool,
+    /// Whether remote debugging is enabled.
+    pub enable_remote_debugging: bool,
+}
+
+impl Default for WebViewConfig {
+    fn default() -> Self {
+        Self {
+            initial_url: None,
+            bounds: WebViewBounds::new(0.0, 0.0, 0.0, 0.0),
+            navigation_policy: WebViewNavigationPolicy::default(),
+            allow_file_access: false,
+            enable_remote_debugging: false,
+        }
+    }
+}
+
+impl WebViewConfig {
+    /// Create a new WebView configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the initial URL to navigate after creation.
+    pub fn initial_url(mut self, initial_url: impl Into<String>) -> Self {
+        self.initial_url = Some(initial_url.into());
+        self
+    }
+
+    /// Set the initial WebView bounds.
+    pub fn bounds(mut self, bounds: WebViewBounds) -> Self {
+        self.bounds = bounds;
+        self
+    }
+
+    /// Set navigation allowlist policy.
+    pub fn navigation_policy(mut self, navigation_policy: WebViewNavigationPolicy) -> Self {
+        self.navigation_policy = navigation_policy;
+        self
+    }
+
+    /// Set file-access capability.
+    pub fn allow_file_access(mut self, allow_file_access: bool) -> Self {
+        self.allow_file_access = allow_file_access;
+        self
+    }
+
+    /// Set remote debugging capability.
+    pub fn enable_remote_debugging(mut self, enable_remote_debugging: bool) -> Self {
+        self.enable_remote_debugging = enable_remote_debugging;
+        self
+    }
+}
+
+/// Stable identifier for a WebView instance.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct WebViewId(pub u64);
+
+/// WebView error details for asynchronous callback/reporting paths.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WebViewError {
+    /// WebView failed to initialize.
+    CreationFailed(String),
+    /// A navigation request failed.
+    NavigationFailed(String),
+    /// Message bridge failed.
+    MessageFailed(String),
+    /// Any backend-specific error.
+    Other(String),
+}
+
+/// WebView lifecycle and bridge events.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WebViewEvent {
+    /// WebView is initialized and ready.
+    Ready,
+    /// Navigation started for a URL.
+    NavigationStarted(String),
+    /// Navigation finished for a URL.
+    NavigationFinished(String),
+    /// Message received from web content.
+    Message(String),
+    /// Error emitted by the backend.
+    Error(WebViewError),
+}
+
+/// Callback invoked for WebView events.
+pub type WebViewEventHandler = Box<dyn Fn(WebViewEvent) + Send + Sync + 'static>;
+
+/// WebView abstraction used by platform backends.
+pub trait WebView: Send {
+    /// Get the stable WebView identifier.
+    fn id(&self) -> WebViewId;
+
+    /// Destroy this WebView and release platform resources.
+    fn destroy(&mut self) -> Result<()>;
+
+    /// Update WebView bounds within the host window.
+    fn set_bounds(&self, bounds: WebViewBounds) -> Result<()>;
+
+    /// Navigate WebView to the provided URL.
+    fn navigate(&self, url: &str) -> Result<()>;
+
+    /// Post a message to web content.
+    fn post_message(&self, message: &str) -> Result<()>;
+
+    /// Register or clear the event callback.
+    fn set_event_handler(&mut self, handler: Option<WebViewEventHandler>) -> Result<()>;
+}
+
+/// Host capability for creating WebViews.
+pub trait WebViewHost: Send + Sync {
+    /// Concrete WebView type used by this host.
+    type WebView: WebView;
+
+    /// Create a new WebView instance.
+    fn create_webview(&self, config: WebViewConfig) -> Result<Self::WebView>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_webview_bounds_constructor() {
+        let bounds = WebViewBounds::new(10.0, 20.0, 300.0, 200.0);
+
+        assert_eq!(bounds.x, 10.0);
+        assert_eq!(bounds.y, 20.0);
+        assert_eq!(bounds.width, 300.0);
+        assert_eq!(bounds.height, 200.0);
+    }
+
+    #[test]
+    fn test_webview_config_builder() {
+        let bounds = WebViewBounds::new(0.0, 0.0, 640.0, 480.0);
+        let config = WebViewConfig::new()
+            .initial_url("https://example.com")
+            .bounds(bounds)
+            .navigation_policy(WebViewNavigationPolicy::new().allow_origin("https://example.com"));
+
+        assert_eq!(config.initial_url.as_deref(), Some("https://example.com"));
+        assert_eq!(config.bounds, bounds);
+        assert_eq!(
+            config.navigation_policy.allowed_origins,
+            vec!["https://example.com"]
+        );
+        assert!(!config.allow_file_access);
+        assert!(!config.enable_remote_debugging);
+    }
+
+    #[test]
+    fn test_navigation_policy_allows_origin() {
+        let policy = WebViewNavigationPolicy::new().allow_origin("https://example.com");
+
+        let decision = policy.evaluate("https://example.com/docs");
+
+        assert_eq!(
+            decision,
+            WebViewNavigationDecision::Allowed {
+                url: "https://example.com/docs".to_string(),
+                origin: "https://example.com".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_navigation_policy_blocks_disallowed_origin() {
+        let policy = WebViewNavigationPolicy::new().allow_origin("https://example.com");
+
+        let decision = policy.evaluate("https://not-allowed.example/path");
+
+        assert_eq!(
+            decision,
+            WebViewNavigationDecision::Blocked {
+                url: "https://not-allowed.example/path".to_string(),
+                origin: Some("https://not-allowed.example".to_string()),
+                reason: WebViewNavigationBlockReason::OriginNotAllowed,
+            }
+        );
+    }
+
+    #[test]
+    fn test_navigation_policy_blocks_malformed_url() {
+        let policy = WebViewNavigationPolicy::new().allow_origin("https://example.com");
+
+        let decision = policy.evaluate("not-a-valid-url");
+
+        assert_eq!(
+            decision,
+            WebViewNavigationDecision::Blocked {
+                url: "not-a-valid-url".to_string(),
+                origin: None,
+                reason: WebViewNavigationBlockReason::MalformedUrl,
+            }
+        );
+    }
+}

--- a/docs/plans/2026-02-13-blinc-webview-embed-packaging-baseline.md
+++ b/docs/plans/2026-02-13-blinc-webview-embed-packaging-baseline.md
@@ -1,0 +1,31 @@
+# Blinc WebView Embedding Packaging Baseline (macOS/Windows/Linux)
+
+Task 6 baseline for release packaging in the `Blinc-wt-webview-packaging` worktree.
+
+## Source of Truth
+
+- `toolchain/targets/macos.toml`
+- `toolchain/targets/windows.toml`
+- `toolchain/targets/linux.toml`
+
+## Baseline Output Contract
+
+| Target | Artifact name | Default output path (smoke) | Signing / security assumptions |
+| --- | --- | --- | --- |
+| macOS | `BlincApp.app` | `target/package/macos/BlincApp.app` | Code signing identity from `[signing].identity` (default `-` for ad-hoc). Optional notarization is controlled by `[notarization]` fields and environment (`BLINC_APPLE_ID`, `BLINC_APPLE_PASSWORD`, `BLINC_APPLE_TEAM_ID`). |
+| Windows | `blincapp.exe` and installer `blincapp.msix` | `target/package/windows/blincapp.exe` and `target/package/windows/blincapp.msix` | Release signing from `[signing].certificate` and password via env when enabled. |
+| Linux | `blinc-app` and `blinc-app.AppImage` | `target/package/linux/blinc-app` and `target/package/linux/blinc-app.AppImage` | Not required in smoke by default; package metadata exists in `[appimage]`, `[flatpak]`, `[snap]` sections.
+
+## Script Contract (`scripts/package-smoke.sh`)
+
+- Target filter required via one or multiple `--target` values (`macos`, `windows`, `linux`).
+- `--dry-run` prints deterministic build command plan and resolved artifact paths.
+- `--output-root` defaults to `target/package`.
+- `--expect-artifact <path>` verifies an artifact exists; returns non-zero with a clear error if missing.
+- `--version` can override version metadata shown in output.
+
+## Non-goals for Task 6
+
+- App-store submission and distribution storefront workflows.
+- Runtime code changes to `blinc_platform`, `blinc_app`, or rendering crates.
+- Signing certificate bootstrap logic.

--- a/docs/plans/2026-02-13-blinc-webview-embed-release-runbook.md
+++ b/docs/plans/2026-02-13-blinc-webview-embed-release-runbook.md
@@ -1,0 +1,70 @@
+# Blinc WebView Embed Packaging Release Runbook (Task 8)
+
+Final verification and rollback runbook for the `Blinc-wt-webview-packaging` worktree.
+
+## Scope
+
+- Consolidate final release checks for formatting, compile/test/build, and packaging smoke.
+- Capture rollback procedures for compile-time and runtime fallback behavior.
+- Keep package-smoke checks deterministic by using `--dry-run`.
+
+## Final Verification Commands
+
+Run from repository root:
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo check --workspace --all-features
+cargo test --workspace --all-features
+cargo build --workspace --all-features
+./scripts/package-smoke.sh --dry-run --target macos --target windows --target linux
+./scripts/package-smoke.sh --dry-run --target macos --expect-artifact target/package/macos/__missing__.app
+```
+
+## Expected Results
+
+- `cargo fmt --all` completes without changing tracked formatting policy.
+- `cargo fmt --all -- --check` exits with status `0`.
+- `cargo check --workspace --all-features` exits with status `0`.
+- `cargo test --workspace --all-features` exits with status `0`.
+- `cargo build --workspace --all-features` exits with status `0`.
+- `scripts/package-smoke.sh --dry-run ...` prints target metadata and deterministic artifact paths for macOS/Windows/Linux.
+- Negative artifact check exits non-zero with:
+  - `error: expected artifact not found: target/package/macos/__missing__.app`
+
+## Rollback Procedures
+
+### 1) Compile-time rollback: disable `webview` feature
+
+Use this when the embedded WebView integration must be excluded from build output.
+
+```bash
+cargo check -p blinc_app --no-default-features --features windowed
+```
+
+What this achieves:
+
+- Removes `webview` feature-gated code paths from compilation.
+- Keeps desktop `windowed` flow compile-valid without embedded webview dependency activation.
+
+### 2) Runtime rollback: unset WebView env controls
+
+Use this when you want runtime behavior to avoid custom webview URL/origin inputs.
+
+```bash
+unset BLINC_WEBVIEW_URL
+unset BLINC_WEBVIEW_ALLOW_ORIGINS
+```
+
+What this achieves:
+
+- `BLINC_WEBVIEW_URL` unset: no explicit startup URL override is provided.
+- `BLINC_WEBVIEW_ALLOW_ORIGINS` unset: policy falls back to default restrictive behavior.
+- Desktop lifecycle remains graceful when webview backend is unavailable (`PlatformError::Unavailable` is non-fatal).
+
+## Release Operator Notes
+
+- `scripts/package-smoke.sh` supports dry-run validation for `macos`, `windows`, and `linux` targets and reports expected artifact locations.
+- Keep negative artifact check in the final gate to ensure missing outputs fail loudly before release publication.
+- If verification regresses, run rollback steps first, then re-run the command block above to confirm stabilization.

--- a/extensions/blinc_platform_desktop/Cargo.toml
+++ b/extensions/blinc_platform_desktop/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["lib"]
 
 [features]
 default = []
+webview = ["blinc_platform/webview"]
 
 [dependencies]
 # Platform abstraction

--- a/extensions/blinc_platform_desktop/src/event_loop.rs
+++ b/extensions/blinc_platform_desktop/src/event_loop.rs
@@ -159,6 +159,24 @@ where
         self.last_scroll_event_at = None;
         self.scroll_end_pending = false;
     }
+
+    fn sync_webview_bounds(&self) {
+        #[cfg(feature = "webview")]
+        if let Some(ref window) = self.window {
+            if let Err(error) = window.sync_webview_bounds() {
+                tracing::warn!("Failed to sync desktop webview bounds: {}", error);
+            }
+        }
+    }
+
+    fn cleanup_webviews(&self) {
+        #[cfg(feature = "webview")]
+        if let Some(ref window) = self.window {
+            if let Err(error) = window.cleanup_webviews() {
+                tracing::warn!("Failed to cleanup desktop webview resources: {}", error);
+            }
+        }
+    }
 }
 
 impl<F> ApplicationHandler for DesktopApp<F>
@@ -213,6 +231,7 @@ where
                     width: size.width,
                     height: size.height,
                 }));
+                self.sync_webview_bounds();
             }
 
             WinitWindowEvent::Moved(pos) => {
@@ -230,6 +249,7 @@ where
                 self.handle_event(Event::Window(WindowEvent::ScaleFactorChanged {
                     scale_factor,
                 }));
+                self.sync_webview_bounds();
             }
 
             WinitWindowEvent::RedrawRequested => {
@@ -328,6 +348,7 @@ where
 
         // Check for exit
         if self.should_exit {
+            self.cleanup_webviews();
             event_loop.exit();
         }
     }

--- a/extensions/blinc_platform_desktop/src/lib.rs
+++ b/extensions/blinc_platform_desktop/src/lib.rs
@@ -32,9 +32,13 @@
 
 pub mod event_loop;
 pub mod input;
+#[cfg(feature = "webview")]
+pub mod webview;
 pub mod window;
 
 pub use event_loop::{DesktopEventLoop, WakeProxy};
+#[cfg(feature = "webview")]
+pub use webview::{DesktopWebView, DesktopWebViewHost};
 pub use window::DesktopWindow;
 
 use blinc_platform::{Platform, PlatformError, WindowConfig};

--- a/extensions/blinc_platform_desktop/src/webview.rs
+++ b/extensions/blinc_platform_desktop/src/webview.rs
@@ -1,0 +1,123 @@
+//! Desktop WebView adapter surface.
+
+use blinc_platform::{
+    PlatformError, Result, WebView, WebViewBounds, WebViewConfig, WebViewEventHandler, WebViewHost,
+    WebViewId,
+};
+use std::sync::{Arc, Mutex, MutexGuard};
+use winit::window::Window as WinitWindow;
+
+const BACKEND_UNAVAILABLE_REASON: &str =
+    "desktop webview backend adapter is not linked in this build";
+
+#[derive(Default)]
+struct DesktopWebViewHostState {
+    cleaned_up: bool,
+}
+
+/// Desktop-side host for creating and managing embedded WebViews.
+#[derive(Clone)]
+pub struct DesktopWebViewHost {
+    window: Arc<WinitWindow>,
+    state: Arc<Mutex<DesktopWebViewHostState>>,
+}
+
+impl DesktopWebViewHost {
+    pub(crate) fn new(window: Arc<WinitWindow>) -> Self {
+        Self {
+            window,
+            state: Arc::new(Mutex::new(DesktopWebViewHostState::default())),
+        }
+    }
+
+    /// Lifecycle hook for window-size/scale updates.
+    pub fn sync_bounds_with_window(&self) -> Result<()> {
+        let state = self.lock_state()?;
+        if state.cleaned_up {
+            return Err(PlatformError::Unavailable(
+                "desktop webview host already cleaned up".to_string(),
+            ));
+        }
+
+        // Keep deterministic behavior until a concrete backend is linked.
+        let _ = self.window.scale_factor();
+        Ok(())
+    }
+
+    /// Lifecycle hook for explicit cleanup on window teardown.
+    pub fn cleanup(&self) -> Result<()> {
+        let mut state = self.lock_state()?;
+        state.cleaned_up = true;
+        Ok(())
+    }
+
+    fn lock_state(&self) -> Result<MutexGuard<'_, DesktopWebViewHostState>> {
+        self.state.lock().map_err(|_| {
+            PlatformError::Other("desktop webview host state lock poisoned".to_string())
+        })
+    }
+
+    fn unavailable_error(&self, action: &str) -> PlatformError {
+        PlatformError::Unavailable(format!(
+            "desktop webview {action} unavailable for window {:?}: {BACKEND_UNAVAILABLE_REASON}",
+            self.window.id()
+        ))
+    }
+}
+
+impl WebViewHost for DesktopWebViewHost {
+    type WebView = DesktopWebView;
+
+    fn create_webview(&self, _config: WebViewConfig) -> Result<Self::WebView> {
+        let state = self.lock_state()?;
+        if state.cleaned_up {
+            return Err(PlatformError::Unavailable(
+                "desktop webview host already cleaned up".to_string(),
+            ));
+        }
+        drop(state);
+
+        Err(self.unavailable_error("creation"))
+    }
+}
+
+/// Desktop-side WebView handle.
+pub struct DesktopWebView {
+    id: WebViewId,
+}
+
+impl WebView for DesktopWebView {
+    fn id(&self) -> WebViewId {
+        self.id
+    }
+
+    fn destroy(&mut self) -> Result<()> {
+        Err(PlatformError::Unavailable(format!(
+            "desktop webview destroy unavailable: {BACKEND_UNAVAILABLE_REASON}"
+        )))
+    }
+
+    fn set_bounds(&self, _bounds: WebViewBounds) -> Result<()> {
+        Err(PlatformError::Unavailable(format!(
+            "desktop webview bounds update unavailable: {BACKEND_UNAVAILABLE_REASON}"
+        )))
+    }
+
+    fn navigate(&self, _url: &str) -> Result<()> {
+        Err(PlatformError::Unavailable(format!(
+            "desktop webview navigation unavailable: {BACKEND_UNAVAILABLE_REASON}"
+        )))
+    }
+
+    fn post_message(&self, _message: &str) -> Result<()> {
+        Err(PlatformError::Unavailable(format!(
+            "desktop webview messaging unavailable: {BACKEND_UNAVAILABLE_REASON}"
+        )))
+    }
+
+    fn set_event_handler(&mut self, _handler: Option<WebViewEventHandler>) -> Result<()> {
+        Err(PlatformError::Unavailable(format!(
+            "desktop webview event handler unavailable: {BACKEND_UNAVAILABLE_REASON}"
+        )))
+    }
+}

--- a/scripts/package-smoke.sh
+++ b/scripts/package-smoke.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_DIR="${SCRIPT_DIR}/toolchain/targets"
+
+selected_targets=()
+expect_artifact=""
+dry_run=0
+output_root="${BLINC_PACKAGE_OUTPUT_ROOT:-target/package}"
+build_cmd="${BLINC_BUILD_CMD:-blinc}"
+version="${BLINC_PACKAGE_VERSION:-1.0.0}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  package-smoke.sh [--target macos|windows|linux] [--dry-run] [--output-root DIR]
+                    [--expect-artifact PATH] [--version VERSION]
+
+  --target TARGET        Filter targets. Repeatable. Defaults to all targets.
+  --dry-run              Print commands only.
+  --output-root DIR      Directory where artifacts are expected.
+  --expect-artifact PATH Require this artifact to exist.
+  --version VERSION      Version override used in output metadata.
+  -h, --help            Show this help text.
+EOF
+}
+
+is_valid_target() {
+  case "$1" in
+    macos|windows|linux)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --target)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --target requires a target name" >&2
+        usage
+        exit 2
+      fi
+      selected_targets+=("$2")
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --output-root)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --output-root requires a value" >&2
+        usage
+        exit 2
+      fi
+      output_root="$2"
+      shift 2
+      ;;
+    --expect-artifact)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --expect-artifact requires a path" >&2
+        usage
+        exit 2
+      fi
+      expect_artifact="$2"
+      shift 2
+      ;;
+    --version)
+      if [[ "$#" -lt 2 ]]; then
+        echo "error: --version requires a value" >&2
+        usage
+        exit 2
+      fi
+      version="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ${#selected_targets[@]} -eq 0 ]]; then
+  selected_targets=(macos windows linux)
+fi
+
+validate_targets() {
+  for t in "${selected_targets[@]}"; do
+    if ! is_valid_target "$t"; then
+      echo "error: unsupported target '$t'" >&2
+      echo "valid targets: macos windows linux" >&2
+      exit 2
+    fi
+
+    if [[ ! -f "${TARGET_DIR}/${t}.toml" ]]; then
+      echo "error: missing config file ${TARGET_DIR}/${t}.toml" >&2
+      exit 2
+    fi
+  done
+}
+
+get_target_meta() {
+  local target=$1
+  local config="${TARGET_DIR}/${target}.toml"
+
+  python3 - "$target" "$config" "$version" <<'PY'
+import re
+import sys
+import tomllib
+
+target = sys.argv[1]
+config_path = sys.argv[2]
+version = sys.argv[3]
+
+text = open(config_path, "rb").read()
+config = tomllib.loads(text.decode("utf-8"))
+
+
+def slugify(value: str) -> str:
+    value = (value or "").strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = value.strip("-")
+    return value or "blincapp"
+
+
+if target == "macos":
+    bundle = config.get("bundle", {})
+    signing = config.get("signing", {})
+    notarization = config.get("notarization", {})
+    artifact = f"{bundle.get('bundle_name', 'BlincApp')}.app"
+    print(f"bundle_name={bundle.get('bundle_name', 'BlincApp')}")
+    print(f"artifact={artifact}")
+    print(f"bundle_id={bundle.get('bundle_identifier', 'com.example.blincapp')}")
+    print(f"bundle_version={bundle.get('bundle_version', version)}")
+    print(f"identity={signing.get('identity', '-')}")
+    print(f"hardened_runtime={signing.get('hardened_runtime', True)}")
+    print(f"notarization_enabled={bool(notarization.get('apple_id'))}")
+    print("signing_profile=")
+elif target == "windows":
+    executable = config.get("executable", {})
+    installer = config.get("installer", {})
+    signing = config.get("signing", {})
+    artifact = executable.get("original_filename", "blincapp.exe")
+    print(f"executable={artifact}")
+    print(f"product_name={executable.get('product_name', 'BlincApp')}")
+    print(f"file_version={executable.get('file_version', f'{version}.0')}")
+    print(f"installer_type={installer.get('type', 'msix')}")
+    print(f"publisher={installer.get('publisher', '')}")
+    print(f"certificate={signing.get('certificate', '')}")
+    print(f"timestamp_url={signing.get('timestamp_url', '')}")
+    print("signing_profile=windows")
+elif target == "linux":
+    desktop = config.get("desktop", {})
+    flatpak = config.get("flatpak", {})
+    appimage = config.get("appimage", {})
+    bundle = config.get("bundle", {})
+    name = desktop.get("name", "Blinc App")
+    slug = slugify(name)
+    print(f"desktop_name={name}")
+    print(f"desktop_slug={slug}")
+    print(f"app_id={flatpak.get('app_id', 'com.example.BlincApp')}")
+    print(f"bundle_version={bundle.get('bundle_version', version)}")
+    print(f"appimage_enabled={appimage.get('enabled', True)}")
+    print(f"artifact={slug}")
+    print(f"appimage_artifact={slug}.AppImage")
+    print(f"signing_profile={flatpak.get('app_id', 'com.example.BlincApp')}")
+else:
+    raise SystemExit(1)
+PY
+}
+
+run_target() {
+  local target=$1
+  local out_dir="${output_root}/${target}"
+  mkdir -p "$out_dir"
+
+  local meta
+  local kv_bundle_name=""
+  local kv_bundle_id=""
+  local kv_bundle_version=""
+  local kv_identity=""
+  local kv_hardened_runtime=""
+  local kv_notarization_enabled=""
+  local kv_executable=""
+  local kv_product_name=""
+  local kv_file_version=""
+  local kv_installer_type=""
+  local kv_publisher=""
+  local kv_certificate=""
+  local kv_timestamp_url=""
+  local kv_desktop_name=""
+  local kv_desktop_slug=""
+  local kv_app_id=""
+  local kv_appimage_enabled=""
+  local kv_artifact=""
+  local kv_appimage_artifact=""
+  local kv_signing_profile=""
+
+  meta=$(get_target_meta "$target")
+
+  while IFS='=' read -r key value; do
+    [ -z "$key" ] && continue
+    case "$key" in
+      bundle_name) kv_bundle_name="$value" ;;
+      bundle_id) kv_bundle_id="$value" ;;
+      bundle_version) kv_bundle_version="$value" ;;
+      identity) kv_identity="$value" ;;
+      hardened_runtime) kv_hardened_runtime="$value" ;;
+      notarization_enabled) kv_notarization_enabled="$value" ;;
+      executable) kv_executable="$value" ;;
+      product_name) kv_product_name="$value" ;;
+      file_version) kv_file_version="$value" ;;
+      installer_type) kv_installer_type="$value" ;;
+      publisher) kv_publisher="$value" ;;
+      certificate) kv_certificate="$value" ;;
+      timestamp_url) kv_timestamp_url="$value" ;;
+      desktop_name) kv_desktop_name="$value" ;;
+      desktop_slug) kv_desktop_slug="$value" ;;
+      app_id) kv_app_id="$value" ;;
+      appimage_enabled) kv_appimage_enabled="$value" ;;
+      artifact) kv_artifact="$value" ;;
+      appimage_artifact) kv_appimage_artifact="$value" ;;
+      signing_profile) kv_signing_profile="$value" ;;
+    esac
+  done <<<"$meta"
+
+  local command=("$build_cmd" "build" "--target" "$target" "--release")
+  local command_str
+  command_str="${command[*]}"
+  local artifact=""
+
+  case "$target" in
+    macos)
+      artifact="${out_dir}/${kv_artifact}"
+      command+=("--output" "$artifact")
+      echo "[dry-run:macos]"
+      echo "  artifact: $artifact"
+      echo "  bundle_id: ${kv_bundle_id}"
+      echo "  version: ${kv_bundle_version}"
+      echo "  signing: identity=${kv_identity} hardened_runtime=${kv_hardened_runtime} notarization=${kv_notarization_enabled}"
+      ;;
+    windows)
+      local exe_name="${kv_executable}"
+      local exe_path="${out_dir}/${exe_name}"
+      local installer="${out_dir}/blincapp.${kv_installer_type}"
+      artifact="$exe_path"
+      command+=("--output" "$exe_path")
+      echo "[dry-run:windows]"
+      echo "  exe: $exe_path"
+      echo "  installer: $installer"
+      echo "  signing: certificate_set=${kv_certificate:+yes}; timestamp=${kv_timestamp_url}; publisher=${kv_publisher}"
+      echo "  signing_profile=${kv_signing_profile}"
+      ;;
+    linux)
+      local binary="${kv_desktop_slug}"
+      local binary_path="${out_dir}/${binary}"
+      local appimage_path="${out_dir}/${kv_appimage_artifact}"
+      artifact="$binary_path"
+      command+=("--output" "$binary_path")
+      echo "[dry-run:linux]"
+      echo "  desktop_entry: ${binary}.desktop"
+      echo "  desktop_name: ${kv_desktop_name}"
+      echo "  binary: $binary_path"
+      echo "  appimage: $appimage_path (enabled=${kv_appimage_enabled})"
+      echo "  app_id: ${kv_app_id}"
+      echo "  signing_profile=${kv_signing_profile}"
+      ;;
+    *)
+      echo "error: unsupported target '$target'" >&2
+      return 1
+      ;;
+  esac
+
+  command_str="${command[*]}"
+  echo "  command: $command_str"
+  echo "  expected_from_meta: ${artifact}"
+
+  if [[ "$dry_run" == "1" ]]; then
+    echo "  mode: dry-run"
+  else
+    echo "  mode: execute"
+    "${command[@]}"
+  fi
+
+  if [[ -n "$expect_artifact" ]]; then
+    if [[ ! -f "$expect_artifact" ]]; then
+      echo "error: expected artifact not found: $expect_artifact" >&2
+      return 1
+    fi
+    echo "  expect-artifact: ok ($expect_artifact)"
+  fi
+
+  echo
+}
+
+validate_targets
+for target in "${selected_targets[@]}"; do
+  run_target "$target"
+done
+
+echo "package-smoke complete"


### PR DESCRIPTION
## Summary
- add a feature-gated WebView abstraction in `blinc_platform` and hook a desktop backend adapter into `WindowedApp` lifecycle with graceful fallback when backend is unavailable
- add restrictive navigation allowlist policy defaults and machine-grepable allow/block decision logging with unit coverage for allowed, blocked, and malformed URL paths
- add cross-platform packaging smoke automation (`scripts/package-smoke.sh`), CI desktop feature matrix checks, and final release runbook for 3-OS rollout/rollback steps

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features`
- `cargo test --workspace --all-features`
- `cargo build --workspace --all-features`
- `./scripts/package-smoke.sh --dry-run --target macos --target windows --target linux`
- `./scripts/package-smoke.sh --dry-run --target macos --expect-artifact target/package/macos/__missing__.app` (expected non-zero)