### PR TITLE
feat(charts): finalize charts package wrap-up and gallery controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,20 @@ Easing::EaseOutBounce    // Bounce effect
 | Fuschia | In progress | wgpu (Vulkan/Scenic) |
 | HarmonyOS | In progress | wgpu (Vulkan/OpenGL ES) |
 
+## BlincCharts D3 Capability Policy
+
+BlincCharts follows an explicit capability contract against D3 modules:
+
+- `Full`: equivalent capability exists in BlincCharts.
+- `Partial`: capability exists with a narrower surface or constraints.
+- `Missing`: no practical equivalent yet.
+- `Out-of-scope`: runtime/data/DOM helpers intentionally outside `blinc_charts`.
+
+Reference docs:
+
+- Capability matrix: `docs/references/2026-02-11-d3-blinccharts-capability-matrix.md`
+- Gap closure backlog/implementation plan: `docs/plans/2026-02-11-d3-blinccharts-gap-backlog.md`
+
 ## Roadmap
 
 ### Completed

--- a/crates/blinc_app/examples/charts_gallery_demo.rs
+++ b/crates/blinc_app/examples/charts_gallery_demo.rs
@@ -644,52 +644,61 @@ impl GalleryModels {
             ),
         };
 
-        if let Ok(mut m) = self.line.0.lock() {
+        Self::with_locked_model(&self.line.0, |m| {
             m.set_downsample_max_points(line_points);
-        }
-        if let Ok(mut m) = self.area.0.lock() {
+        });
+        Self::with_locked_model(&self.area.0, |m| {
             m.set_downsample_max_points(area_points);
-        }
-        if let Ok(mut m) = self.scatter.0.lock() {
+        });
+        Self::with_locked_model(&self.scatter.0, |m| {
             m.style.max_points = scatter_points.max(512);
             m.set_max_points(scatter_points);
-        }
-        if let Ok(mut m) = self.multi.0.lock() {
+        });
+        Self::with_locked_model(&self.multi.0, |m| {
             m.style.max_series = multi_series;
             m.style.max_total_segments = multi_segments;
             m.style.max_points_per_series = multi_points;
-        }
-        if let Ok(mut m) = self.bar.0.lock() {
+        });
+        Self::with_locked_model(&self.bar.0, |m| {
             m.style.max_bins = bar_bins;
-        }
-        if let Ok(mut m) = self.candle.0.lock() {
+        });
+        Self::with_locked_model(&self.candle.0, |m| {
             m.style.max_candles = candle_max;
-        }
-        if let Ok(mut m) = self.heat.0.lock() {
+        });
+        Self::with_locked_model(&self.heat.0, |m| {
             m.style.max_cells_x = heat_x;
             m.style.max_cells_y = heat_y;
-        }
-        if let Ok(mut m) = self.density.0.lock() {
+        });
+        Self::with_locked_model(&self.density.0, |m| {
             m.style.max_cells_x = density_x;
             m.style.max_cells_y = density_y;
             m.style.max_points = density_points;
-        }
-        if let Ok(mut m) = self.contour.0.lock() {
+        });
+        Self::with_locked_model(&self.contour.0, |m| {
             m.style.max_segments = contour_segments;
             m.style.levels = contour_levels;
-        }
-        if let Ok(mut m) = self.hierarchy.0.lock() {
+        });
+        Self::with_locked_model(&self.hierarchy.0, |m| {
             m.style.max_leaves = hierarchy_leaves;
-        }
-        if let Ok(mut m) = self.network.0.lock() {
+        });
+        Self::with_locked_model(&self.network.0, |m| {
             m.style.max_nodes = network_nodes;
             m.style.max_links = network_links;
-        }
-        if let Ok(mut m) = self.polar.0.lock() {
+        });
+        Self::with_locked_model(&self.polar.0, |m| {
             m.style.max_series = polar_series;
-        }
-        if let Ok(mut m) = self.geo.0.lock() {
+        });
+        Self::with_locked_model(&self.geo.0, |m| {
             m.style.max_points = geo_points;
+        });
+    }
+
+    fn with_locked_model<M, F>(model: &std::sync::Arc<std::sync::Mutex<M>>, apply: F)
+    where
+        F: FnOnce(&mut M),
+    {
+        if let Ok(mut locked) = model.lock() {
+            apply(&mut locked);
         }
     }
 
@@ -703,7 +712,7 @@ impl GalleryModels {
     }
 
     fn apply_advanced_series_options(&mut self, cfg: &GalleryConfig) {
-        if let Ok(mut m) = self.line.0.lock() {
+        Self::with_locked_model(&self.line.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Line) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -720,9 +729,9 @@ impl GalleryModels {
                 "max_points",
                 &[2_500, 8_000, 20_000, 60_000],
             ));
-        }
+        });
 
-        if let Ok(mut m) = self.area.0.lock() {
+        Self::with_locked_model(&self.area.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Area) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -741,9 +750,9 @@ impl GalleryModels {
                 "max_points",
                 &[2_500, 8_000, 20_000, 60_000],
             ));
-        }
+        });
 
-        if let Ok(mut m) = self.multi.0.lock() {
+        Self::with_locked_model(&self.multi.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::MultiLine) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -771,9 +780,9 @@ impl GalleryModels {
                 &[256, 512, 1_024, 2_048],
             );
             m.set_gap_dx(cfg.pick_f32(ChartKind::MultiLine, "gap_dx", &[2.0, 6.0, 10.0, 14.0]));
-        }
+        });
 
-        if let Ok(mut m) = self.bar.0.lock() {
+        Self::with_locked_model(&self.bar.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Bar) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -787,9 +796,9 @@ impl GalleryModels {
             m.style.scroll_zoom_factor =
                 cfg.pick_f32(ChartKind::Bar, "scroll", &[0.01, 0.02, 0.04]);
             m.style.pinch_zoom_min = cfg.pick_f32(ChartKind::Bar, "pinch", &[0.01, 0.05, 0.1]);
-        }
+        });
 
-        if let Ok(mut m) = self.hist.0.lock() {
+        Self::with_locked_model(&self.hist.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Histogram) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -802,9 +811,9 @@ impl GalleryModels {
                 cfg.pick_f32(ChartKind::Histogram, "scroll", &[0.01, 0.02, 0.04]);
             m.style.pinch_zoom_min =
                 cfg.pick_f32(ChartKind::Histogram, "pinch", &[0.01, 0.05, 0.1]);
-        }
+        });
 
-        if let Ok(mut m) = self.scatter.0.lock() {
+        Self::with_locked_model(&self.scatter.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Scatter) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -826,9 +835,9 @@ impl GalleryModels {
             );
             m.style.max_points = max_points.max(512);
             m.set_max_points(max_points);
-        }
+        });
 
-        if let Ok(mut m) = self.candle.0.lock() {
+        Self::with_locked_model(&self.candle.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Candlestick) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -849,11 +858,11 @@ impl GalleryModels {
                 cfg.pick_f32(ChartKind::Candlestick, "scroll", &[0.01, 0.02, 0.04]);
             m.style.pinch_zoom_min =
                 cfg.pick_f32(ChartKind::Candlestick, "pinch", &[0.01, 0.05, 0.1]);
-        }
+        });
     }
 
     fn apply_advanced_field_options(&mut self, cfg: &GalleryConfig) {
-        if let Ok(mut m) = self.heat.0.lock() {
+        Self::with_locked_model(&self.heat.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Heatmap) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -862,9 +871,9 @@ impl GalleryModels {
             m.style.max_cells_x =
                 cfg.pick_usize(ChartKind::Heatmap, "cells_x", &[64, 128, 192, 256]);
             m.style.max_cells_y = cfg.pick_usize(ChartKind::Heatmap, "cells_y", &[32, 64, 96, 128]);
-        }
+        });
 
-        if let Ok(mut m) = self.stacked_area.0.lock() {
+        Self::with_locked_model(&self.stacked_area.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::StackedArea) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -877,9 +886,9 @@ impl GalleryModels {
                 cfg.pick_f32(ChartKind::StackedArea, "scroll", &[0.01, 0.02, 0.04]);
             m.style.pinch_zoom_min =
                 cfg.pick_f32(ChartKind::StackedArea, "pinch", &[0.01, 0.05, 0.1]);
-        }
+        });
 
-        if let Ok(mut m) = self.density.0.lock() {
+        Self::with_locked_model(&self.density.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::DensityMap) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -898,9 +907,9 @@ impl GalleryModels {
                 cfg.pick_f32(ChartKind::DensityMap, "scroll", &[0.01, 0.02, 0.04]);
             m.style.pinch_zoom_min =
                 cfg.pick_f32(ChartKind::DensityMap, "pinch", &[0.01, 0.05, 0.1]);
-        }
+        });
 
-        if let Ok(mut m) = self.contour.0.lock() {
+        Self::with_locked_model(&self.contour.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Contour) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -925,9 +934,9 @@ impl GalleryModels {
             m.style.scroll_zoom_factor =
                 cfg.pick_f32(ChartKind::Contour, "scroll", &[0.01, 0.02, 0.04]);
             m.style.pinch_zoom_min = cfg.pick_f32(ChartKind::Contour, "pinch", &[0.01, 0.05, 0.1]);
-        }
+        });
 
-        if let Ok(mut m) = self.stats.0.lock() {
+        Self::with_locked_model(&self.stats.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Statistics) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -939,11 +948,11 @@ impl GalleryModels {
                 cfg.pick_f32(ChartKind::Statistics, "scroll", &[0.01, 0.02, 0.04]);
             m.style.pinch_zoom_min =
                 cfg.pick_f32(ChartKind::Statistics, "pinch", &[0.01, 0.05, 0.1]);
-        }
+        });
     }
 
     fn apply_advanced_structural_options(&mut self, cfg: &GalleryConfig) {
-        if let Ok(mut m) = self.hierarchy.0.lock() {
+        Self::with_locked_model(&self.hierarchy.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Hierarchy) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -955,9 +964,9 @@ impl GalleryModels {
                 "max_leaves",
                 &[600, 2_000, 4_000, 8_000],
             );
-        }
+        });
 
-        if let Ok(mut m) = self.network.0.lock() {
+        Self::with_locked_model(&self.network.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Network) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -974,9 +983,9 @@ impl GalleryModels {
             m.style.scroll_zoom_factor =
                 cfg.pick_f32(ChartKind::Network, "scroll", &[0.01, 0.02, 0.04]);
             m.style.pinch_zoom_min = cfg.pick_f32(ChartKind::Network, "pinch", &[0.01, 0.05, 0.1]);
-        }
+        });
 
-        if let Ok(mut m) = self.polar.0.lock() {
+        Self::with_locked_model(&self.polar.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Polar) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -990,11 +999,11 @@ impl GalleryModels {
             let range = ranges[cfg.option_index(ChartKind::Polar, "range", ranges.len())];
             m.style.min_value = 0.0;
             m.style.max_value = range;
-        }
+        });
     }
 
     fn apply_advanced_specialized_options(&mut self, cfg: &GalleryConfig) {
-        if let Ok(mut m) = self.gauge.0.lock() {
+        Self::with_locked_model(&self.gauge.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Gauge) {
                 m.style.bg = p.bg;
                 m.style.track = p.grid;
@@ -1013,18 +1022,18 @@ impl GalleryModels {
                 "transition_dt",
                 &[1.0 / 120.0, 1.0 / 90.0, 1.0 / 60.0, 1.0 / 30.0],
             );
-        }
+        });
 
-        if let Ok(mut m) = self.funnel.0.lock() {
+        Self::with_locked_model(&self.funnel.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Funnel) {
                 m.style.bg = p.bg;
                 m.style.text = p.text;
                 m.style.fill = p.b;
                 m.style.stroke = p.c;
             }
-        }
+        });
 
-        if let Ok(mut m) = self.geo.0.lock() {
+        Self::with_locked_model(&self.geo.0, |m| {
             if let Some(p) = cfg.theme_palette(ChartKind::Geo) {
                 m.style.bg = p.bg;
                 m.style.grid = p.grid;
@@ -1040,7 +1049,7 @@ impl GalleryModels {
             m.style.scroll_zoom_factor =
                 cfg.pick_f32(ChartKind::Geo, "scroll", &[0.01, 0.02, 0.04]);
             m.style.pinch_zoom_min = cfg.pick_f32(ChartKind::Geo, "pinch", &[0.01, 0.05, 0.1]);
-        }
+        });
     }
 }
 
@@ -1491,7 +1500,6 @@ fn control_panel(
     config: State<GalleryConfig>,
     models: State<GalleryModels>,
 ) -> impl ElementBuilder {
-    // Intentionally explicit: control chips map 1:1 to chart-kind option keys.
     let cfg = config.try_get().expect("config exists");
 
     let mut row = div()
@@ -1570,242 +1578,98 @@ fn control_panel(
         }));
     }
 
-    row = row.child(cycle_option_chip(
-        format!("Theme: T{}", cfg.option_index(item.kind, "theme", 4) + 1),
-        dense,
-        config.clone(),
-        models.clone(),
-        item.kind,
-        "theme",
-        4,
+    row = row.child(cycle_index_chip(
+        &cfg, dense, &config, &models, item.kind, "theme", "Theme: T", 4, 1,
     ));
 
     match item.kind {
         ChartKind::Line => {
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Stroke {:.1}",
-                    cfg.pick_f32(ChartKind::Line, "stroke", &[1.0, 1.5, 2.2, 3.0])
-                ),
+            let kind = ChartKind::Line;
+            row = row.child(cycle_f32_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Line,
+                &config,
+                &models,
+                kind,
                 "stroke",
-                4,
+                "Stroke",
+                &[1.0, 1.5, 2.2, 3.0],
+                1,
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "MaxPts {}",
-                    cfg.pick_usize(
-                        ChartKind::Line,
-                        "max_points",
-                        &[2_500, 8_000, 20_000, 60_000]
-                    )
-                ),
+            row = row.child(cycle_usize_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Line,
+                &config,
+                &models,
+                kind,
                 "max_points",
-                4,
+                "MaxPts",
+                &[2_500, 8_000, 20_000, 60_000],
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::Line, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Line,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::Line, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Line,
-                "pinch",
-                3,
-            ));
+            for (name, label, values) in [
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..]),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..]),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, 2,
+                ));
+            }
         }
         ChartKind::Area => {
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Stroke {:.1}",
-                    cfg.pick_f32(ChartKind::Area, "stroke", &[1.0, 1.5, 2.2, 3.0])
-                ),
+            let kind = ChartKind::Area;
+            for (name, label, values) in [
+                ("stroke", "Stroke", &[1.0, 1.5, 2.2, 3.0][..]),
+                ("baseline", "Baseline", &[-0.5, 0.0, 0.5][..]),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, 1,
+                ));
+            }
+            row = row.child(cycle_usize_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Area,
-                "stroke",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Baseline {:.1}",
-                    cfg.pick_f32(ChartKind::Area, "baseline", &[-0.5, 0.0, 0.5])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Area,
-                "baseline",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "MaxPts {}",
-                    cfg.pick_usize(
-                        ChartKind::Area,
-                        "max_points",
-                        &[2_500, 8_000, 20_000, 60_000]
-                    )
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Area,
+                &config,
+                &models,
+                kind,
                 "max_points",
-                4,
+                "MaxPts",
+                &[2_500, 8_000, 20_000, 60_000],
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::Area, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Area,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::Area, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Area,
-                "pinch",
-                3,
-            ));
+            for (name, label, values) in [
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..]),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..]),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, 2,
+                ));
+            }
         }
         ChartKind::MultiLine => {
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Stroke {:.1}",
-                    cfg.pick_f32(ChartKind::MultiLine, "stroke", &[0.8, 1.2, 1.8, 2.5])
+            let kind = ChartKind::MultiLine;
+            for (name, label, values, decimals) in [
+                ("stroke", "Stroke", &[0.8, 1.2, 1.8, 2.5][..], 1usize),
+                ("alpha", "Alpha", &[0.30, 0.45, 0.60, 0.75][..], 2usize),
+                ("gap_dx", "Gap", &[2.0, 6.0, 10.0, 14.0][..], 1usize),
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..], 2usize),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..], 2usize),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, decimals,
+                ));
+            }
+            for (name, label, values) in [
+                ("max_series", "Series", &[24, 48, 72, 96][..]),
+                ("max_segments", "Seg", &[8_000, 22_000, 40_000, 80_000][..]),
+                (
+                    "max_points_per_series",
+                    "Pts/Series",
+                    &[256, 512, 1_024, 2_048][..],
                 ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::MultiLine,
-                "stroke",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Alpha {:.2}",
-                    cfg.pick_f32(ChartKind::MultiLine, "alpha", &[0.30, 0.45, 0.60, 0.75])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::MultiLine,
-                "alpha",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Series {}",
-                    cfg.pick_usize(ChartKind::MultiLine, "max_series", &[24, 48, 72, 96])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::MultiLine,
-                "max_series",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Seg {}",
-                    cfg.pick_usize(
-                        ChartKind::MultiLine,
-                        "max_segments",
-                        &[8_000, 22_000, 40_000, 80_000]
-                    )
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::MultiLine,
-                "max_segments",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pts/Series {}",
-                    cfg.pick_usize(
-                        ChartKind::MultiLine,
-                        "max_points_per_series",
-                        &[256, 512, 1_024, 2_048]
-                    )
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::MultiLine,
-                "max_points_per_series",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Gap {:.1}",
-                    cfg.pick_f32(ChartKind::MultiLine, "gap_dx", &[2.0, 6.0, 10.0, 14.0])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::MultiLine,
-                "gap_dx",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::MultiLine, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::MultiLine,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::MultiLine, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::MultiLine,
-                "pinch",
-                3,
-            ));
+            ] {
+                row = row.child(cycle_usize_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values,
+                ));
+            }
         }
         ChartKind::Bar => {
             let config_for_click = config.clone();
@@ -1829,250 +1693,111 @@ fn control_panel(
                     refresh_models(&config_for_click, &models_for_click);
                 },
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Alpha {:.2}",
-                    cfg.pick_f32(ChartKind::Bar, "alpha", &[0.45, 0.65, 0.85, 1.0])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Bar,
-                "alpha",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Series {}",
-                    cfg.pick_usize(ChartKind::Bar, "max_series", &[2, 4, 8, 16])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Bar,
-                "max_series",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Bins {}",
-                    cfg.pick_usize(ChartKind::Bar, "max_bins", &[2_000, 8_000, 20_000, 40_000])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Bar,
-                "max_bins",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::Bar, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Bar,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::Bar, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Bar,
-                "pinch",
-                3,
-            ));
+            let kind = ChartKind::Bar;
+            for (name, label, values, decimals) in [
+                ("alpha", "Alpha", &[0.45, 0.65, 0.85, 1.0][..], 2usize),
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..], 2usize),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..], 2usize),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, decimals,
+                ));
+            }
+            for (name, label, values) in [
+                ("max_series", "Series", &[2, 4, 8, 16][..]),
+                ("max_bins", "Bins", &[2_000, 8_000, 20_000, 40_000][..]),
+            ] {
+                row = row.child(cycle_usize_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values,
+                ));
+            }
         }
         ChartKind::Histogram => {
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Bins {}",
-                    cfg.pick_usize(ChartKind::Histogram, "bins", &[24, 48, 96, 192])
-                ),
+            let kind = ChartKind::Histogram;
+            row = row.child(cycle_usize_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Histogram,
+                &config,
+                &models,
+                kind,
                 "bins",
-                4,
+                "Bins",
+                &[24, 48, 96, 192],
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::Histogram, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Histogram,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::Histogram, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Histogram,
-                "pinch",
-                3,
-            ));
+            for (name, label, values) in [
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..]),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..]),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, 2,
+                ));
+            }
         }
         ChartKind::Scatter => {
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Radius {:.1}",
-                    cfg.pick_f32(ChartKind::Scatter, "radius", &[0.8, 1.2, 1.8, 2.5])
-                ),
+            let kind = ChartKind::Scatter;
+            for (name, label, values, decimals) in [
+                ("radius", "Radius", &[0.8, 1.2, 1.8, 2.5][..], 1usize),
+                ("hit", "Hit", &[8.0, 12.0, 16.0, 24.0][..], 0usize),
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..], 2usize),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..], 2usize),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, decimals,
+                ));
+            }
+            row = row.child(cycle_usize_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Scatter,
-                "radius",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Hit {:.0}",
-                    cfg.pick_f32(ChartKind::Scatter, "hit", &[8.0, 12.0, 16.0, 24.0])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Scatter,
-                "hit",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "MaxPts {}",
-                    cfg.pick_usize(
-                        ChartKind::Scatter,
-                        "max_points",
-                        &[1_600, 4_000, 7_000, 14_000]
-                    )
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Scatter,
+                &config,
+                &models,
+                kind,
                 "max_points",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::Scatter, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Scatter,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::Scatter, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Scatter,
-                "pinch",
-                3,
+                "MaxPts",
+                &[1_600, 4_000, 7_000, 14_000],
             ));
         }
         ChartKind::Candlestick => {
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Stroke {:.1}",
-                    cfg.pick_f32(ChartKind::Candlestick, "stroke", &[1.0, 1.5, 2.0, 2.8])
-                ),
+            let kind = ChartKind::Candlestick;
+            row = row.child(cycle_f32_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Candlestick,
+                &config,
+                &models,
+                kind,
                 "stroke",
-                4,
+                "Stroke",
+                &[1.0, 1.5, 2.0, 2.8],
+                1,
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "MaxCandle {}",
-                    cfg.pick_usize(
-                        ChartKind::Candlestick,
-                        "max_candles",
-                        &[3_500, 12_000, 20_000, 35_000]
-                    )
-                ),
+            row = row.child(cycle_usize_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Candlestick,
+                &config,
+                &models,
+                kind,
                 "max_candles",
-                4,
+                "MaxCandle",
+                &[3_500, 12_000, 20_000, 35_000],
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::Candlestick, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Candlestick,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::Candlestick, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Candlestick,
-                "pinch",
-                3,
-            ));
+            for (name, label, values) in [
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..]),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..]),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, 2,
+                ));
+            }
         }
         ChartKind::Heatmap => {
-            row = row.child(cycle_option_chip(
-                format!(
-                    "CellsX {}",
-                    cfg.pick_usize(ChartKind::Heatmap, "cells_x", &[64, 128, 192, 256])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Heatmap,
-                "cells_x",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "CellsY {}",
-                    cfg.pick_usize(ChartKind::Heatmap, "cells_y", &[32, 64, 96, 128])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Heatmap,
-                "cells_y",
-                4,
-            ));
+            let kind = ChartKind::Heatmap;
+            for (name, label, values) in [
+                ("cells_x", "CellsX", &[64, 128, 192, 256][..]),
+                ("cells_y", "CellsY", &[32, 64, 96, 128][..]),
+            ] {
+                row = row.child(cycle_usize_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values,
+                ));
+            }
         }
         ChartKind::StackedArea => {
             let config_for_click = config.clone();
@@ -2089,198 +1814,96 @@ fn control_panel(
                     refresh_models(&config_for_click, &models_for_click);
                 },
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Stroke {:.1}",
-                    cfg.pick_f32(ChartKind::StackedArea, "stroke", &[0.8, 1.2, 1.8, 2.4])
-                ),
+            let kind = ChartKind::StackedArea;
+            row = row.child(cycle_f32_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::StackedArea,
+                &config,
+                &models,
+                kind,
                 "stroke",
-                4,
+                "Stroke",
+                &[0.8, 1.2, 1.8, 2.4],
+                1,
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::StackedArea, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::StackedArea,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::StackedArea, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::StackedArea,
-                "pinch",
-                3,
-            ));
+            for (name, label, values) in [
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..]),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..]),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, 2,
+                ));
+            }
         }
         ChartKind::DensityMap => {
-            row = row.child(cycle_option_chip(
-                format!(
-                    "CellsX {}",
-                    cfg.pick_usize(ChartKind::DensityMap, "cells_x", &[72, 128, 192, 256])
+            let kind = ChartKind::DensityMap;
+            for (name, label, values) in [
+                ("cells_x", "CellsX", &[72, 128, 192, 256][..]),
+                ("cells_y", "CellsY", &[36, 64, 96, 128][..]),
+                (
+                    "max_points",
+                    "MaxPts",
+                    &[80_000, 180_000, 250_000, 400_000][..],
                 ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::DensityMap,
-                "cells_x",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "CellsY {}",
-                    cfg.pick_usize(ChartKind::DensityMap, "cells_y", &[36, 64, 96, 128])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::DensityMap,
-                "cells_y",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "MaxPts {}",
-                    cfg.pick_usize(
-                        ChartKind::DensityMap,
-                        "max_points",
-                        &[80_000, 180_000, 250_000, 400_000]
-                    )
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::DensityMap,
-                "max_points",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::DensityMap, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::DensityMap,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::DensityMap, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::DensityMap,
-                "pinch",
-                3,
-            ));
+            ] {
+                row = row.child(cycle_usize_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values,
+                ));
+            }
+            for (name, label, values) in [
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..]),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..]),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, 2,
+                ));
+            }
         }
         ChartKind::Contour => {
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Stroke {:.1}",
-                    cfg.pick_f32(ChartKind::Contour, "stroke", &[1.0, 1.5, 2.2, 3.0])
-                ),
+            let kind = ChartKind::Contour;
+            row = row.child(cycle_f32_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Contour,
+                &config,
+                &models,
+                kind,
                 "stroke",
-                4,
+                "Stroke",
+                &[1.0, 1.5, 2.2, 3.0],
+                1,
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Segments {}",
-                    cfg.pick_usize(
-                        ChartKind::Contour,
-                        "max_segments",
-                        &[7_000, 20_000, 35_000, 60_000]
-                    )
-                ),
+            row = row.child(cycle_usize_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Contour,
+                &config,
+                &models,
+                kind,
                 "max_segments",
-                4,
+                "Segments",
+                &[7_000, 20_000, 35_000, 60_000],
             ));
-            let lvl = cfg.option_index(ChartKind::Contour, "levels", 4) + 1;
-            row = row.child(cycle_option_chip(
-                format!("Levels L{lvl}"),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Contour,
-                "levels",
-                4,
+            row = row.child(cycle_index_chip(
+                &cfg, dense, &config, &models, kind, "levels", "Levels L", 4, 1,
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::Contour, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Contour,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::Contour, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Contour,
-                "pinch",
-                3,
-            ));
+            for (name, label, values) in [
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..]),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..]),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, 2,
+                ));
+            }
         }
         ChartKind::Statistics => {
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::Statistics, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Statistics,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::Statistics, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Statistics,
-                "pinch",
-                3,
-            ));
+            let kind = ChartKind::Statistics;
+            for (name, label, values) in [
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..]),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..]),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, 2,
+                ));
+            }
         }
         ChartKind::Hierarchy => {
             let config_for_click = config.clone();
@@ -2297,21 +1920,15 @@ fn control_panel(
                     refresh_models(&config_for_click, &models_for_click);
                 },
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Leaves {}",
-                    cfg.pick_usize(
-                        ChartKind::Hierarchy,
-                        "max_leaves",
-                        &[600, 2_000, 4_000, 8_000]
-                    )
-                ),
+            row = row.child(cycle_usize_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
+                &config,
+                &models,
                 ChartKind::Hierarchy,
                 "max_leaves",
-                4,
+                "Leaves",
+                &[600, 2_000, 4_000, 8_000],
             ));
         }
         ChartKind::Network => {
@@ -2329,66 +1946,34 @@ fn control_panel(
                     refresh_models(&config_for_click, &models_for_click);
                 },
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Radius {:.1}",
-                    cfg.pick_f32(ChartKind::Network, "radius", &[3.0, 6.0, 10.0, 14.0])
-                ),
+            let kind = ChartKind::Network;
+            row = row.child(cycle_f32_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Network,
+                &config,
+                &models,
+                kind,
                 "radius",
-                4,
+                "Radius",
+                &[3.0, 6.0, 10.0, 14.0],
+                1,
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Nodes {}",
-                    cfg.pick_usize(ChartKind::Network, "max_nodes", &[96, 256, 512, 1_024])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Network,
-                "max_nodes",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Links {}",
-                    cfg.pick_usize(ChartKind::Network, "max_links", &[700, 2_000, 4_000, 8_000])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Network,
-                "max_links",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::Network, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Network,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::Network, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Network,
-                "pinch",
-                3,
-            ));
+            for (name, label, values) in [
+                ("max_nodes", "Nodes", &[96, 256, 512, 1_024][..]),
+                ("max_links", "Links", &[700, 2_000, 4_000, 8_000][..]),
+            ] {
+                row = row.child(cycle_usize_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values,
+                ));
+            }
+            for (name, label, values) in [
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..]),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..]),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, 2,
+                ));
+            }
         }
         ChartKind::Polar => {
             let config_for_click = config.clone();
@@ -2405,139 +1990,92 @@ fn control_panel(
                     refresh_models(&config_for_click, &models_for_click);
                 },
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Fill {:.2}",
-                    cfg.pick_f32(ChartKind::Polar, "fill_alpha", &[0.10, 0.20, 0.35, 0.50])
-                ),
+            let kind = ChartKind::Polar;
+            for (name, label, values, decimals) in [
+                ("fill_alpha", "Fill", &[0.10, 0.20, 0.35, 0.50][..], 2usize),
+                ("range", "Range", &[0.8, 1.0, 1.2, 1.5][..], 1usize),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, decimals,
+                ));
+            }
+            row = row.child(cycle_usize_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Polar,
-                "fill_alpha",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Series {}",
-                    cfg.pick_usize(ChartKind::Polar, "max_series", &[4, 8, 16, 32])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Polar,
+                &config,
+                &models,
+                kind,
                 "max_series",
-                4,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Range {:.1}",
-                    cfg.pick_f32(ChartKind::Polar, "range", &[0.8, 1.0, 1.2, 1.5])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Polar,
-                "range",
-                4,
+                "Series",
+                &[4, 8, 16, 32],
             ));
         }
         ChartKind::Gauge => {
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Stroke {:.0}",
-                    cfg.pick_f32(ChartKind::Gauge, "stroke", &[4.0, 8.0, 12.0, 16.0])
-                ),
+            let kind = ChartKind::Gauge;
+            row = row.child(cycle_f32_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Gauge,
+                &config,
+                &models,
+                kind,
                 "stroke",
-                4,
+                "Stroke",
+                &[4.0, 8.0, 12.0, 16.0],
+                0,
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Arc x{:.2}",
-                    cfg.pick_f32(ChartKind::Gauge, "span", &[0.5, 0.75, 1.0, 1.25])
-                ),
+            row = row.child(cycle_f32_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Gauge,
+                &config,
+                &models,
+                kind,
                 "span",
-                4,
+                "Arc x",
+                &[0.5, 0.75, 1.0, 1.25],
+                2,
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Anim {}Hz",
-                    (1.0 / cfg.pick_f32(
-                        ChartKind::Gauge,
-                        "transition_dt",
-                        &[1.0 / 120.0, 1.0 / 90.0, 1.0 / 60.0, 1.0 / 30.0]
-                    ))
-                    .round() as i32
-                ),
+            row = row.child(cycle_hz_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Gauge,
+                &config,
+                &models,
+                kind,
                 "transition_dt",
-                4,
+                "Anim",
+                &[1.0 / 120.0, 1.0 / 90.0, 1.0 / 60.0, 1.0 / 30.0],
             ));
         }
         ChartKind::Geo => {
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Stroke {:.1}",
-                    cfg.pick_f32(ChartKind::Geo, "stroke", &[0.8, 1.2, 1.8, 2.6])
-                ),
+            let kind = ChartKind::Geo;
+            row = row.child(cycle_f32_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Geo,
+                &config,
+                &models,
+                kind,
                 "stroke",
-                4,
+                "Stroke",
+                &[0.8, 1.2, 1.8, 2.6],
+                1,
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "MaxPts {}",
-                    cfg.pick_usize(
-                        ChartKind::Geo,
-                        "max_points",
-                        &[6_000, 20_000, 35_000, 60_000]
-                    )
-                ),
+            row = row.child(cycle_usize_chip(
+                &cfg,
                 dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Geo,
+                &config,
+                &models,
+                kind,
                 "max_points",
-                4,
+                "MaxPts",
+                &[6_000, 20_000, 35_000, 60_000],
             ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Scroll {:.2}",
-                    cfg.pick_f32(ChartKind::Geo, "scroll", &[0.01, 0.02, 0.04])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Geo,
-                "scroll",
-                3,
-            ));
-            row = row.child(cycle_option_chip(
-                format!(
-                    "Pinch {:.2}",
-                    cfg.pick_f32(ChartKind::Geo, "pinch", &[0.01, 0.05, 0.1])
-                ),
-                dense,
-                config.clone(),
-                models.clone(),
-                ChartKind::Geo,
-                "pinch",
-                3,
-            ));
+            for (name, label, values) in [
+                ("scroll", "Scroll", &[0.01, 0.02, 0.04][..]),
+                ("pinch", "Pinch", &[0.01, 0.05, 0.1][..]),
+            ] {
+                row = row.child(cycle_f32_chip(
+                    &cfg, dense, &config, &models, kind, name, label, values, 2,
+                ));
+            }
         }
         _ => {}
     }
@@ -2560,6 +2098,97 @@ fn control_panel(
                 .color(Color::rgba(0.62, 0.69, 0.77, 0.95)),
         )
         .child(row)
+}
+
+fn cycle_f32_chip(
+    cfg: &GalleryConfig,
+    dense: bool,
+    config: &State<GalleryConfig>,
+    models: &State<GalleryModels>,
+    kind: ChartKind,
+    name: &'static str,
+    label: &'static str,
+    values: &[f32],
+    decimals: usize,
+) -> impl ElementBuilder {
+    let value = cfg.pick_f32(kind, name, values);
+    let chip_label = format!("{label} {value:.decimals$}");
+    cycle_option_chip(
+        chip_label,
+        dense,
+        config.clone(),
+        models.clone(),
+        kind,
+        name,
+        values.len(),
+    )
+}
+
+fn cycle_usize_chip(
+    cfg: &GalleryConfig,
+    dense: bool,
+    config: &State<GalleryConfig>,
+    models: &State<GalleryModels>,
+    kind: ChartKind,
+    name: &'static str,
+    label: &'static str,
+    values: &[usize],
+) -> impl ElementBuilder {
+    let value = cfg.pick_usize(kind, name, values);
+    cycle_option_chip(
+        format!("{label} {value}"),
+        dense,
+        config.clone(),
+        models.clone(),
+        kind,
+        name,
+        values.len(),
+    )
+}
+
+fn cycle_index_chip(
+    cfg: &GalleryConfig,
+    dense: bool,
+    config: &State<GalleryConfig>,
+    models: &State<GalleryModels>,
+    kind: ChartKind,
+    name: &'static str,
+    label_prefix: &'static str,
+    len: usize,
+    offset: usize,
+) -> impl ElementBuilder {
+    let label_value = cfg.option_index(kind, name, len) + offset;
+    cycle_option_chip(
+        format!("{label_prefix}{label_value}"),
+        dense,
+        config.clone(),
+        models.clone(),
+        kind,
+        name,
+        len,
+    )
+}
+
+fn cycle_hz_chip(
+    cfg: &GalleryConfig,
+    dense: bool,
+    config: &State<GalleryConfig>,
+    models: &State<GalleryModels>,
+    kind: ChartKind,
+    name: &'static str,
+    label: &'static str,
+    values: &[f32],
+) -> impl ElementBuilder {
+    let hz = (1.0 / cfg.pick_f32(kind, name, values)).round() as i32;
+    cycle_option_chip(
+        format!("{label} {hz}Hz"),
+        dense,
+        config.clone(),
+        models.clone(),
+        kind,
+        name,
+        values.len(),
+    )
 }
 
 fn action_chip<F>(

--- a/crates/blinc_app/examples/charts_gallery_demo.rs
+++ b/crates/blinc_app/examples/charts_gallery_demo.rs
@@ -694,8 +694,13 @@ impl GalleryModels {
     }
 
     fn apply_advanced_options(&mut self, config: &GalleryConfig) {
-        let cfg = config;
+        self.apply_advanced_series_options(config);
+        self.apply_advanced_field_options(config);
+        self.apply_advanced_structural_options(config);
+        self.apply_advanced_specialized_options(config);
+    }
 
+    fn apply_advanced_series_options(&mut self, cfg: &GalleryConfig) {
         if let Ok(mut m) = self.line.0.lock() {
             if let Some(p) = cfg.theme_palette(ChartKind::Line) {
                 m.style.bg = p.bg;
@@ -843,7 +848,9 @@ impl GalleryModels {
             m.style.pinch_zoom_min =
                 cfg.pick_f32(ChartKind::Candlestick, "pinch", &[0.01, 0.05, 0.1]);
         }
+    }
 
+    fn apply_advanced_field_options(&mut self, cfg: &GalleryConfig) {
         if let Ok(mut m) = self.heat.0.lock() {
             if let Some(p) = cfg.theme_palette(ChartKind::Heatmap) {
                 m.style.bg = p.bg;
@@ -912,7 +919,7 @@ impl GalleryModels {
                 vec![-0.9, -0.6, -0.3, 0.0, 0.3, 0.6, 0.9],
             ];
             m.style.levels =
-                levels[config.option_index(ChartKind::Contour, "levels", levels.len())].clone();
+                levels[cfg.option_index(ChartKind::Contour, "levels", levels.len())].clone();
             m.style.scroll_zoom_factor =
                 cfg.pick_f32(ChartKind::Contour, "scroll", &[0.01, 0.02, 0.04]);
             m.style.pinch_zoom_min = cfg.pick_f32(ChartKind::Contour, "pinch", &[0.01, 0.05, 0.1]);
@@ -931,7 +938,9 @@ impl GalleryModels {
             m.style.pinch_zoom_min =
                 cfg.pick_f32(ChartKind::Statistics, "pinch", &[0.01, 0.05, 0.1]);
         }
+    }
 
+    fn apply_advanced_structural_options(&mut self, cfg: &GalleryConfig) {
         if let Ok(mut m) = self.hierarchy.0.lock() {
             if let Some(p) = cfg.theme_palette(ChartKind::Hierarchy) {
                 m.style.bg = p.bg;
@@ -976,11 +985,13 @@ impl GalleryModels {
                 cfg.pick_f32(ChartKind::Polar, "fill_alpha", &[0.10, 0.20, 0.35, 0.50]);
             m.style.max_series = cfg.pick_usize(ChartKind::Polar, "max_series", &[4, 8, 16, 32]);
             let ranges = [0.8f32, 1.0, 1.2, 1.5];
-            let range = ranges[config.option_index(ChartKind::Polar, "range", ranges.len())];
+            let range = ranges[cfg.option_index(ChartKind::Polar, "range", ranges.len())];
             m.style.min_value = 0.0;
             m.style.max_value = range;
         }
+    }
 
+    fn apply_advanced_specialized_options(&mut self, cfg: &GalleryConfig) {
         if let Ok(mut m) = self.gauge.0.lock() {
             if let Some(p) = cfg.theme_palette(ChartKind::Gauge) {
                 m.style.bg = p.bg;
@@ -992,7 +1003,7 @@ impl GalleryModels {
             m.style.stroke_width =
                 cfg.pick_f32(ChartKind::Gauge, "stroke", &[4.0, 8.0, 12.0, 16.0]);
             let spans = [0.5f32, 0.75, 1.0, 1.25];
-            let span = spans[config.option_index(ChartKind::Gauge, "span", spans.len())];
+            let span = spans[cfg.option_index(ChartKind::Gauge, "span", spans.len())];
             m.style.angle_start_rad = -std::f32::consts::PI * span;
             m.style.angle_end_rad = std::f32::consts::PI * span;
             m.transition_step_sec = cfg.pick_f32(

--- a/crates/blinc_app/examples/charts_gallery_demo.rs
+++ b/crates/blinc_app/examples/charts_gallery_demo.rs
@@ -693,6 +693,8 @@ impl GalleryModels {
         }
     }
 
+    // Keep per-chart option application explicit for type safety:
+    // each model owns a distinct style struct and mutation surface.
     fn apply_advanced_options(&mut self, config: &GalleryConfig) {
         self.apply_advanced_series_options(config);
         self.apply_advanced_field_options(config);
@@ -1489,6 +1491,7 @@ fn control_panel(
     config: State<GalleryConfig>,
     models: State<GalleryModels>,
 ) -> impl ElementBuilder {
+    // Intentionally explicit: control chips map 1:1 to chart-kind option keys.
     let cfg = config.try_get().expect("config exists");
 
     let mut row = div()

--- a/crates/blinc_app/examples/charts_gallery_demo.rs
+++ b/crates/blinc_app/examples/charts_gallery_demo.rs
@@ -238,6 +238,12 @@ const ITEMS: &[ChartEntry] = &[
 
 const ZOOM_SCROLL_OPTIONS: &[f32] = &[0.01, 0.02, 0.04];
 const ZOOM_PINCH_OPTIONS: &[f32] = &[0.01, 0.05, 0.1];
+const CONTOUR_LEVEL_OPTIONS: [&[f32]; 4] = [
+    &[-0.4, 0.0, 0.4],
+    &[-0.6, -0.2, 0.2, 0.6],
+    &[-0.8, -0.4, 0.0, 0.4, 0.8],
+    &[-0.9, -0.6, -0.3, 0.0, 0.3, 0.6, 0.9],
+];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DataPreset {
@@ -963,14 +969,9 @@ impl GalleryModels {
                 "max_segments",
                 &[7_000, 20_000, 35_000, 60_000],
             );
-            let levels = [
-                vec![-0.4, 0.0, 0.4],
-                vec![-0.6, -0.2, 0.2, 0.6],
-                vec![-0.8, -0.4, 0.0, 0.4, 0.8],
-                vec![-0.9, -0.6, -0.3, 0.0, 0.3, 0.6, 0.9],
-            ];
-            m.style.levels =
-                levels[cfg.option_index(ChartKind::Contour, "levels", levels.len())].clone();
+            m.style.levels = CONTOUR_LEVEL_OPTIONS
+                [cfg.option_index(ChartKind::Contour, "levels", CONTOUR_LEVEL_OPTIONS.len())]
+            .to_vec();
             Self::apply_zoom_options(
                 cfg,
                 ChartKind::Contour,

--- a/crates/blinc_charts/src/axis.rs
+++ b/crates/blinc_charts/src/axis.rs
@@ -11,7 +11,7 @@ fn label_width_px(ctx: &mut dyn DrawContext, label: &str, style: &TextStyle) -> 
         .measure_text(label, style)
         .map(|size| size.width)
         .unwrap_or(label.chars().count() as f32 * AVG_LABEL_CHAR_WIDTH_PX);
-    measured.clamp(10.0, 80.0)
+    measured.max(10.0)
 }
 
 #[derive(Clone, Debug)]

--- a/crates/blinc_charts/src/axis.rs
+++ b/crates/blinc_charts/src/axis.rs
@@ -1,0 +1,155 @@
+use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextStyle};
+
+use crate::scale::LinearScale;
+use crate::view::Domain1D;
+
+#[derive(Clone, Debug)]
+pub struct AxisTick {
+    pub value: f32,
+    pub px: f32,
+    pub label: String,
+}
+
+pub fn build_bottom_ticks<F>(
+    domain: Domain1D,
+    plot_x: f32,
+    plot_w: f32,
+    tick_count: usize,
+    formatter: F,
+) -> Vec<AxisTick>
+where
+    F: Fn(f32) -> String,
+{
+    if tick_count == 0 || !domain.is_valid() || plot_w <= 0.0 {
+        return Vec::new();
+    }
+    let s = LinearScale::new(domain.min, domain.max, plot_x, plot_x + plot_w);
+    s.ticks(tick_count)
+        .into_iter()
+        .map(|v| AxisTick {
+            value: v,
+            px: s.map(v),
+            label: formatter(v),
+        })
+        .collect()
+}
+
+pub fn build_left_ticks<F>(
+    domain: Domain1D,
+    plot_y: f32,
+    plot_h: f32,
+    tick_count: usize,
+    formatter: F,
+) -> Vec<AxisTick>
+where
+    F: Fn(f32) -> String,
+{
+    if tick_count == 0 || !domain.is_valid() || plot_h <= 0.0 {
+        return Vec::new();
+    }
+    // Invert so larger values are visually higher.
+    let s = LinearScale::new(domain.min, domain.max, plot_y + plot_h, plot_y);
+    s.ticks(tick_count)
+        .into_iter()
+        .map(|v| AxisTick {
+            value: v,
+            px: s.map(v),
+            label: formatter(v),
+        })
+        .collect()
+}
+
+pub fn draw_bottom_axis(
+    ctx: &mut dyn DrawContext,
+    ticks: &[AxisTick],
+    plot_x: f32,
+    plot_y: f32,
+    plot_w: f32,
+    axis_color: Color,
+    text_color: Color,
+) {
+    if plot_w <= 0.0 {
+        return;
+    }
+
+    ctx.fill_rect(
+        Rect::new(plot_x, plot_y, plot_w, 1.0),
+        0.0.into(),
+        Brush::Solid(axis_color),
+    );
+
+    let style = TextStyle::new(10.0).with_color(text_color);
+    for t in ticks {
+        let label_w = (t.label.chars().count() as f32 * 6.0).clamp(10.0, 80.0);
+        ctx.fill_rect(
+            Rect::new(t.px, plot_y, 1.0, 4.0),
+            0.0.into(),
+            Brush::Solid(axis_color),
+        );
+        ctx.draw_text(
+            &t.label,
+            Point::new((t.px - label_w * 0.5).max(plot_x), plot_y + 4.0),
+            &style,
+        );
+    }
+}
+
+pub fn draw_left_axis(
+    ctx: &mut dyn DrawContext,
+    ticks: &[AxisTick],
+    plot_x: f32,
+    plot_y: f32,
+    plot_h: f32,
+    axis_color: Color,
+    text_color: Color,
+) {
+    if plot_h <= 0.0 {
+        return;
+    }
+
+    ctx.fill_rect(
+        Rect::new(plot_x, plot_y, 1.0, plot_h),
+        0.0.into(),
+        Brush::Solid(axis_color),
+    );
+
+    let style = TextStyle::new(10.0).with_color(text_color);
+    for t in ticks {
+        let label_w = (t.label.chars().count() as f32 * 6.0).clamp(10.0, 80.0);
+        ctx.fill_rect(
+            Rect::new(plot_x - 4.0, t.px, 4.0, 1.0),
+            0.0.into(),
+            Brush::Solid(axis_color),
+        );
+        ctx.draw_text(
+            &t.label,
+            Point::new(plot_x - 6.0 - label_w, t.px - 6.0),
+            &style,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bottom_tick_builder_emits_requested_count() {
+        let ticks = build_bottom_ticks(Domain1D::new(0.0, 10.0), 0.0, 100.0, 4, |v| {
+            format!("{v:.0}")
+        });
+        assert_eq!(ticks.len(), 4);
+    }
+
+    #[test]
+    fn tick_builder_with_zero_count_returns_empty() {
+        let bottom = build_bottom_ticks(Domain1D::new(0.0, 10.0), 0.0, 100.0, 0, |v| {
+            format!("{v:.0}")
+        });
+        let left = build_left_ticks(Domain1D::new(0.0, 10.0), 0.0, 100.0, 0, |v| {
+            format!("{v:.0}")
+        });
+        assert!(bottom.is_empty());
+        assert!(left.is_empty());
+    }
+}

--- a/crates/blinc_charts/src/axis.rs
+++ b/crates/blinc_charts/src/axis.rs
@@ -3,6 +3,8 @@ use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextStyle};
 use crate::scale::LinearScale;
 use crate::view::Domain1D;
 
+const AVG_LABEL_CHAR_WIDTH_PX: f32 = 6.0;
+
 #[derive(Clone, Debug)]
 pub struct AxisTick {
     pub value: f32,
@@ -80,7 +82,7 @@ pub fn draw_bottom_axis(
 
     let style = TextStyle::new(10.0).with_color(text_color);
     for t in ticks {
-        let label_w = (t.label.chars().count() as f32 * 6.0).clamp(10.0, 80.0);
+        let label_w = (t.label.chars().count() as f32 * AVG_LABEL_CHAR_WIDTH_PX).clamp(10.0, 80.0);
         ctx.fill_rect(
             Rect::new(t.px, plot_y, 1.0, 4.0),
             0.0.into(),
@@ -115,7 +117,7 @@ pub fn draw_left_axis(
 
     let style = TextStyle::new(10.0).with_color(text_color);
     for t in ticks {
-        let label_w = (t.label.chars().count() as f32 * 6.0).clamp(10.0, 80.0);
+        let label_w = (t.label.chars().count() as f32 * AVG_LABEL_CHAR_WIDTH_PX).clamp(10.0, 80.0);
         ctx.fill_rect(
             Rect::new(plot_x - 4.0, t.px, 4.0, 1.0),
             0.0.into(),

--- a/crates/blinc_charts/src/axis.rs
+++ b/crates/blinc_charts/src/axis.rs
@@ -1,4 +1,4 @@
-use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextStyle};
+use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextBaseline, TextStyle};
 
 use crate::scale::LinearScale;
 use crate::view::Domain1D;
@@ -89,7 +89,8 @@ pub fn draw_bottom_axis(
         Brush::Solid(axis_color),
     );
 
-    let style = TextStyle::new(10.0).with_color(text_color);
+    let mut style = TextStyle::new(10.0).with_color(text_color);
+    style.baseline = TextBaseline::Top;
     for t in ticks {
         let label_w = label_width_px(ctx, &t.label, &style);
         ctx.fill_rect(
@@ -97,11 +98,8 @@ pub fn draw_bottom_axis(
             0.0.into(),
             Brush::Solid(axis_color),
         );
-        ctx.draw_text(
-            &t.label,
-            Point::new((t.px - label_w * 0.5).max(plot_x), plot_y + 4.0),
-            &style,
-        );
+        let label_x = (t.px - label_w * 0.5).clamp(plot_x, (plot_x + plot_w - label_w).max(plot_x));
+        ctx.draw_text(&t.label, Point::new(label_x, plot_y + 6.0), &style);
     }
 }
 
@@ -124,7 +122,8 @@ pub fn draw_left_axis(
         Brush::Solid(axis_color),
     );
 
-    let style = TextStyle::new(10.0).with_color(text_color);
+    let mut style = TextStyle::new(10.0).with_color(text_color);
+    style.baseline = TextBaseline::Middle;
     for t in ticks {
         let label_w = label_width_px(ctx, &t.label, &style);
         ctx.fill_rect(
@@ -134,7 +133,7 @@ pub fn draw_left_axis(
         );
         ctx.draw_text(
             &t.label,
-            Point::new(plot_x - 6.0 - label_w, t.px - 6.0),
+            Point::new(plot_x - 6.0 - label_w, t.px.clamp(plot_y, plot_y + plot_h)),
             &style,
         );
     }

--- a/crates/blinc_charts/src/axis.rs
+++ b/crates/blinc_charts/src/axis.rs
@@ -3,6 +3,8 @@ use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextStyle};
 use crate::scale::LinearScale;
 use crate::view::Domain1D;
 
+// DrawContext currently has no text-measurement API, so axis labels use a
+// stable width heuristic for approximate centering.
 const AVG_LABEL_CHAR_WIDTH_PX: f32 = 6.0;
 
 #[derive(Clone, Debug)]

--- a/crates/blinc_charts/src/bar.rs
+++ b/crates/blinc_charts/src/bar.rs
@@ -3,9 +3,12 @@ use std::sync::{Arc, Mutex};
 use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextStyle};
 use blinc_layout::ElementBuilder;
 
+use crate::axis::{build_bottom_ticks, build_left_ticks, draw_bottom_axis, draw_left_axis};
 use crate::brush::BrushX;
 use crate::common::{draw_grid, fill_bg};
+use crate::format::format_compact;
 use crate::link::ChartLinkHandle;
+use crate::time_format::format_time_or_number;
 use crate::time_series::TimeSeriesF32;
 use crate::view::{ChartView, Domain1D, Domain2D};
 use crate::xy_stack::InteractiveXChartModel;
@@ -423,8 +426,21 @@ impl BarChartModel {
             );
         }
 
+        let x_ticks = build_bottom_ticks(self.view.domain.x, px, pw, 5, format_time_or_number);
+        draw_bottom_axis(
+            ctx,
+            &x_ticks,
+            px,
+            py + ph,
+            pw,
+            self.style.grid,
+            self.style.text,
+        );
+        let y_ticks = build_left_ticks(self.view.domain.y, py, ph, 5, format_compact);
+        draw_left_axis(ctx, &y_ticks, px, py, ph, self.style.grid, self.style.text);
+
         if let Some(x) = self.hover_x {
-            let text = format!("x={:.3}", x);
+            let text = format!("x={}", format_time_or_number(x));
             let style = TextStyle::new(12.0).with_color(self.style.text);
             ctx.draw_text(&text, Point::new(px + 6.0, py + 6.0), &style);
         }

--- a/crates/blinc_charts/src/contour.rs
+++ b/crates/blinc_charts/src/contour.rs
@@ -7,6 +7,7 @@ use blinc_layout::ElementBuilder;
 
 use crate::brush::BrushRect;
 use crate::common::{draw_grid, fill_bg};
+use crate::polygon::{point_in_polygon, polygon_area, rect_polygon};
 use crate::view::{ChartView, Domain1D, Domain2D};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -420,9 +421,18 @@ impl ContourChartModel {
         }
 
         if let Some((a, b)) = self.selection {
+            let poly = rect_polygon(a.x, a.y, b.x, b.y);
+            let area = polygon_area(&poly);
+            let contains_hover = self
+                .hover_xy
+                .map(|p| point_in_polygon(p, &poly))
+                .unwrap_or(false);
             let style = TextStyle::new(12.0).with_color(self.style.text);
             ctx.draw_text(
-                &format!("sel: ({:.2},{:.2})..({:.2},{:.2})", a.x, a.y, b.x, b.y),
+                &format!(
+                    "sel: ({:.2},{:.2})..({:.2},{:.2})  area={:.2}  hover_in={contains_hover}",
+                    a.x, a.y, b.x, b.y, area
+                ),
                 Point::new(px + 6.0, py + 24.0),
                 &style,
             );

--- a/crates/blinc_charts/src/density_map.rs
+++ b/crates/blinc_charts/src/density_map.rs
@@ -7,6 +7,7 @@ use blinc_layout::ElementBuilder;
 
 use crate::brush::BrushRect;
 use crate::common::{draw_grid, fill_bg};
+use crate::polygon::{point_in_polygon, polygon_area, rect_polygon};
 use crate::view::{ChartView, Domain1D, Domain2D};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -405,9 +406,18 @@ impl DensityMapChartModel {
         }
 
         if let Some((a, b)) = self.selection {
+            let poly = rect_polygon(a.x, a.y, b.x, b.y);
+            let area = polygon_area(&poly);
+            let contains_hover = self
+                .hover_point
+                .map(|p| point_in_polygon(p, &poly))
+                .unwrap_or(false);
             let style = TextStyle::new(12.0).with_color(self.style.text);
             ctx.draw_text(
-                &format!("sel: ({:.2},{:.2})..({:.2},{:.2})", a.x, a.y, b.x, b.y),
+                &format!(
+                    "sel: ({:.2},{:.2})..({:.2},{:.2})  area={:.2}  hover_in={contains_hover}",
+                    a.x, a.y, b.x, b.y, area
+                ),
                 Point::new(px + 6.0, py + 24.0),
                 &style,
             );

--- a/crates/blinc_charts/src/format.rs
+++ b/crates/blinc_charts/src/format.rs
@@ -1,0 +1,57 @@
+pub fn format_fixed(value: f32, decimals: usize) -> String {
+    if !value.is_finite() {
+        return if value.is_nan() {
+            "NaN".to_string()
+        } else if value.is_sign_positive() {
+            "Inf".to_string()
+        } else {
+            "-Inf".to_string()
+        };
+    }
+    format!("{value:.decimals$}")
+}
+
+pub fn format_compact(value: f32) -> String {
+    if !value.is_finite() {
+        return format_fixed(value, 0);
+    }
+    let abs = value.abs();
+    if abs >= 1_000_000_000.0 {
+        return format_with_suffix(value / 1_000_000_000.0, "B");
+    }
+    if abs >= 1_000_000.0 {
+        return format_with_suffix(value / 1_000_000.0, "M");
+    }
+    if abs >= 1_000.0 {
+        return format_with_suffix(value / 1_000.0, "K");
+    }
+
+    trim_trailing_zeroes(format!("{value:.3}"))
+}
+
+fn format_with_suffix(value: f32, suffix: &str) -> String {
+    format!("{}{}", trim_trailing_zeroes(format!("{value:.1}")), suffix)
+}
+
+fn trim_trailing_zeroes(mut s: String) -> String {
+    if let Some(dot) = s.find('.') {
+        while s.ends_with('0') {
+            s.pop();
+        }
+        if s.len() == dot + 1 {
+            s.pop();
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_uses_suffixes() {
+        assert_eq!(format_compact(12_400.0), "12.4K");
+        assert_eq!(format_compact(2_000_000.0), "2M");
+    }
+}

--- a/crates/blinc_charts/src/format.rs
+++ b/crates/blinc_charts/src/format.rs
@@ -30,7 +30,7 @@ pub fn format_compact(value: f32) -> String {
 }
 
 fn format_with_suffix(value: f32, suffix: &str) -> String {
-    format!("{}{}", trim_trailing_zeroes(format!("{value:.1}")), suffix)
+    format!("{}{}", trim_trailing_zeroes(format!("{value:.2}")), suffix)
 }
 
 fn trim_trailing_zeroes(mut s: String) -> String {
@@ -53,5 +53,11 @@ mod tests {
     fn compact_uses_suffixes() {
         assert_eq!(format_compact(12_400.0), "12.4K");
         assert_eq!(format_compact(2_000_000.0), "2M");
+    }
+
+    #[test]
+    fn compact_keeps_useful_precision_for_close_values() {
+        assert_eq!(format_compact(1_210.0), "1.21K");
+        assert_eq!(format_compact(1_290.0), "1.29K");
     }
 }

--- a/crates/blinc_charts/src/gauge.rs
+++ b/crates/blinc_charts/src/gauge.rs
@@ -99,7 +99,7 @@ impl GaugeChartModel {
         out
     }
 
-    pub fn render_plot(&mut self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
+    pub fn render_plot(&self, ctx: &mut dyn DrawContext, w: f32, h: f32) {
         fill_bg(ctx, w, h, self.style.bg);
 
         let cx = w * 0.5;

--- a/crates/blinc_charts/src/gauge.rs
+++ b/crates/blinc_charts/src/gauge.rs
@@ -189,7 +189,9 @@ pub fn gauge_chart(handle: GaugeChartHandle) -> impl ElementBuilder {
                 } else {
                     m.transition_step_sec
                 };
-                m.tick_transition(dt.clamp(1.0 / 240.0, 0.25));
+                // Clamp only the upper bound to avoid large jumps on frame drops,
+                // while preserving smooth progression on high-refresh displays.
+                m.tick_transition(dt.min(0.25));
                 m.render_plot(ctx, bounds.width, bounds.height);
                 if m.transition.is_some() {
                     blinc_layout::stateful::request_redraw();

--- a/crates/blinc_charts/src/interpolate.rs
+++ b/crates/blinc_charts/src/interpolate.rs
@@ -1,0 +1,20 @@
+use blinc_core::Point;
+
+pub fn lerp_f32(a: f32, b: f32, t: f32) -> f32 {
+    a + (b - a) * t.clamp(0.0, 1.0)
+}
+
+pub fn lerp_point(a: Point, b: Point, t: f32) -> Point {
+    Point::new(lerp_f32(a.x, b.x, t), lerp_f32(a.y, b.y, t))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lerp_clamps_t() {
+        assert_eq!(lerp_f32(0.0, 10.0, -1.0), 0.0);
+        assert_eq!(lerp_f32(0.0, 10.0, 2.0), 10.0);
+    }
+}

--- a/crates/blinc_charts/src/lib.rs
+++ b/crates/blinc_charts/src/lib.rs
@@ -7,13 +7,22 @@
 //! - Use Blinc's built-in event routing (mouse/touch/scroll/pinch/drag)
 //! - Prioritize performance for large datasets via sampling/LOD and GPU pipelines
 
+pub mod axis;
 mod brush;
 mod common;
+pub mod format;
 pub mod input;
+pub mod interpolate;
 mod link;
 mod lod;
+pub mod polygon;
+pub mod scale;
 mod segments;
+pub mod spatial_index;
+pub mod time_format;
 mod time_series;
+pub mod transition;
+pub mod triangulation;
 mod view;
 mod xy_stack;
 

--- a/crates/blinc_charts/src/line.rs
+++ b/crates/blinc_charts/src/line.rs
@@ -3,9 +3,12 @@ use std::sync::{Arc, Mutex};
 use blinc_core::{Brush, Color, CornerRadius, DrawContext, Point, Rect, Stroke, TextStyle};
 use blinc_layout::ElementBuilder;
 
+use crate::axis::{build_bottom_ticks, build_left_ticks, draw_bottom_axis, draw_left_axis};
 use crate::brush::BrushX;
+use crate::format::format_compact;
 use crate::link::ChartLinkHandle;
 use crate::lod::{downsample_min_max, DownsampleParams};
+use crate::time_format::format_time_or_number;
 use crate::time_series::TimeSeriesF32;
 use crate::view::{ChartView, Domain1D, Domain2D};
 use crate::xy_stack::InteractiveXChartModel;
@@ -351,9 +354,26 @@ impl LineChartModel {
             );
         }
 
+        let x_ticks = build_bottom_ticks(self.view.domain.x, px, pw, 5, format_time_or_number);
+        draw_bottom_axis(
+            ctx,
+            &x_ticks,
+            px,
+            py + ph,
+            pw,
+            self.style.grid,
+            self.style.text,
+        );
+        let y_ticks = build_left_ticks(self.view.domain.y, py, ph, 5, format_compact);
+        draw_left_axis(ctx, &y_ticks, px, py, ph, self.style.grid, self.style.text);
+
         // Tooltip (simple)
         if let Some(p) = self.hover_point {
-            let text = format!("x={:.3}  y={:.3}", p.x, p.y);
+            let text = format!(
+                "x={}  y={}",
+                format_time_or_number(p.x),
+                format_compact(p.y)
+            );
             let style = TextStyle::new(12.0).with_color(self.style.text);
             // Anchor near top-left of plot.
             ctx.draw_text(&text, Point::new(px + 6.0, py + 6.0), &style);

--- a/crates/blinc_charts/src/polar.rs
+++ b/crates/blinc_charts/src/polar.rs
@@ -198,9 +198,10 @@ impl PolarChartModel {
 
         // Series lines.
         let max_series = self.series.len().min(self.style.max_series);
+        let mut pts = Vec::with_capacity(dims_n);
         for s in 0..max_series {
             let vals = &self.series[s];
-            let mut pts = Vec::with_capacity(dims_n);
+            pts.clear();
             for i in 0..dims_n {
                 let v = vals.get(i).copied().unwrap_or(self.style.min_value);
                 let v = if v.is_finite() {

--- a/crates/blinc_charts/src/polygon.rs
+++ b/crates/blinc_charts/src/polygon.rs
@@ -1,0 +1,78 @@
+use blinc_core::Point;
+
+pub fn rect_polygon(x0: f32, y0: f32, x1: f32, y1: f32) -> [Point; 4] {
+    let left = x0.min(x1);
+    let right = x0.max(x1);
+    let top = y0.min(y1);
+    let bottom = y0.max(y1);
+    [
+        Point::new(left, top),
+        Point::new(right, top),
+        Point::new(right, bottom),
+        Point::new(left, bottom),
+    ]
+}
+
+pub fn polygon_area(poly: &[Point]) -> f32 {
+    if poly.len() < 3 {
+        return 0.0;
+    }
+    let mut sum = 0.0f32;
+    for i in 0..poly.len() {
+        let a = poly[i];
+        let b = poly[(i + 1) % poly.len()];
+        sum += a.x * b.y - b.x * a.y;
+    }
+    sum.abs() * 0.5
+}
+
+pub fn point_in_polygon(p: Point, poly: &[Point]) -> bool {
+    if poly.len() < 3 {
+        return false;
+    }
+    let mut inside = false;
+    let mut j = poly.len() - 1;
+    for i in 0..poly.len() {
+        let pi = poly[i];
+        let pj = poly[j];
+        let intersects = if (pi.y > p.y) != (pj.y > p.y) {
+            let dy = pj.y - pi.y;
+            if dy.abs() < 1e-12 {
+                false
+            } else {
+                p.x < (pj.x - pi.x) * (p.y - pi.y) / dy + pi.x
+            }
+        } else {
+            false
+        };
+        if intersects {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn area_and_contains_for_rect() {
+        let poly = rect_polygon(0.0, 0.0, 2.0, 1.0);
+        assert!((polygon_area(&poly) - 2.0).abs() < 1e-5);
+        assert!(point_in_polygon(Point::new(1.0, 0.5), &poly));
+        assert!(!point_in_polygon(Point::new(3.0, 0.5), &poly));
+    }
+
+    #[test]
+    fn contains_handles_descending_non_vertical_edges() {
+        let poly = vec![
+            Point::new(-1.0, -1.0),
+            Point::new(3.0, -1.0),
+            Point::new(2.0, 1.0),
+            Point::new(-2.0, 1.0),
+        ];
+        assert!(point_in_polygon(Point::new(1.0, 0.0), &poly));
+    }
+}

--- a/crates/blinc_charts/src/polygon.rs
+++ b/crates/blinc_charts/src/polygon.rs
@@ -40,6 +40,7 @@ pub fn point_in_polygon(p: Point, poly: &[Point]) -> bool {
             if dy.abs() < 1e-12 {
                 false
             } else {
+                // Boundary convention: points exactly on an edge are treated as outside.
                 p.x < (pj.x - pi.x) * (p.y - pi.y) / dy + pi.x
             }
         } else {

--- a/crates/blinc_charts/src/scale.rs
+++ b/crates/blinc_charts/src/scale.rs
@@ -1,0 +1,134 @@
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct LinearScale {
+    domain_min: f32,
+    domain_max: f32,
+    range_min: f32,
+    range_max: f32,
+}
+
+impl LinearScale {
+    pub fn new(domain_min: f32, domain_max: f32, range_min: f32, range_max: f32) -> Self {
+        Self {
+            domain_min,
+            domain_max,
+            range_min,
+            range_max,
+        }
+    }
+
+    pub fn map(&self, value: f32) -> f32 {
+        let d = self.domain_max - self.domain_min;
+        if d.abs() < 1e-12 {
+            return self.range_min;
+        }
+        let t = (value - self.domain_min) / d;
+        self.range_min + t * (self.range_max - self.range_min)
+    }
+
+    pub fn invert(&self, px: f32) -> f32 {
+        let r = self.range_max - self.range_min;
+        if r.abs() < 1e-12 {
+            return self.domain_min;
+        }
+        let t = (px - self.range_min) / r;
+        self.domain_min + t * (self.domain_max - self.domain_min)
+    }
+
+    pub fn ticks(&self, count: usize) -> Vec<f32> {
+        let n = count.max(2);
+        let mut out = Vec::with_capacity(n);
+        let span = self.domain_max - self.domain_min;
+        for i in 0..n {
+            let t = i as f32 / (n - 1) as f32;
+            out.push(self.domain_min + span * t);
+        }
+        out
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BandScale {
+    count: usize,
+    start: f32,
+    step: f32,
+    band_width: f32,
+}
+
+impl BandScale {
+    pub fn new(
+        count: usize,
+        range_min: f32,
+        range_max: f32,
+        padding_inner: f32,
+        padding_outer: f32,
+    ) -> Self {
+        if count == 0 {
+            return Self {
+                count: 0,
+                start: range_min,
+                step: 0.0,
+                band_width: 0.0,
+            };
+        }
+        let count_f = count as f32;
+        let span = (range_max - range_min).max(0.0);
+        let denom = (count_f - padding_inner + 2.0 * padding_outer).max(1e-6);
+        let step = span / denom;
+        let band_width = step * (1.0 - padding_inner).max(0.0);
+        let start = range_min + step * padding_outer;
+        Self {
+            count,
+            start,
+            step,
+            band_width,
+        }
+    }
+
+    pub fn band_width(&self) -> f32 {
+        self.band_width
+    }
+
+    pub fn band_start(&self, idx: usize) -> Option<f32> {
+        if idx >= self.count {
+            return None;
+        }
+        Some(self.start + self.step * idx as f32)
+    }
+
+    pub fn center(&self, idx: usize) -> Option<f32> {
+        self.band_start(idx).map(|x| x + self.band_width * 0.5)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linear_ticks_include_endpoints() {
+        let s = LinearScale::new(10.0, 20.0, 0.0, 100.0);
+        let t = s.ticks(4);
+        assert_eq!(t[0], 10.0);
+        assert_eq!(t[3], 20.0);
+    }
+
+    #[test]
+    fn band_scale_bounds_indices() {
+        let b = BandScale::new(3, 0.0, 300.0, 0.1, 0.05);
+        assert!(b.band_start(2).is_some());
+        assert!(b.band_start(3).is_none());
+    }
+
+    #[test]
+    fn linear_invert_handles_descending_range() {
+        let s = LinearScale::new(0.0, 100.0, 200.0, 100.0);
+        assert!((s.invert(150.0) - 50.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn band_scale_with_zero_count_has_no_band_width() {
+        let b = BandScale::new(0, 0.0, 100.0, 0.1, 0.05);
+        assert_eq!(b.band_width(), 0.0);
+        assert!(b.band_start(0).is_none());
+    }
+}

--- a/crates/blinc_charts/src/scatter.rs
+++ b/crates/blinc_charts/src/scatter.rs
@@ -16,6 +16,8 @@ use crate::triangulation::triangulate_fan;
 use crate::view::{ChartView, Domain1D, Domain2D};
 use crate::xy_stack::InteractiveXChartModel;
 
+const MESH_TRIANGULATION_POINT_LIMIT: usize = 512;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct SampleKey {
     x_min: u32,
@@ -275,7 +277,7 @@ impl ScatterChartModel {
             self.points_px.push(pp);
         }
         self.spatial_index = Some(SpatialIndex::build(&self.points_px, 24, 24));
-        let mesh_n = self.downsampled.len().min(512);
+        let mesh_n = self.downsampled.len().min(MESH_TRIANGULATION_POINT_LIMIT);
         self.mesh_triangle_count = triangulate_fan(&self.downsampled[..mesh_n]).len();
 
         self.last_sample_key = Some(key);

--- a/crates/blinc_charts/src/spatial_index.rs
+++ b/crates/blinc_charts/src/spatial_index.rs
@@ -1,0 +1,132 @@
+use blinc_core::Point;
+
+#[derive(Clone, Debug)]
+pub struct SpatialIndex {
+    points: Vec<Point>,
+    cells: Vec<Vec<usize>>,
+    cols: usize,
+    rows: usize,
+    min_x: f32,
+    max_x: f32,
+    min_y: f32,
+    max_y: f32,
+}
+
+impl SpatialIndex {
+    pub fn build(points: &[Point], cols: usize, rows: usize) -> Self {
+        let cols = cols.max(1);
+        let rows = rows.max(1);
+
+        let mut min_x = f32::INFINITY;
+        let mut max_x = f32::NEG_INFINITY;
+        let mut min_y = f32::INFINITY;
+        let mut max_y = f32::NEG_INFINITY;
+
+        for p in points {
+            if !p.x.is_finite() || !p.y.is_finite() {
+                continue;
+            }
+            min_x = min_x.min(p.x);
+            max_x = max_x.max(p.x);
+            min_y = min_y.min(p.y);
+            max_y = max_y.max(p.y);
+        }
+
+        if !min_x.is_finite() || !max_x.is_finite() || !min_y.is_finite() || !max_y.is_finite() {
+            min_x = 0.0;
+            max_x = 1.0;
+            min_y = 0.0;
+            max_y = 1.0;
+        }
+        if (max_x - min_x).abs() < 1e-6 {
+            max_x = min_x + 1.0;
+        }
+        if (max_y - min_y).abs() < 1e-6 {
+            max_y = min_y + 1.0;
+        }
+
+        let mut cells = vec![Vec::new(); cols * rows];
+        let mut owned_points = Vec::with_capacity(points.len());
+        for (i, p) in points.iter().enumerate() {
+            owned_points.push(*p);
+            if !p.x.is_finite() || !p.y.is_finite() {
+                continue;
+            }
+            let c = (((p.x - min_x) / (max_x - min_x)) * cols as f32)
+                .floor()
+                .clamp(0.0, (cols - 1) as f32) as usize;
+            let r = (((p.y - min_y) / (max_y - min_y)) * rows as f32)
+                .floor()
+                .clamp(0.0, (rows - 1) as f32) as usize;
+            cells[r * cols + c].push(i);
+        }
+
+        Self {
+            points: owned_points,
+            cells,
+            cols,
+            rows,
+            min_x,
+            max_x,
+            min_y,
+            max_y,
+        }
+    }
+
+    pub fn nearest(&self, x: f32, y: f32, max_radius: f32) -> Option<(usize, f32)> {
+        if self.points.is_empty() {
+            return None;
+        }
+        let max_radius = max_radius.max(0.0);
+        let max_r2 = max_radius * max_radius;
+        let cell_w = (self.max_x - self.min_x) / self.cols as f32;
+        let cell_h = (self.max_y - self.min_y) / self.rows as f32;
+
+        let cx = (((x - self.min_x) / (self.max_x - self.min_x)) * self.cols as f32)
+            .floor()
+            .clamp(0.0, (self.cols - 1) as f32) as i32;
+        let cy = (((y - self.min_y) / (self.max_y - self.min_y)) * self.rows as f32)
+            .floor()
+            .clamp(0.0, (self.rows - 1) as f32) as i32;
+
+        let rx = (max_radius / cell_w.max(1e-6)).ceil() as i32;
+        let ry = (max_radius / cell_h.max(1e-6)).ceil() as i32;
+
+        let mut best: Option<(usize, f32)> = None;
+        for row in (cy - ry).max(0)..=(cy + ry).min(self.rows as i32 - 1) {
+            for col in (cx - rx).max(0)..=(cx + rx).min(self.cols as i32 - 1) {
+                for &idx in &self.cells[row as usize * self.cols + col as usize] {
+                    let p = self.points[idx];
+                    if !p.x.is_finite() || !p.y.is_finite() {
+                        continue;
+                    }
+                    let dx = p.x - x;
+                    let dy = p.y - y;
+                    let d2 = dx * dx + dy * dy;
+                    if d2 > max_r2 {
+                        continue;
+                    }
+                    if best.map(|(_, b)| d2 < b).unwrap_or(true) {
+                        best = Some((idx, d2));
+                    }
+                }
+            }
+        }
+
+        best.map(|(i, d2)| (i, d2.sqrt()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nearest_returns_expected_index() {
+        let pts = vec![Point::new(0.0, 0.0), Point::new(10.0, 10.0)];
+        let idx = SpatialIndex::build(&pts, 4, 4)
+            .nearest(9.0, 9.0, 3.0)
+            .map(|(i, _)| i);
+        assert_eq!(idx, Some(1));
+    }
+}

--- a/crates/blinc_charts/src/time_format.rs
+++ b/crates/blinc_charts/src/time_format.rs
@@ -1,0 +1,34 @@
+use crate::format::format_compact;
+
+pub fn format_hms(seconds: f64) -> String {
+    if !seconds.is_finite() {
+        return "--:--:--".to_string();
+    }
+    let total = seconds.round() as i64;
+    let sec = total.rem_euclid(60);
+    let min_total = total.div_euclid(60);
+    let min = min_total.rem_euclid(60);
+    let hour = min_total.div_euclid(60);
+    format!("{hour:02}:{min:02}:{sec:02}")
+}
+
+pub fn format_time_or_number(value: f32) -> String {
+    if !value.is_finite() {
+        return format_compact(value);
+    }
+    let abs = value.abs();
+    if abs >= 86_400.0 {
+        return format_hms(value as f64);
+    }
+    format_compact(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hms_formats_expected() {
+        assert_eq!(format_hms(3661.0), "01:01:01");
+    }
+}

--- a/crates/blinc_charts/src/transition.rs
+++ b/crates/blinc_charts/src/transition.rs
@@ -1,0 +1,56 @@
+use crate::interpolate::lerp_f32;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ValueTransition {
+    start: f32,
+    end: f32,
+    duration: f32,
+    elapsed: f32,
+    value: f32,
+}
+
+impl ValueTransition {
+    pub fn new(start: f32, end: f32, duration_seconds: f32) -> Self {
+        let duration = duration_seconds.max(1e-6);
+        Self {
+            start,
+            end,
+            duration,
+            elapsed: 0.0,
+            value: start,
+        }
+    }
+
+    pub fn step(&mut self, dt_seconds: f32) {
+        if self.is_finished() {
+            self.value = self.end;
+            return;
+        }
+        self.elapsed = (self.elapsed + dt_seconds.max(0.0)).min(self.duration);
+        let t = self.elapsed / self.duration;
+        self.value = lerp_f32(self.start, self.end, t);
+    }
+
+    pub fn value(&self) -> f32 {
+        self.value
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.elapsed >= self.duration
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transition_reaches_target() {
+        let mut t = ValueTransition::new(0.0, 1.0, 1.0);
+        t.step(0.4);
+        assert!(t.value() > 0.0 && t.value() < 1.0);
+        t.step(0.6);
+        assert_eq!(t.value(), 1.0);
+        assert!(t.is_finished());
+    }
+}

--- a/crates/blinc_charts/src/triangulation.rs
+++ b/crates/blinc_charts/src/triangulation.rs
@@ -1,0 +1,42 @@
+use blinc_core::Point;
+
+/// Deterministic fan triangulation in input order.
+///
+/// This is intentionally lightweight and stable for chart overlays where only
+/// triangle count metadata is needed and a full triangulation engine would be overkill.
+pub fn triangulate_fan(points: &[Point]) -> Vec<[usize; 3]> {
+    if points.len() < 3 {
+        return Vec::new();
+    }
+
+    let idx: Vec<usize> = points
+        .iter()
+        .enumerate()
+        .filter_map(|(i, p)| (p.x.is_finite() && p.y.is_finite()).then_some(i))
+        .collect();
+    if idx.len() < 3 {
+        return Vec::new();
+    }
+
+    let mut out = Vec::with_capacity(idx.len().saturating_sub(2));
+    for i in 1..idx.len() - 1 {
+        out.push([idx[0], idx[i], idx[i + 1]]);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fan_triangulates_quad_to_two_tris() {
+        let pts = vec![
+            Point::new(0.0, 0.0),
+            Point::new(1.0, 0.0),
+            Point::new(1.0, 1.0),
+            Point::new(0.0, 1.0),
+        ];
+        assert_eq!(triangulate_fan(&pts).len(), 2);
+    }
+}

--- a/crates/blinc_charts/src/view.rs
+++ b/crates/blinc_charts/src/view.rs
@@ -1,3 +1,4 @@
+use crate::scale::LinearScale;
 use blinc_core::Point;
 
 /// 1D numeric domain (min..max).
@@ -90,24 +91,46 @@ impl ChartView {
     }
 
     pub fn x_to_px(&self, x: f32, plot_x: f32, plot_w: f32) -> f32 {
-        let t = (x - self.domain.x.min) / self.domain.x.span();
-        plot_x + t * plot_w
+        LinearScale::new(
+            self.domain.x.min,
+            self.domain.x.max,
+            plot_x,
+            plot_x + plot_w,
+        )
+        .map(x)
     }
 
     pub fn y_to_px(&self, y: f32, plot_y: f32, plot_h: f32) -> f32 {
         // y increases downward in screen coords.
-        let t = (y - self.domain.y.min) / self.domain.y.span();
-        plot_y + (1.0 - t) * plot_h
+        LinearScale::new(
+            self.domain.y.min,
+            self.domain.y.max,
+            plot_y + plot_h,
+            plot_y,
+        )
+        .map(y)
     }
 
     pub fn px_to_x(&self, px: f32, plot_x: f32, plot_w: f32) -> f32 {
-        let t = ((px - plot_x) / plot_w).clamp(0.0, 1.0);
-        self.domain.x.min + t * self.domain.x.span()
+        let px = px.clamp(plot_x, plot_x + plot_w);
+        LinearScale::new(
+            self.domain.x.min,
+            self.domain.x.max,
+            plot_x,
+            plot_x + plot_w,
+        )
+        .invert(px)
     }
 
     pub fn px_to_y(&self, py: f32, plot_y: f32, plot_h: f32) -> f32 {
-        let t = ((py - plot_y) / plot_h).clamp(0.0, 1.0);
-        self.domain.y.min + (1.0 - t) * self.domain.y.span()
+        let py = py.clamp(plot_y, plot_y + plot_h);
+        LinearScale::new(
+            self.domain.y.min,
+            self.domain.y.max,
+            plot_y + plot_h,
+            plot_y,
+        )
+        .invert(py)
     }
 
     pub fn data_to_px(

--- a/crates/blinc_charts/tests/d3_gap_modules.rs
+++ b/crates/blinc_charts/tests/d3_gap_modules.rs
@@ -1,0 +1,77 @@
+use blinc_charts::axis::build_bottom_ticks;
+use blinc_charts::format::{format_compact, format_fixed};
+use blinc_charts::interpolate::lerp_f32;
+use blinc_charts::polygon::{point_in_polygon, polygon_area, rect_polygon};
+use blinc_charts::scale::{BandScale, LinearScale};
+use blinc_charts::spatial_index::SpatialIndex;
+use blinc_charts::time_format::format_hms;
+use blinc_charts::transition::ValueTransition;
+use blinc_charts::triangulation::triangulate_fan;
+use blinc_charts::Domain1D;
+use blinc_core::Point;
+
+#[test]
+fn linear_scale_maps_and_inverts() {
+    let s = LinearScale::new(0.0, 100.0, 10.0, 210.0);
+    assert!((s.map(50.0) - 110.0).abs() < 1e-5);
+    assert!((s.invert(110.0) - 50.0).abs() < 1e-5);
+}
+
+#[test]
+fn band_scale_returns_valid_band_metrics() {
+    let b = BandScale::new(4, 0.0, 400.0, 0.1, 0.05);
+    assert!(b.band_width() > 0.0);
+    assert!(b.center(0).unwrap() < b.center(3).unwrap());
+}
+
+#[test]
+fn axis_ticks_use_formatter() {
+    let ticks = build_bottom_ticks(Domain1D::new(0.0, 100.0), 0.0, 200.0, 5, |v| {
+        format!("v={v:.0}")
+    });
+    assert_eq!(ticks.len(), 5);
+    assert!(ticks.iter().all(|t| t.label.starts_with("v=")));
+}
+
+#[test]
+fn format_helpers_cover_numeric_and_time() {
+    assert_eq!(format_fixed(std::f32::consts::PI, 2), "3.14");
+    assert_eq!(format_compact(12_400.0), "12.4K");
+    assert_eq!(format_hms(3661.0), "01:01:01");
+}
+
+#[test]
+fn spatial_index_finds_nearest_point() {
+    let pts = vec![Point::new(10.0, 10.0), Point::new(50.0, 50.0)];
+    let index = SpatialIndex::build(&pts, 8, 8);
+    let hit = index.nearest(48.0, 52.0, 10.0).unwrap();
+    assert_eq!(hit.0, 1);
+}
+
+#[test]
+fn triangulation_and_polygon_helpers_work() {
+    let square = vec![
+        Point::new(0.0, 0.0),
+        Point::new(1.0, 0.0),
+        Point::new(1.0, 1.0),
+        Point::new(0.0, 1.0),
+    ];
+    let tris = triangulate_fan(&square);
+    assert!(!tris.is_empty());
+
+    let rect = rect_polygon(0.0, 0.0, 2.0, 1.0);
+    assert!(point_in_polygon(Point::new(1.0, 0.5), &rect));
+    assert!((polygon_area(&rect) - 2.0).abs() < 1e-5);
+}
+
+#[test]
+fn interpolate_and_transition_progress_deterministically() {
+    assert!((lerp_f32(0.0, 10.0, 0.25) - 2.5).abs() < 1e-6);
+
+    let mut tr = ValueTransition::new(0.0, 100.0, 1.0);
+    tr.step(0.5);
+    assert!((tr.value() - 50.0).abs() < 1e-3);
+    tr.step(0.5);
+    assert!((tr.value() - 100.0).abs() < 1e-3);
+    assert!(tr.is_finished());
+}

--- a/crates/blinc_core/src/draw.rs
+++ b/crates/blinc_core/src/draw.rs
@@ -1235,6 +1235,13 @@ pub trait DrawContext {
     /// Draw text at a position
     fn draw_text(&mut self, text: &str, origin: Point, style: &TextStyle);
 
+    /// Measure text dimensions for layout/alignment use-cases.
+    ///
+    /// Returns `None` when the active backend cannot provide reliable text metrics.
+    fn measure_text(&mut self, _text: &str, _style: &TextStyle) -> Option<Size> {
+        None
+    }
+
     /// Draw an image
     fn draw_image(&mut self, image: ImageId, rect: Rect, options: &ImageOptions);
 

--- a/crates/blinc_gpu/src/paint.rs
+++ b/crates/blinc_gpu/src/paint.rs
@@ -2229,6 +2229,12 @@ impl<'a> DrawContext for GpuPaintContext<'a> {
         }
     }
 
+    fn measure_text(&mut self, text: &str, style: &TextStyle) -> Option<Size> {
+        let text_ctx = self.text_ctx.as_mut()?;
+        let (width, height) = text_ctx.measure_text(text, style.size);
+        Some(Size::new(width, height))
+    }
+
     fn draw_image(&mut self, image: ImageId, rect: Rect, options: &ImageOptions) {
         if image.0 == 0 {
             return;

--- a/docs/plans/2026-02-11-d3-blinccharts-gap-backlog.md
+++ b/docs/plans/2026-02-11-d3-blinccharts-gap-backlog.md
@@ -12,10 +12,10 @@
 
 ## Source of Truth
 
-- Capability matrix: `/Users/cypark/Documents/project/Blinc/docs/references/2026-02-11-d3-blinccharts-capability-matrix.md`
-- Chart module surface: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/lib.rs`
-- Gallery coverage: `/Users/cypark/Documents/project/Blinc/crates/blinc_app/examples/charts_gallery_demo.rs`
-- Parallel stub evidence: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/polar.rs`
+- Capability matrix: `docs/references/2026-02-11-d3-blinccharts-capability-matrix.md`
+- Chart module surface: `crates/blinc_charts/src/lib.rs`
+- Gallery coverage: `crates/blinc_app/examples/charts_gallery_demo.rs`
+- Parallel stub evidence: `crates/blinc_charts/src/polar.rs`
 
 ## Prioritization Rubric
 
@@ -81,9 +81,9 @@
 ### Task 1: `BLC-D3-001` Parallel Coordinates Real Implementation
 
 **Files:**
-- Modify: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/polar.rs`
-- Modify: `/Users/cypark/Documents/project/Blinc/crates/blinc_app/examples/charts_gallery_demo.rs` (labels/help text only if needed)
-- Test: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/tests/gallery_completion_smoke.rs`
+- Modify: `crates/blinc_charts/src/polar.rs`
+- Modify: `crates/blinc_app/examples/charts_gallery_demo.rs` (labels/help text only if needed)
+- Test: `crates/blinc_charts/tests/gallery_completion_smoke.rs`
 
 **Step 1: Write failing tests for `Parallel` behavior**
 
@@ -114,9 +114,9 @@
 ### Task 2: `BLC-D3-002` Support Policy Publication
 
 **Files:**
-- Modify: `/Users/cypark/Documents/project/Blinc/docs/references/2026-02-11-d3-blinccharts-capability-matrix.md`
-- Modify: `/Users/cypark/Documents/project/Blinc/docs/plans/2026-02-11-d3-blinccharts-gap-backlog.md`
-- Modify: `/Users/cypark/Documents/project/Blinc/README.md` (short pointer section)
+- Modify: `docs/references/2026-02-11-d3-blinccharts-capability-matrix.md`
+- Modify: `docs/plans/2026-02-11-d3-blinccharts-gap-backlog.md`
+- Modify: `README.md` (short pointer section)
 
 **Step 1: Add visible rubric pointer from README**
 
@@ -134,12 +134,12 @@
 ### Task 3: `BLC-D3-003` Reusable Axis/Tick Module (Phase 1 first)
 
 **Files:**
-- Create: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/axis.rs`
-- Modify: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/lib.rs`
-- Modify: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/line.rs`
-- Modify: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/bar.rs`
-- Modify: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/scatter.rs`
-- Test: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/tests/gallery_completion_smoke.rs` (or new dedicated axis tests)
+- Create: `crates/blinc_charts/src/axis.rs`
+- Modify: `crates/blinc_charts/src/lib.rs`
+- Modify: `crates/blinc_charts/src/line.rs`
+- Modify: `crates/blinc_charts/src/bar.rs`
+- Modify: `crates/blinc_charts/src/scatter.rs`
+- Test: `crates/blinc_charts/tests/gallery_completion_smoke.rs` (or new dedicated axis tests)
 
 **Step 1: Add axis API and failing tests**
 

--- a/docs/plans/2026-02-11-d3-blinccharts-gap-backlog.md
+++ b/docs/plans/2026-02-11-d3-blinccharts-gap-backlog.md
@@ -1,12 +1,12 @@
-# D3 Gap Closure Backlog for BlincCharts
+# D3 Gap Closure for BlincCharts Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Turn the D3-vs-BlincCharts capability matrix into a prioritized, phase-based backlog that supports repository split decisions.
+**Goal:** Convert the D3-vs-BlincCharts audit into an execution-ready backlog that protects split readiness while keeping scope aligned with Blinc-native chart priorities.
 
-**Architecture:** Keep the default track as product-parity (Blinc-native chart library), then add optional library-parity phases. Preserve current chart rendering/event model (`blinc_charts` + `blinc_layout` + `blinc_core`) and avoid foundation-package churn unless a concrete requirement forces it.
+**Architecture:** Keep the default track as product-parity for `blinc_charts` and gate any broader library-parity work behind explicit demand. Implement split blockers first (`Parallel` mode credibility + support policy publication), then build reusable utility layers (axis, scale, formatting), then algorithmic modules. Avoid touching `blinc_layout` and `blinc_core` unless a concrete API constraint is proven.
 
-**Tech Stack:** Rust workspace crates (`blinc_charts`, `blinc_layout`, `blinc_core`), docs under `docs/references` and `docs/plans`.
+**Tech Stack:** Rust workspace crates (`blinc_charts`, `blinc_app`, optional `blinc_layout`), documentation under `docs/references` and `docs/plans`, cargo test/check pipeline.
 
 ---
 
@@ -15,139 +15,155 @@
 - Capability matrix: `/Users/cypark/Documents/project/Blinc/docs/references/2026-02-11-d3-blinccharts-capability-matrix.md`
 - Chart module surface: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/lib.rs`
 - Gallery coverage: `/Users/cypark/Documents/project/Blinc/crates/blinc_app/examples/charts_gallery_demo.rs`
+- Parallel stub evidence: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/polar.rs`
 
 ## Prioritization Rubric
 
-- `P0`: split blocking or correctness credibility issue.
-- `P1`: core developer-facing API gap for reusable chart library.
-- `P2`: algorithmic depth and ecosystem parity improvements.
-- `P3`: polish and optional parity layers.
+- `P0`: split-blocking credibility or contract clarity issue.
+- `P1`: core reusable chart-library API gap.
+- `P2`: algorithmic depth and heavy-data interaction improvements.
+- `P3`: optional interpolation/transition parity layer.
 
 ## Package Change Policy (for split)
 
-- Default policy: changes should remain in `blinc_charts`.
-- Allowed optional touch points:
-  - `blinc_layout`: only if new event primitives are strictly required.
-  - `blinc_core`: only if new draw primitive API is strictly required.
-- Any item that requires `blinc_layout` or `blinc_core` changes must carry explicit justification in its PR description.
+- Default: keep all work inside `blinc_charts`.
+- Optional touch points:
+  - `blinc_layout`: only when transition/event primitives are strictly required.
+  - `blinc_core`: only when drawing primitives are strictly required.
+- If a task needs `blinc_layout` or `blinc_core`, PR must include explicit justification.
 
-## Phase 0 (P0): Split Credibility Blockers
+## Backlog Ledger
 
-Target window: immediate (before repo split announcement).
+| ID | Priority | Scope | Dependencies | Status | Done criteria |
+|---|---|---|---|---|---|
+| `BLC-D3-001` | P0 | Real parallel coordinates rendering for `PolarChartMode::Parallel` | none | Completed (initial, 2026-02-11) | `render_parallel_stub` removed, distinct axes + polyline renderer added, gallery mode visibly differs from radar |
+| `BLC-D3-002` | P0 | Publish support policy for `Full/Partial/Missing/Out-of-scope` | none | Completed (2026-02-11) | matrix rubric linked from entry docs and split recommendation |
+| `BLC-D3-003` | P1 | Reusable axis/tick module for Cartesian charts | `BLC-D3-001` | Completed (initial, 2026-02-11) | line/bar/scatter share axis renderer, tick count + formatter configurable |
+| `BLC-D3-004` | P1 | Shared scale abstraction (linear + band first) | `BLC-D3-003` recommended | Completed (initial, 2026-02-11) | chart modules can migrate incrementally from ad-hoc mapping |
+| `BLC-D3-005` | P1 | Number/time formatting utilities | `BLC-D3-003`, `BLC-D3-004` | Completed (initial, 2026-02-11) | shared formatter API used in overlays/tooltips/axes |
+| `BLC-D3-006` | P2 | Spatial index for dense hover/hit test | `BLC-D3-004` | Completed (initial, 2026-02-11) | optional index path for nearest-point queries in scatter/network |
+| `BLC-D3-007` | P2 | Triangulation utility module | `BLC-D3-006` optional | Completed (initial, 2026-02-11) | finite-input tests + at least one consumer mode |
+| `BLC-D3-008` | P2 | Polygon utility helpers | none | Completed (initial, 2026-02-11) | shared point-in-polygon/area helpers wired into selection path |
+| `BLC-D3-009` | P3 | Interpolation helper module | `BLC-D3-003`~`005` recommended | Completed (initial, 2026-02-11) | reusable interpolation API for chart transitions |
+| `BLC-D3-010` | P3 | Minimal deterministic transition policy | `BLC-D3-009` | Completed (initial, 2026-02-11) | documented lifecycle + one bounded-cost chart animation demo |
 
-1. Replace `Parallel` stub in polar chart with real parallel coordinates rendering.
-- Priority: `P0`
-- D3 mapping: `d3-shape` / partial `d3-scale` parity credibility
-- Current gap evidence: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/polar.rs`
-- Package impact: `blinc_charts` only (expected)
-- Done criteria:
-  - `PolarChartMode::Parallel` no longer calls `render_parallel_stub`.
-  - Distinct axes + polyline rendering path exists.
-  - Gallery mode toggle visibly switches to true parallel visualization.
+## Phase Plan
 
-2. Publish explicit support policy for `Full/Partial/Missing/Out-of-scope`.
-- Priority: `P0`
-- D3 mapping: all modules (contract clarity)
-- Package impact: docs only
-- Done criteria:
-  - Matrix status rubric is referenced from README/docs entry point.
-  - Split decision references product-parity target explicitly.
+### Phase 0 (Split Gate)
 
-## Phase 1 (P1): Core Reusable Utility Layer
+- Target: immediate (before split announcement)
+- Required items: `BLC-D3-001`, `BLC-D3-002`
+- Required verification:
+  - `cargo test -p blinc_charts`
+  - `cargo check -p blinc_app --example charts_gallery_demo --features windowed`
 
-Target window: first cycle after split (if library consumers are expected).
+### Phase 1 (Core Library Surface)
 
-3. Add reusable axis/tick module for Cartesian charts.
-- Priority: `P1`
-- D3 mapping: `d3-axis`
-- Package impact: `blinc_charts` only (expected)
-- Done criteria:
-  - Shared axis renderer used by at least line/bar/scatter.
-  - Tick generation configurable by count and formatter callback.
+- Target: first cycle after split
+- Required items: `BLC-D3-003`, `BLC-D3-004`, `BLC-D3-005`
+- Suggested verification:
+  - `cargo test -p blinc_charts`
+  - `cargo test -p blinc_charts --test gallery_completion_smoke`
+  - `cargo check -p blinc_app --example charts_gallery_demo --features windowed`
 
-4. Add scale abstraction beyond raw domain mapping.
-- Priority: `P1`
-- D3 mapping: `d3-scale`
-- Package impact: `blinc_charts` only (expected)
-- Done criteria:
-  - Introduce scale traits/types for linear and band scales.
-  - Existing chart code can opt into shared scales incrementally.
+### Phase 2 (Algorithm Depth)
 
-5. Add formatting utilities for numeric and time labels.
-- Priority: `P1`
-- D3 mapping: `d3-format`, `d3-time-format`, partial `d3-time`
-- Package impact: `blinc_charts` only (expected)
-- Done criteria:
-  - Shared number formatter API replaces ad-hoc overlay text formatting.
-  - Shared time label formatting usable in time-series axes/tooltips.
+- Target: second cycle after split
+- Items: `BLC-D3-006`, `BLC-D3-007`, `BLC-D3-008`
 
-## Phase 2 (P2): Algorithmic Depth
+### Phase 3 (Optional Transition Layer)
 
-Target window: second cycle after split (advanced analytics use cases).
+- Target: only if UX animation goals justify maintenance cost
+- Items: `BLC-D3-009`, `BLC-D3-010`
 
-6. Add spatial indexing utilities for dense interaction.
-- Priority: `P2`
-- D3 mapping: `d3-quadtree`
-- Package impact: `blinc_charts` only (expected)
-- Done criteria:
-  - Reusable quadtree-like index for nearest-point queries.
-  - Scatter/network hover hit-testing can optionally use this index.
+## Execution-Ready Tasks (Now)
 
-7. Add triangulation-based utilities for field/mesh workflows.
-- Priority: `P2`
-- D3 mapping: `d3-delaunay`
-- Package impact: `blinc_charts` only (expected)
-- Done criteria:
-  - New utility module with tests for finite input and stable topology.
-  - At least one chart mode consumes the triangulation result.
+### Task 1: `BLC-D3-001` Parallel Coordinates Real Implementation
 
-8. Add polygon utility helpers for clipping/containment.
-- Priority: `P2`
-- D3 mapping: `d3-polygon`
-- Package impact: `blinc_charts` only (expected)
-- Done criteria:
-  - Point-in-polygon and area-like helpers exposed.
-  - At least one brush/selection path uses shared polygon helper.
+**Files:**
+- Modify: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/polar.rs`
+- Modify: `/Users/cypark/Documents/project/Blinc/crates/blinc_app/examples/charts_gallery_demo.rs` (labels/help text only if needed)
+- Test: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/tests/gallery_completion_smoke.rs`
 
-## Phase 3 (P3): Transition and Interpolation Layer
+**Step 1: Write failing tests for `Parallel` behavior**
 
-Target window: optional, based on UX goals.
+- Add tests proving `PolarChartMode::Parallel` does not use radar-only rendering path semantics (geometry/label expectations).
 
-9. Add interpolation helper module.
-- Priority: `P3`
-- D3 mapping: `d3-interpolate`
-- Package impact: `blinc_charts` only (expected)
-- Done criteria:
-  - Reusable interpolation helpers available for chart value/path transitions.
+**Step 2: Run tests to verify failure**
 
-10. Add chart transition API policy (minimal, deterministic).
-- Priority: `P3`
-- D3 mapping: `d3-transition`
-- Package impact: may require `blinc_layout` integration; keep optional
-- Done criteria:
-  - Explicit transition lifecycle API is documented.
-  - At least one chart demonstrates data-change animation with bounded cost.
+- Run: `cargo test -p blinc_charts --test gallery_completion_smoke`
+- Expected: fail on new `Parallel` assertions.
 
-## Explicit Out-of-Scope (for BlincCharts crate)
+**Step 3: Implement minimal parallel coordinates renderer**
+
+- Replace `render_parallel_stub` with dedicated render path:
+  - equally spaced vertical axes by dimension
+  - per-series polylines across axes
+  - preserve finite-value handling + color rules
+
+**Step 4: Re-run tests and fix until pass**
+
+- Run: `cargo test -p blinc_charts --test gallery_completion_smoke`
+- Expected: pass.
+
+**Step 5: Verify gallery compile path**
+
+- Run: `cargo check -p blinc_app --example charts_gallery_demo --features windowed`
+- Expected: pass.
+
+### Task 2: `BLC-D3-002` Support Policy Publication
+
+**Files:**
+- Modify: `/Users/cypark/Documents/project/Blinc/docs/references/2026-02-11-d3-blinccharts-capability-matrix.md`
+- Modify: `/Users/cypark/Documents/project/Blinc/docs/plans/2026-02-11-d3-blinccharts-gap-backlog.md`
+- Modify: `/Users/cypark/Documents/project/Blinc/README.md` (short pointer section)
+
+**Step 1: Add visible rubric pointer from README**
+
+- Add a concise section linking matrix + backlog policy.
+
+**Step 2: Keep matrix and backlog IDs synchronized**
+
+- Ensure backlog IDs (`BLC-D3-001`..`010`) are used consistently.
+
+**Step 3: Verify docs references**
+
+- Run: `rg -n "BLC-D3-00[1-9]|BLC-D3-010|Full/Partial/Missing/Out-of-scope" docs README.md`
+- Expected: IDs and rubric strings found in matrix/backlog/readme.
+
+### Task 3: `BLC-D3-003` Reusable Axis/Tick Module (Phase 1 first)
+
+**Files:**
+- Create: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/axis.rs`
+- Modify: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/lib.rs`
+- Modify: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/line.rs`
+- Modify: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/bar.rs`
+- Modify: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/scatter.rs`
+- Test: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/tests/gallery_completion_smoke.rs` (or new dedicated axis tests)
+
+**Step 1: Add axis API and failing tests**
+
+- Introduce tick generation contract (count + formatter callback).
+
+**Step 2: Implement minimal axis renderer and integrate one chart first**
+
+- Start with line chart, then port bar/scatter.
+
+**Step 3: Verify chart compile and tests**
+
+- Run: `cargo test -p blinc_charts`
+- Run: `cargo check -p blinc_app --example charts_gallery_demo --features windowed`
+
+## Explicit Out-of-Scope for `blinc_charts`
 
 - `d3-fetch`, `d3-dsv`, `d3-selection`, `d3-timer`, `d3-ease`, `d3-random`
-- Rationale: these are runtime/data/DOM/timing helpers, not core chart-rendering responsibilities for this crate.
-
-## Split Decision Gates
-
-Gate A (must-pass for split):
-- Phase 0 complete.
-- Current chart tests remain green: `cargo test -p blinc_charts`.
-- Gallery compiles: `cargo check -p blinc_app --example charts_gallery_demo --features windowed`.
-
-Gate B (optional quality bar before public externalization):
-- At least Phase 1 items 3 and 4 complete.
+- Rationale: runtime/data/DOM/timing helpers are outside this crate’s rendering responsibility.
 
 ## Recommended Execution Order
 
-1. Phase 0 item 1 (Parallel real implementation).
-2. Phase 0 item 2 (support policy visibility).
-3. Phase 1 item 3 (axis/tick).
-4. Phase 1 item 4 (scale abstraction).
-5. Phase 1 item 5 (format/time-format).
-6. Phase 2 and 3 based on external consumer demand.
+1. `BLC-D3-001` (parallel credibility blocker)
+2. `BLC-D3-002` (support policy visibility)
+3. `BLC-D3-003` (axis/tick)
+4. `BLC-D3-004` (scale abstraction)
+5. `BLC-D3-005` (format/time-format)
+6. `BLC-D3-006`..`010` by external consumer demand

--- a/docs/references/2026-02-11-d3-blinccharts-capability-matrix.md
+++ b/docs/references/2026-02-11-d3-blinccharts-capability-matrix.md
@@ -13,11 +13,11 @@ Purpose: compare the latest `d3` package capability surface with current `blinc_
   - `Out-of-scope`: web/DOM utility not intended for BlincCharts runtime.
 
 Key evidence:
-- Public chart modules: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/lib.rs`
-- Gallery coverage (18 chart kinds wired): `/Users/cypark/Documents/project/Blinc/crates/blinc_app/examples/charts_gallery_demo.rs`
-- Shared view/domain mapping: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/view.rs`
-- Shared link/selection state: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/link.rs`
-- Shared interaction bindings: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/input.rs`
+- Public chart modules: `crates/blinc_charts/src/lib.rs`
+- Gallery coverage (18 chart kinds wired): `crates/blinc_app/examples/charts_gallery_demo.rs`
+- Shared view/domain mapping: `crates/blinc_charts/src/view.rs`
+- Shared link/selection state: `crates/blinc_charts/src/link.rs`
+- Shared interaction bindings: `crates/blinc_charts/src/input.rs`
 
 ## Capability Matrix (D3 30 modules)
 
@@ -94,7 +94,7 @@ Use these IDs in commit messages, PR descriptions, and progress notes so the cap
 ## Notable implementation update
 
 - `PolarChartMode::Parallel` now has a dedicated parallel-coordinates render path (axis + polyline), replacing the prior stub.
-  - Evidence: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/polar.rs` (`render_parallel`).
+  - Evidence: `crates/blinc_charts/src/polar.rs` (`render_parallel`).
 - Reusable utility layers (`axis`, `scale`, `format`, `time_format`) and optional algorithm layers (`spatial_index`, `triangulation`, `polygon`) were added for gap closure.
 - Transition/interpolation baseline now exists via `interpolate.rs` + `transition.rs`, with `GaugeChartModel` as the first integrated chart.
 

--- a/docs/references/2026-02-11-d3-blinccharts-capability-matrix.md
+++ b/docs/references/2026-02-11-d3-blinccharts-capability-matrix.md
@@ -24,35 +24,66 @@ Key evidence:
 | D3 module | Primary capability | BlincCharts mapping | Status | Evidence / note |
 |---|---|---|---|---|
 | `d3-array` | stats, bins, extents | histogram/statistics, domain computations | Partial | histogram/statistics exist, but not a general array utility API |
-| `d3-axis` | reusable axis generators | per-chart inline grid/labels only | Missing | no dedicated axis module in `blinc_charts/src` |
+| `d3-axis` | reusable axis generators | shared axis/tick helpers in `axis.rs`, consumed by line/bar/scatter overlays | Partial | reusable module exists, but advanced axis layouts are still limited |
 | `d3-brush` | 1D/2D brushing | `BrushX`, `BrushRect`, linked selection | Full | `brush.rs`, `xy_stack.rs`, `density_map.rs`, `contour.rs` |
 | `d3-chord` | chord layout/rendering | `NetworkMode::Chord` | Partial | chord mode exists in `network.rs`, simplified pipeline |
 | `d3-color` | color parsing/manipulation | `blinc_core::Color` usage in styles | Partial | chart styles use colors, but no d3-like color utility package |
 | `d3-contour` | contour / isobands | `contour.rs` | Full | marching-squares style contour rendering implemented |
-| `d3-delaunay` | delaunay/voronoi | none | Missing | no triangulation/voronoi support found |
+| `d3-delaunay` | delaunay/voronoi | lightweight triangulation helpers | Partial | `triangulation.rs` fan triangulation exists; full delaunay/voronoi not yet implemented |
 | `d3-dispatch` | event dispatch bus | framework events + shared state handles | Partial | interactions are event callbacks, no standalone dispatch API |
 | `d3-drag` | drag behavior | drag pan/brush in all interactive charts | Full | `on_drag*` patterns in line/bar/scatter/etc |
 | `d3-dsv` | CSV/TSV parsing | none in `blinc_charts` | Out-of-scope | data ingestion is outside chart rendering crate |
 | `d3-ease` | easing functions | none in `blinc_charts` | Out-of-scope | animation easing belongs to other runtime layers |
 | `d3-fetch` | web fetch helpers | none in `blinc_charts` | Out-of-scope | network/data fetch is outside chart crate |
 | `d3-force` | force simulation | graph layout mode in `network.rs` | Partial | graph exists, but no standalone configurable force engine API |
-| `d3-format` | number formatting | ad-hoc text formatting only | Missing | no shared numeric formatting utility in `blinc_charts` |
+| `d3-format` | number formatting | shared numeric format helpers | Partial | `format.rs` (`format_fixed`, `format_compact`) used by chart overlays/axes |
 | `d3-geo` | geo projections/pathing | `geo.rs` | Partial | geo chart exists; projection set is narrower than d3-geo |
 | `d3-hierarchy` | tree/treemap/partition/pack | `hierarchy.rs` | Partial | Treemap/Icicle/Sunburst/Packing exist, narrower API surface |
-| `d3-interpolate` | interpolation utilities | ad-hoc chart-level interpolation | Missing | no reusable interpolation module exposed |
+| `d3-interpolate` | interpolation utilities | reusable interpolation helpers | Partial | `interpolate.rs` (`lerp_f32`, `lerp_point`) |
 | `d3-path` | path serialization | `blinc_core::Path` drawing | Partial | path drawing exists, but not a d3-path-like utility package |
-| `d3-polygon` | polygon ops | no general polygon utility API | Missing | chart internals only |
-| `d3-quadtree` | spatial index | none | Missing | no quadtree module found |
+| `d3-polygon` | polygon ops | shared polygon helper module | Partial | `polygon.rs` (`point_in_polygon`, `polygon_area`, `rect_polygon`) wired into contour/density selection overlays |
+| `d3-quadtree` | spatial index | shared spatial index helper module | Partial | `spatial_index.rs` grid index used for scatter/network nearest-hit lookups |
 | `d3-random` | random distributions | demo-local generators only | Out-of-scope | random helpers are in gallery example, not chart API |
 | `d3-scale` | scale primitives | `Domain1D/2D` + px/data transforms | Partial | linear mapping exists (`view.rs`), no band/log/time scale module |
 | `d3-scale-chromatic` | color palettes | per-chart hardcoded palettes | Partial | colors exist, no palette package surface |
 | `d3-selection` | DOM selections | n/a in Blinc UI runtime | Out-of-scope | Blinc uses element builders/events, not DOM selection |
 | `d3-shape` | line/area/arc/symbol generators | line/area/bar/scatter/polar etc | Partial | many shape charts exist; no generic shape generator API |
 | `d3-time` | time intervals/scales | numeric X domain time-series | Partial | time series support exists (`time_series.rs`), no rich calendar API |
-| `d3-time-format` | locale time formatting | none | Missing | no dedicated time formatter in chart crate |
+| `d3-time-format` | locale time formatting | shared time-format helper module | Partial | `time_format.rs` (`format_hms`, `format_time_or_number`) used in Cartesian chart overlays/axes |
 | `d3-timer` | frame timers | none in `blinc_charts` | Out-of-scope | scheduling runtime is outside chart crate |
-| `d3-transition` | declarative transitions | none in `blinc_charts` | Missing | no transition API in chart module |
+| `d3-transition` | declarative transitions | deterministic value transition helper + gauge integration | Partial | `transition.rs` (`ValueTransition`) + gauge demo path |
 | `d3-zoom` | pan/zoom behavior | scroll/pinch/drag pan across chart types | Full | widespread `on_scroll`/`on_pinch`/`on_drag_pan_total` |
+
+## Backlog Mapping (Execution IDs)
+
+Use these IDs in commit messages, PR descriptions, and progress notes so the capability matrix and backlog stay synchronized.
+
+| Backlog ID | Priority | D3 module(s) | Work summary | Primary files |
+|---|---|---|---|---|
+| `BLC-D3-001` | P0 | `d3-shape` (parallel-coordinates credibility) | Replace `PolarChartMode::Parallel` stub with real parallel coordinates rendering | `crates/blinc_charts/src/polar.rs`, `crates/blinc_app/examples/charts_gallery_demo.rs`, `crates/blinc_charts/tests/gallery_completion_smoke.rs` |
+| `BLC-D3-002` | P0 | All (status contract) | Publish and link `Full/Partial/Missing/Out-of-scope` support policy from entry docs | `docs/references/2026-02-11-d3-blinccharts-capability-matrix.md`, `docs/plans/2026-02-11-d3-blinccharts-gap-backlog.md`, `README.md` |
+| `BLC-D3-003` | P1 | `d3-axis` | Add reusable axis/tick renderer consumed by line/bar/scatter | `crates/blinc_charts/src/axis.rs` (new), `crates/blinc_charts/src/lib.rs`, `crates/blinc_charts/src/line.rs`, `crates/blinc_charts/src/bar.rs`, `crates/blinc_charts/src/scatter.rs` |
+| `BLC-D3-004` | P1 | `d3-scale` | Introduce shared linear/band scale abstractions | `crates/blinc_charts/src/scale.rs` (new), `crates/blinc_charts/src/view.rs`, `crates/blinc_charts/src/lib.rs` |
+| `BLC-D3-005` | P1 | `d3-format`, `d3-time-format` | Add numeric/time formatting helpers for axis/tooltips/overlay text | `crates/blinc_charts/src/format.rs` (new), `crates/blinc_charts/src/time_format.rs` (new), chart modules with overlay labels |
+| `BLC-D3-006` | P2 | `d3-quadtree` | Add optional spatial index for dense hit-testing | `crates/blinc_charts/src/spatial_index.rs` (new), `crates/blinc_charts/src/scatter.rs`, `crates/blinc_charts/src/network.rs` |
+| `BLC-D3-007` | P2 | `d3-delaunay` | Add triangulation utilities and wire at least one chart mode | `crates/blinc_charts/src/triangulation.rs` (new), one consuming chart module |
+| `BLC-D3-008` | P2 | `d3-polygon` | Add polygon helpers (containment/area) for shared selection logic | `crates/blinc_charts/src/polygon.rs` (new), brush/selection consumers |
+| `BLC-D3-009` | P3 | `d3-interpolate` | Add interpolation utility module for deterministic transitions | `crates/blinc_charts/src/interpolate.rs` (new), chart animation consumers |
+| `BLC-D3-010` | P3 | `d3-transition` | Define minimal transition lifecycle policy and sample integration | docs + selected chart module, optional `blinc_layout` touch |
+
+## Transition Policy (Minimal, Deterministic)
+
+- Lifecycle states:
+  - `Idle`: no active transition (`transition = None`).
+  - `Active`: `ValueTransition` exists and advances with `step(dt)`.
+  - `Completed`: elapsed time reaches duration, value snaps to target, transition cleared.
+- Determinism rule:
+  - transitions use explicit `dt` progression (`tick_transition`) and no hidden scheduler/timer inside `blinc_charts`.
+  - chart render path may apply a fixed per-frame step to keep cost bounded and predictable.
+- Initial integration target:
+  - `GaugeChartModel` uses `set_value_transition` + `tick_transition` as the reference implementation.
+- Scope rule:
+  - this crate provides interpolation/transition primitives; orchestration across multiple charts or timeline control remains optional and can be added by higher layers.
 
 ## BlincCharts coverage snapshot
 
@@ -60,23 +91,25 @@ Key evidence:
 - X-domain linking + hover + brush selection are standardized via `ChartLink`.
 - Interaction binding is data-driven via `ChartInputBindings`.
 
-## Notable gap found during audit
+## Notable implementation update
 
-- `PolarChartMode::Parallel` is currently a stub message (`"parallel (uses radar v1)"`) and reuses radar rendering.
-  - Evidence: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/polar.rs` (`render_parallel_stub`).
+- `PolarChartMode::Parallel` now has a dedicated parallel-coordinates render path (axis + polyline), replacing the prior stub.
+  - Evidence: `/Users/cypark/Documents/project/Blinc/crates/blinc_charts/src/polar.rs` (`render_parallel`).
+- Reusable utility layers (`axis`, `scale`, `format`, `time_format`) and optional algorithm layers (`spatial_index`, `triangulation`, `polygon`) were added for gap closure.
+- Transition/interpolation baseline now exists via `interpolate.rs` + `transition.rs`, with `GaugeChartModel` as the first integrated chart.
 
 ## Split Readiness Judgment (for D3 parity goals)
 
 - If split goal is "Blinc-native interactive chart library with major chart types": ready.
 - If split goal is "near D3 module parity": not yet; the main gaps are:
-  - Missing reusable utility layers: axis, scale variants, numeric/time formatting.
-  - Missing algorithm modules: delaunay/quadtree/polygon ops.
-  - Missing transition/interpolation surface.
+  - Utility/algorithm/transition layers are now present but intentionally minimal.
+  - Advanced parity remains open (true delaunay/voronoi, richer scales/axes, broader transition orchestration across charts).
 
 ## Minimum actions before split (recommended)
 
 1. Decide parity target explicitly:
    - `Product parity` (recommended): keep current scope, track D3 gaps as backlog.
    - `Library parity`: add utility modules first (`axis`, `scale`, `format`, `time_format`).
-2. Promote one clear roadmap issue for "Parallel coordinates true implementation" (replace `render_parallel_stub`).
-3. Keep this matrix as the contract file for future gap closure checks.
+2. Complete `BLC-D3-001` ("Parallel coordinates true implementation", replace `render_parallel_stub`) — completed in this branch (initial cut).
+3. Complete `BLC-D3-002` (rubric/support policy visibility from README/docs entry) — completed in this branch.
+4. Keep this matrix as the contract file for future gap closure checks.


### PR DESCRIPTION
## Summary
- complete blinc_charts d3-gap coverage modules (axis, scale, format, time_format, interpolate, transition, polygon, triangulation, spatial_index) and export wiring
- harden chart stability paths (gauge transition ticking, network hover alignment, axis label placement, contour/density/line/scatter/bar robustness) with tests
- expand charts_gallery_demo controls: per-chart runtime option cycling, global noise toggle, and chart theme/preset controls

## Validation
- cargo fmt --all
- cargo fmt --all -- --check
- cargo test -p blinc_charts
- cargo check -p blinc_app --example charts_gallery_demo --features windowed
- gemini review on full diff: NO_ISSUES

## Notes
- upstream (project-blinc/Blinc) was not targeted/modified
