### PR TITLE
fix(ci): restore fork CI after upstream sync

### DIFF
--- a/crates/blinc_app/Cargo.toml
+++ b/crates/blinc_app/Cargo.toml
@@ -76,6 +76,7 @@ image.workspace = true
 tracing-subscriber.workspace = true
 blinc_cn = { path = "../blinc_cn", version = "0.1.12" }
 blinc_charts = { path = "../blinc_charts", version = "0.1.12" }
+blinc_icons = { path = "../blinc_icons", version = "0.1.12" }
 
 [features]
 default = ["windowed"]

--- a/crates/blinc_layout/src/stateful.rs
+++ b/crates/blinc_layout/src/stateful.rs
@@ -3900,16 +3900,6 @@ impl<S: StateTransitions> ElementBuilder for Stateful<S> {
         ElementTypeId::Div
     }
 
-    fn element_id(&self) -> Option<&str> {
-        // SAFETY: Same pattern as children_builders/layout_style - stable during rendering
-        unsafe { (*self.inner.as_ptr()).element_id.as_deref() }
-    }
-
-    fn element_classes(&self) -> &[String] {
-        // SAFETY: Same pattern as children_builders/layout_style - stable during rendering
-        unsafe { &(*self.inner.as_ptr()).classes }
-    }
-
     fn event_handlers(&self) -> Option<&crate::event_handler::EventHandlers> {
         // SAFETY: We use a raw pointer here because we need to return a reference
         // to the event handlers cache. The cache is stable during rendering.

--- a/crates/blinc_layout/src/widgets/checkbox.rs
+++ b/crates/blinc_layout/src/widgets/checkbox.rs
@@ -525,7 +525,7 @@ impl ElementBuilder for CheckboxBuilder {
 
 /// Create a checkbox with reactive checked state
 ///
-/// The checkbox uses Stateful<ButtonState> internally for hover detection,
+/// The checkbox uses `Stateful<ButtonState>` internally for hover detection,
 /// and connects to the `State<bool>` signal via `.deps()` for immediate
 /// visual updates on toggle.
 ///

--- a/crates/blinc_layout/src/widgets/radio.rs
+++ b/crates/blinc_layout/src/widgets/radio.rs
@@ -586,7 +586,7 @@ impl ElementBuilder for RadioGroupBuilder {
 
 /// Create a radio group with reactive state
 ///
-/// The radio group uses Stateful<ButtonState> internally for hover detection.
+/// The radio group uses `Stateful<ButtonState>` internally for hover detection.
 /// Use `.id("name")` to enable CSS styling via `:hover`, `:checked`, `:disabled`.
 ///
 /// # Example

--- a/crates/blinc_theme/src/presets/mod.rs
+++ b/crates/blinc_theme/src/presets/mod.rs
@@ -270,6 +270,7 @@ fn build_colors(base: BasePalette, scheme: ColorScheme) -> ColorTokens {
         text_inverse: base.primary_foreground,
         text_link: base.primary,
         border: base.border,
+        border_secondary: base.border,
         border_hover,
         border_focus: base.ring,
         border_error: base.destructive,


### PR DESCRIPTION
## Summary
- add missing `border_secondary` assignment in theme preset color builder
- remove duplicate `element_id`/`element_classes` implementations in `Stateful<S>`
- align GPU glass primitive API with merged paint code (`border_color`, `with_border_color`, `push_nested_glass` shim)
- add missing `blinc_icons` dev-dependency for `music_player` example build

## Verification
- cargo check -p blinc_theme
- cargo check --workspace
- cargo check --workspace --all-features
- cargo test --workspace --all-features --no-run
- cargo fmt --all
- cargo fmt --all -- --check

## Context
Main branch (`2d097a5`) was already updated directly during upstream sync. This PR contains only follow-up CI-fix commits for the fork.
