### PR TITLE
feat(blinc_charts): close kuva parity gaps across core modules

### DIFF
--- a/crates/blinc_charts/src/annotation.rs
+++ b/crates/blinc_charts/src/annotation.rs
@@ -1,0 +1,112 @@
+use blinc_core::{Brush, Color, DrawContext, Point, Rect, Stroke, TextStyle};
+
+#[derive(Clone, Debug)]
+pub enum ChartAnnotation {
+    Line {
+        from: Point,
+        to: Point,
+        color: Color,
+        width: f32,
+    },
+    Rect {
+        min: Point,
+        max: Point,
+        color: Color,
+    },
+    Text {
+        at: Point,
+        text: String,
+        color: Color,
+    },
+}
+
+pub fn draw_annotations<F>(
+    ctx: &mut dyn DrawContext,
+    annotations: &[ChartAnnotation],
+    map_point: F,
+    fallback_text_color: Color,
+) where
+    F: Fn(Point) -> Point,
+{
+    for ann in annotations {
+        match ann {
+            ChartAnnotation::Line {
+                from,
+                to,
+                color,
+                width,
+            } => {
+                let p0 = map_point(*from);
+                let p1 = map_point(*to);
+                ctx.stroke_polyline(
+                    &[p0, p1],
+                    &Stroke::new((*width).max(0.75)),
+                    Brush::Solid(*color),
+                );
+            }
+            ChartAnnotation::Rect { min, max, color } => {
+                let p0 = map_point(*min);
+                let p1 = map_point(*max);
+                let x = p0.x.min(p1.x);
+                let y = p0.y.min(p1.y);
+                let w = (p1.x - p0.x).abs().max(1.0);
+                let h = (p1.y - p0.y).abs().max(1.0);
+                ctx.fill_rect(
+                    Rect::new(x, y, w, h),
+                    0.0.into(),
+                    Brush::Solid(Color::rgba(color.r, color.g, color.b, 0.12)),
+                );
+                ctx.stroke_rect(
+                    Rect::new(x, y, w, h),
+                    0.0.into(),
+                    &Stroke::new(1.0),
+                    Brush::Solid(*color),
+                );
+            }
+            ChartAnnotation::Text { at, text, color } => {
+                let p = map_point(*at);
+                let style = TextStyle::new(11.0).with_color(if color.a > 0.0 {
+                    *color
+                } else {
+                    fallback_text_color
+                });
+                ctx.draw_text(text, p, &style);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use blinc_core::{RecordingContext, Size};
+
+    #[test]
+    fn draw_annotations_smoke() {
+        let anns = vec![
+            ChartAnnotation::Line {
+                from: Point::new(0.0, 0.0),
+                to: Point::new(1.0, 1.0),
+                color: Color::rgba(1.0, 0.0, 0.0, 1.0),
+                width: 1.0,
+            },
+            ChartAnnotation::Rect {
+                min: Point::new(0.2, 0.2),
+                max: Point::new(0.8, 0.8),
+                color: Color::rgba(0.0, 1.0, 0.0, 1.0),
+            },
+            ChartAnnotation::Text {
+                at: Point::new(0.5, 0.5),
+                text: "A".to_string(),
+                color: Color::rgba(1.0, 1.0, 1.0, 1.0),
+            },
+        ];
+        let mut ctx = RecordingContext::new(Size::new(100.0, 80.0));
+        draw_annotations(
+            &mut ctx,
+            &anns,
+            |p| Point::new(p.x * 100.0, p.y * 80.0),
+            Color::rgba(1.0, 1.0, 1.0, 1.0),
+        );
+    }
+}

--- a/crates/blinc_charts/src/axis.rs
+++ b/crates/blinc_charts/src/axis.rs
@@ -1,6 +1,6 @@
 use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextBaseline, TextStyle};
 
-use crate::scale::LinearScale;
+use crate::scale::{LinearScale, LogScale};
 use crate::view::Domain1D;
 
 // Fallback width used only when backend text measurement is unavailable.
@@ -60,6 +60,58 @@ where
     }
     // Invert so larger values are visually higher.
     let s = LinearScale::new(domain.min, domain.max, plot_y + plot_h, plot_y);
+    s.ticks(tick_count)
+        .into_iter()
+        .map(|v| AxisTick {
+            value: v,
+            px: s.map(v),
+            label: formatter(v),
+        })
+        .collect()
+}
+
+pub fn build_bottom_ticks_log<F>(
+    domain: Domain1D,
+    plot_x: f32,
+    plot_w: f32,
+    tick_count: usize,
+    formatter: F,
+) -> Vec<AxisTick>
+where
+    F: Fn(f32) -> String,
+{
+    if tick_count == 0 || !domain.is_valid() || plot_w <= 0.0 || domain.min <= 0.0 {
+        return Vec::new();
+    }
+    let Some(s) = LogScale::new(domain.min, domain.max, plot_x, plot_x + plot_w) else {
+        return Vec::new();
+    };
+    s.ticks(tick_count)
+        .into_iter()
+        .map(|v| AxisTick {
+            value: v,
+            px: s.map(v),
+            label: formatter(v),
+        })
+        .collect()
+}
+
+pub fn build_left_ticks_log<F>(
+    domain: Domain1D,
+    plot_y: f32,
+    plot_h: f32,
+    tick_count: usize,
+    formatter: F,
+) -> Vec<AxisTick>
+where
+    F: Fn(f32) -> String,
+{
+    if tick_count == 0 || !domain.is_valid() || plot_h <= 0.0 || domain.min <= 0.0 {
+        return Vec::new();
+    }
+    let Some(s) = LogScale::new(domain.min, domain.max, plot_y + plot_h, plot_y) else {
+        return Vec::new();
+    };
     s.ticks(tick_count)
         .into_iter()
         .map(|v| AxisTick {
@@ -161,5 +213,15 @@ mod tests {
         });
         assert!(bottom.is_empty());
         assert!(left.is_empty());
+    }
+
+    #[test]
+    fn log_tick_builder_returns_power_ticks() {
+        let ticks = build_bottom_ticks_log(Domain1D::new(1.0, 1000.0), 0.0, 200.0, 5, |v| {
+            format!("{v:.0}")
+        });
+        assert_eq!(ticks.len(), 4);
+        assert_eq!(ticks.first().map(|t| t.value), Some(1.0));
+        assert_eq!(ticks.last().map(|t| t.value), Some(1000.0));
     }
 }

--- a/crates/blinc_charts/src/bar.rs
+++ b/crates/blinc_charts/src/bar.rs
@@ -3,11 +3,13 @@ use std::sync::{Arc, Mutex};
 use blinc_core::{Brush, Color, DrawContext, Point, Rect, TextStyle};
 use blinc_layout::ElementBuilder;
 
+use crate::annotation::{draw_annotations, ChartAnnotation};
 use crate::axis::{build_bottom_ticks, build_left_ticks, draw_bottom_axis, draw_left_axis};
 use crate::brush::BrushX;
 use crate::common::{draw_grid, fill_bg};
 use crate::format::format_compact;
 use crate::link::ChartLinkHandle;
+use crate::palette;
 use crate::time_format::format_time_or_number;
 use crate::time_series::TimeSeriesF32;
 use crate::view::{ChartView, Domain1D, Domain2D};
@@ -73,6 +75,7 @@ pub struct BarChartModel {
 
     pub crosshair_x: Option<f32>,
     pub hover_x: Option<f32>,
+    pub annotations: Vec<ChartAnnotation>,
 
     bins: Vec<f32>, // bins_n * series_n
     counts: Vec<u32>,
@@ -89,38 +92,31 @@ impl BarChartModel {
             !series.is_empty(),
             "BarChartModel requires at least 1 series"
         );
-        anyhow::ensure!(
-            !series
-                .iter()
-                .flat_map(|s| s.y.iter())
-                .any(|v| v.is_finite() && *v < 0.0),
-            "BarChartModel does not support negative values"
-        );
 
         let mut x_min = f32::INFINITY;
         let mut x_max = f32::NEG_INFINITY;
         let mut y_min = f32::INFINITY;
-        let mut y_max_pos_sum = 0.0f32;
+        let mut y_max = f32::NEG_INFINITY;
 
         for s in &series {
             let (sx0, sx1) = s.x_min_max();
             x_min = x_min.min(sx0);
             x_max = x_max.max(sx1);
-            let (sy0, sy1) = s.y_min_max();
-            y_min = y_min.min(sy0);
-            if sy1.is_finite() {
-                y_max_pos_sum += sy1.max(0.0);
+            for &v in s.y.iter() {
+                if !v.is_finite() {
+                    continue;
+                }
+                y_min = y_min.min(v);
+                y_max = y_max.max(v);
             }
         }
 
-        if !y_min.is_finite() {
+        if !y_min.is_finite() || !y_max.is_finite() {
             y_min = -1.0;
+            y_max = 1.0;
         }
-        let mut y_max = if y_max_pos_sum.is_finite() && y_max_pos_sum > y_min {
-            y_max_pos_sum
-        } else {
-            1.0
-        };
+        y_min = y_min.min(0.0);
+        y_max = y_max.max(0.0);
         if y_max.partial_cmp(&y_min) != Some(std::cmp::Ordering::Greater) {
             y_max = y_min + 1.0;
         }
@@ -132,6 +128,7 @@ impl BarChartModel {
             style: BarChartStyle::default(),
             crosshair_x: None,
             hover_x: None,
+            annotations: Vec::new(),
             bins: Vec::new(),
             counts: Vec::new(),
             bins_n: 0,
@@ -146,17 +143,7 @@ impl BarChartModel {
     }
 
     fn series_color(&self, i: usize) -> Color {
-        // Simple deterministic palette (good enough for now).
-        let hues = [
-            (0.35, 0.65, 1.0),
-            (0.95, 0.55, 0.35),
-            (0.40, 0.85, 0.55),
-            (0.90, 0.75, 0.25),
-            (0.75, 0.55, 0.95),
-            (0.25, 0.80, 0.85),
-        ];
-        let (r, g, b) = hues[i % hues.len()];
-        Color::rgba(r, g, b, self.style.bar_alpha)
+        palette::qualitative(i, self.style.bar_alpha)
     }
 
     pub fn on_mouse_move(&mut self, local_x: f32, local_y: f32, w: f32, h: f32) {
@@ -319,18 +306,32 @@ impl BarChartModel {
             }
         }
 
-        // Expand y domain to fit current bins (stacked sum).
+        // Expand y domain to fit current bins (stacked sum, with diverging sign support).
         if self.style.stacked {
             let mut max_sum = 0.0f32;
+            let mut min_sum = 0.0f32;
             for bin in 0..bins_n {
-                let mut sum = 0.0f32;
+                let mut pos = 0.0f32;
+                let mut neg = 0.0f32;
                 for s_idx in 0..series_n {
-                    sum += self.bins[s_idx * bins_n + bin].max(0.0);
+                    let v = self.bins[s_idx * bins_n + bin];
+                    if v >= 0.0 {
+                        pos += v;
+                    } else {
+                        neg += v;
+                    }
                 }
-                max_sum = max_sum.max(sum);
+                max_sum = max_sum.max(pos);
+                min_sum = min_sum.min(neg);
             }
-            if max_sum.is_finite() && max_sum > self.view.domain.y.min {
-                self.view.domain.y.max = max_sum.max(self.view.domain.y.min + 1e-6);
+            if min_sum.is_finite() {
+                self.view.domain.y.min = min_sum.min(0.0);
+            }
+            if max_sum.is_finite() {
+                self.view.domain.y.max = max_sum.max(0.0);
+            }
+            if self.view.domain.y.max <= self.view.domain.y.min {
+                self.view.domain.y.max = self.view.domain.y.min + 1e-6;
             }
         }
 
@@ -363,12 +364,21 @@ impl BarChartModel {
             let x = px + bin as f32 * (pw / self.bins_n as f32);
 
             if self.style.stacked {
-                let mut acc = baseline_y;
+                let mut acc_pos = baseline_y;
+                let mut acc_neg = baseline_y;
                 for s_idx in 0..series_n {
                     let v = self.bins[s_idx * self.bins_n + bin];
-                    let y0 = acc;
-                    let y1 = acc + v;
-                    acc = y1;
+                    let (y0, y1) = if v >= 0.0 {
+                        let y0 = acc_pos;
+                        let y1 = acc_pos + v;
+                        acc_pos = y1;
+                        (y0, y1)
+                    } else {
+                        let y0 = acc_neg;
+                        let y1 = acc_neg + v;
+                        acc_neg = y1;
+                        (y0, y1)
+                    };
 
                     let y0_px = self.view.y_to_px(y0, py, ph);
                     let y1_px = self.view.y_to_px(y1, py, ph);
@@ -438,6 +448,12 @@ impl BarChartModel {
         );
         let y_ticks = build_left_ticks(self.view.domain.y, py, ph, 5, format_compact);
         draw_left_axis(ctx, &y_ticks, px, py, ph, self.style.grid, self.style.text);
+        draw_annotations(
+            ctx,
+            &self.annotations,
+            |p| self.view.data_to_px(p, px, py, pw, ph),
+            self.style.text,
+        );
 
         if let Some(x) = self.hover_x {
             let text = format!("x={}", format_time_or_number(x));
@@ -546,8 +562,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn new_rejects_negative_values() {
+    fn new_accepts_negative_values() {
         let series = TimeSeriesF32::new(vec![0.0, 1.0], vec![1.0, -0.5]).unwrap();
-        assert!(BarChartModel::new(vec![series]).is_err());
+        let model = BarChartModel::new(vec![series]).unwrap();
+        assert!(model.view.domain.y.min <= -0.5);
+        assert!(model.view.domain.y.max >= 1.0);
+    }
+
+    #[test]
+    fn stacked_domain_tracks_positive_and_negative_sums() {
+        let s_pos = TimeSeriesF32::new(vec![0.0, 1.0], vec![2.0, 1.5]).unwrap();
+        let s_neg = TimeSeriesF32::new(vec![0.0, 1.0], vec![-3.0, -4.0]).unwrap();
+        let mut model = BarChartModel::new(vec![s_pos, s_neg]).unwrap();
+        model.style.stacked = true;
+        model.ensure_bins(320.0, 180.0);
+        assert!(model.view.domain.y.max >= 1.99);
+        assert!(model.view.domain.y.min <= -3.99);
     }
 }

--- a/crates/blinc_charts/src/hierarchy.rs
+++ b/crates/blinc_charts/src/hierarchy.rs
@@ -6,6 +6,7 @@ use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
 use crate::common::{draw_grid, fill_bg};
+use crate::palette;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum HierarchyMode {
@@ -143,20 +144,12 @@ impl HierarchyChartModel {
 
     fn leaf_color(&self, depth: usize, i: usize) -> Color {
         // Deterministic palette with depth tint.
-        let hues = [
-            (0.35, 0.65, 1.0),
-            (0.95, 0.55, 0.35),
-            (0.40, 0.85, 0.55),
-            (0.90, 0.75, 0.25),
-            (0.75, 0.55, 0.95),
-            (0.25, 0.80, 0.85),
-        ];
-        let (mut r, mut g, mut b) = hues[i % hues.len()];
+        let mut c = palette::qualitative(i, 0.75);
         let tint = 1.0 - (depth as f32 * 0.08).clamp(0.0, 0.35);
-        r *= tint;
-        g *= tint;
-        b *= tint;
-        Color::rgba(r, g, b, 0.75)
+        c.r *= tint;
+        c.g *= tint;
+        c.b *= tint;
+        c
     }
 
     fn ensure_layout(&mut self, w: f32, h: f32) {
@@ -178,7 +171,7 @@ impl HierarchyChartModel {
 
         match self.style.mode {
             HierarchyMode::Treemap => {
-                self.layout_treemap(&root, Rect::new(px, py, pw, ph), 0, true);
+                self.layout_treemap(&root, Rect::new(px, py, pw, ph), 0);
             }
             HierarchyMode::Icicle => {
                 let max_depth = Self::max_depth(&root);
@@ -214,7 +207,7 @@ impl HierarchyChartModel {
         }
     }
 
-    fn layout_treemap(&mut self, n: &HierarchyNode, rect: Rect, depth: usize, split_x: bool) {
+    fn layout_treemap(&mut self, n: &HierarchyNode, rect: Rect, depth: usize) {
         if n.children.is_empty() {
             self.leaves_px.push(LeafRect {
                 rect,
@@ -224,31 +217,109 @@ impl HierarchyChartModel {
             });
             return;
         }
-        let total: f32 = n.children.iter().map(|c| c.weight().max(0.0)).sum();
-        if total.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+        let total_weight: f32 = n.children.iter().map(|c| c.weight().max(0.0)).sum();
+        if total_weight.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater)
+            || rect.width() <= 0.0
+            || rect.height() <= 0.0
+        {
             return;
         }
 
-        let mut cur = 0.0f32;
-        for c in &n.children {
-            let w = c.weight().max(0.0);
-            if w <= 0.0 {
-                continue;
-            }
-            let t0 = cur / total;
-            cur += w;
-            let t1 = cur / total;
+        #[derive(Clone, Copy)]
+        struct Item {
+            idx: usize,
+            area: f32,
+        }
 
-            let child_rect = if split_x {
-                let x0 = rect.x() + rect.width() * t0;
-                let x1 = rect.x() + rect.width() * t1;
-                Rect::new(x0, rect.y(), (x1 - x0).max(0.0), rect.height())
-            } else {
-                let y0 = rect.y() + rect.height() * t0;
-                let y1 = rect.y() + rect.height() * t1;
-                Rect::new(rect.x(), y0, rect.width(), (y1 - y0).max(0.0))
+        let rect_area = rect.width() * rect.height();
+        let mut items: Vec<Item> = n
+            .children
+            .iter()
+            .enumerate()
+            .filter_map(|(i, c)| {
+                let w = c.weight().max(0.0);
+                if w > 0.0 {
+                    Some(Item {
+                        idx: i,
+                        area: rect_area * (w / total_weight),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if items.is_empty() {
+            return;
+        }
+        items.sort_by(|a, b| b.area.total_cmp(&a.area));
+
+        let mut free = rect;
+        let mut cursor = 0usize;
+        while cursor < items.len() && free.width() > 0.0 && free.height() > 0.0 {
+            let short_side = free.width().min(free.height()).max(1e-6);
+            let mut row = vec![items[cursor]];
+            cursor += 1;
+
+            let row_worst = |row_items: &[Item]| -> f32 {
+                let row_sum: f32 = row_items.iter().map(|it| it.area).sum();
+                if row_sum <= 0.0 {
+                    return f32::INFINITY;
+                }
+                let min_area = row_items
+                    .iter()
+                    .map(|it| it.area)
+                    .fold(f32::INFINITY, f32::min);
+                let max_area = row_items
+                    .iter()
+                    .map(|it| it.area)
+                    .fold(f32::NEG_INFINITY, f32::max);
+                let s2 = short_side * short_side;
+                ((s2 * max_area) / (row_sum * row_sum)).max((row_sum * row_sum) / (s2 * min_area))
             };
-            self.layout_treemap(c, child_rect, depth + 1, !split_x);
+
+            while cursor < items.len() {
+                let mut candidate = row.clone();
+                candidate.push(items[cursor]);
+                if row_worst(&candidate) <= row_worst(&row) {
+                    row.push(items[cursor]);
+                    cursor += 1;
+                } else {
+                    break;
+                }
+            }
+
+            let row_sum: f32 = row.iter().map(|it| it.area).sum();
+            if free.width() >= free.height() {
+                let row_h = (row_sum / free.width().max(1e-6)).clamp(0.0, free.height());
+                let mut x = free.x();
+                for it in &row {
+                    let w = (it.area / row_h.max(1e-6)).clamp(0.0, free.x() + free.width() - x);
+                    let child_rect = Rect::new(x, free.y(), w, row_h);
+                    self.layout_treemap(&n.children[it.idx], child_rect, depth + 1);
+                    x += w;
+                }
+                free = Rect::new(
+                    free.x(),
+                    free.y() + row_h,
+                    free.width(),
+                    (free.height() - row_h).max(0.0),
+                );
+            } else {
+                let row_w = (row_sum / free.height().max(1e-6)).clamp(0.0, free.width());
+                let mut y = free.y();
+                for it in &row {
+                    let h = (it.area / row_w.max(1e-6)).clamp(0.0, free.y() + free.height() - y);
+                    let child_rect = Rect::new(free.x(), y, row_w, h);
+                    self.layout_treemap(&n.children[it.idx], child_rect, depth + 1);
+                    y += h;
+                }
+                free = Rect::new(
+                    free.x() + row_w,
+                    free.y(),
+                    (free.width() - row_w).max(0.0),
+                    free.height(),
+                );
+            }
         }
     }
 
@@ -328,7 +399,7 @@ impl HierarchyChartModel {
     }
 
     fn layout_packing(&mut self, n: &HierarchyNode, cx: f32, cy: f32, r: f32) {
-        // Naive packing: place leaf circles along a spiral, with radius ~ sqrt(weight).
+        // Deterministic relaxation-based packing from weighted initial seed positions.
         let mut leaves = Vec::new();
         Self::collect_leaves(n, 0, &mut leaves);
         if leaves.is_empty() {
@@ -342,42 +413,57 @@ impl HierarchyChartModel {
         }
 
         let mut placed: Vec<(f32, f32, f32, String, f32, usize)> = Vec::new(); // (x,y,rad,label,val,depth)
+        let leaf_count = leaves.len();
+        let golden = std::f32::consts::PI * (3.0 - 5.0_f32.sqrt());
         for (i, (label, depth, w)) in leaves.into_iter().enumerate() {
             let rr = ((w / total).max(0.0)).sqrt() * r * 0.75;
             let max_rr = (r * 0.35).max(4.0);
             let rr = rr.clamp(4.0, max_rr);
-            if i == 0 {
-                placed.push((0.0, 0.0, rr, label, w, depth));
-                continue;
-            }
-
-            let mut ang = 0.0f32;
-            let mut rad = 0.0f32;
-            let mut best = None;
-            for _ in 0..2_000 {
-                ang += 0.35;
-                rad += 0.18;
-                let x = rad * ang.cos();
-                let y = rad * ang.sin();
-                if x * x + y * y > (r - rr).powi(2) {
-                    continue;
-                }
-                let mut ok = true;
-                for (px, py, pr, ..) in &placed {
-                    let dx = x - *px;
-                    let dy = y - *py;
-                    if dx * dx + dy * dy < (*pr + rr).powi(2) * 1.02 {
-                        ok = false;
-                        break;
-                    }
-                }
-                if ok {
-                    best = Some((x, y));
-                    break;
-                }
-            }
-            let (x, y) = best.unwrap_or((0.0, 0.0));
+            let t = if leaf_count <= 1 {
+                0.0
+            } else {
+                i as f32 / (leaf_count - 1) as f32
+            };
+            let ang = i as f32 * golden;
+            let rad = t.sqrt() * (r - rr).max(0.0);
+            let x = rad * ang.cos();
+            let y = rad * ang.sin();
             placed.push((x, y, rr, label, w, depth));
+        }
+
+        let iter_n = 72usize;
+        for _ in 0..iter_n {
+            for i in 0..placed.len() {
+                for j in (i + 1)..placed.len() {
+                    let (ax, ay, ar, ..) = placed[i];
+                    let (bx, by, br, ..) = placed[j];
+                    let dx = bx - ax;
+                    let dy = by - ay;
+                    let dist2 = dx * dx + dy * dy;
+                    let min_d = ar + br + 0.35;
+                    if dist2 >= min_d * min_d {
+                        continue;
+                    }
+                    let dist = dist2.sqrt().max(1e-6);
+                    let push = (min_d - dist) * 0.5;
+                    let nx = dx / dist;
+                    let ny = dy / dist;
+                    placed[i].0 -= nx * push;
+                    placed[i].1 -= ny * push;
+                    placed[j].0 += nx * push;
+                    placed[j].1 += ny * push;
+                }
+            }
+            for p in &mut placed {
+                let rr = p.2;
+                let limit = (r - rr).max(0.0);
+                let d2 = p.0 * p.0 + p.1 * p.1;
+                if d2 > limit * limit && d2 > 1e-6 {
+                    let d = d2.sqrt();
+                    p.0 = p.0 / d * limit;
+                    p.1 = p.1 / d * limit;
+                }
+            }
         }
 
         for (x, y, rr, label, v, depth) in placed {
@@ -415,8 +501,6 @@ impl HierarchyChartModel {
 
         match self.style.mode {
             HierarchyMode::Sunburst => {
-                // Hover detection for sunburst is approximate: find the first sector
-                // whose annulus wedge contains the point.
                 let cx = px + pw * 0.5;
                 let cy = py + ph * 0.5;
                 let dx = local_x - cx;
@@ -426,17 +510,19 @@ impl HierarchyChartModel {
                 if a < 0.0 {
                     a += std::f32::consts::TAU;
                 }
-                self.hover_leaf = None;
+                let mut best: Option<LeafRect> = None;
                 for leaf in &self.leaves_px {
                     let a0 = leaf.rect.x();
                     let a1 = leaf.rect.y();
                     let r0 = leaf.rect.width();
                     let r1 = leaf.rect.height();
                     if rr >= r0 && rr <= r1 && a >= a0 && a <= a1 {
-                        self.hover_leaf = Some(leaf.clone());
-                        break;
+                        if best.as_ref().map(|b| leaf.depth >= b.depth).unwrap_or(true) {
+                            best = Some(leaf.clone());
+                        }
                     }
                 }
+                self.hover_leaf = best;
             }
             HierarchyMode::Packing => {
                 self.hover_leaf = None;
@@ -673,5 +759,59 @@ mod tests {
         }));
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn treemap_layout_produces_valid_rects() {
+        let root = HierarchyNode::node(
+            "root",
+            vec![
+                HierarchyNode::leaf("a", 6.0),
+                HierarchyNode::leaf("b", 3.0),
+                HierarchyNode::leaf("c", 2.0),
+                HierarchyNode::leaf("d", 1.0),
+            ],
+        );
+        let mut model = HierarchyChartModel::new(root).unwrap();
+        model.style.mode = HierarchyMode::Treemap;
+        model.ensure_layout(320.0, 220.0);
+        assert!(!model.leaves_px.is_empty());
+        assert!(model.leaves_px.iter().all(|l| l.rect.width() >= 0.0));
+        assert!(model.leaves_px.iter().all(|l| l.rect.height() >= 0.0));
+    }
+
+    #[test]
+    fn sunburst_hover_picks_deepest_matching_leaf() {
+        let root = HierarchyNode::node(
+            "root",
+            vec![HierarchyNode::node(
+                "p",
+                vec![
+                    HierarchyNode::leaf("child", 2.0),
+                    HierarchyNode::leaf("sibling", 1.0),
+                ],
+            )],
+        );
+        let mut model = HierarchyChartModel::new(root).unwrap();
+        model.style.mode = HierarchyMode::Sunburst;
+        model.ensure_layout(360.0, 240.0);
+        let target = model
+            .leaves_px
+            .iter()
+            .find(|l| l.label == "child")
+            .cloned()
+            .expect("leaf exists");
+
+        let (px, py, pw, ph) = model.plot_rect(360.0, 240.0);
+        let cx = px + pw * 0.5;
+        let cy = py + ph * 0.5;
+        let a = (target.rect.x() + target.rect.y()) * 0.5;
+        let rr = (target.rect.width() + target.rect.height()) * 0.5;
+        model.on_mouse_move(cx + rr * a.cos(), cy + rr * a.sin(), 360.0, 240.0);
+
+        assert_eq!(
+            model.hover_leaf.as_ref().map(|h| h.label.as_str()),
+            Some("child")
+        );
     }
 }

--- a/crates/blinc_charts/src/lib.rs
+++ b/crates/blinc_charts/src/lib.rs
@@ -7,6 +7,7 @@
 //! - Use Blinc's built-in event routing (mouse/touch/scroll/pinch/drag)
 //! - Prioritize performance for large datasets via sampling/LOD and GPU pipelines
 
+pub mod annotation;
 pub mod axis;
 mod brush;
 mod common;
@@ -15,6 +16,7 @@ pub mod input;
 pub mod interpolate;
 mod link;
 mod lod;
+pub mod palette;
 pub mod polygon;
 pub mod scale;
 mod segments;
@@ -44,6 +46,7 @@ pub mod scatter;
 pub mod stacked_area;
 pub mod statistics;
 
+pub use annotation::ChartAnnotation;
 pub use brush::BrushX;
 pub use candlestick::{Candle, CandleSeries};
 pub use input::{ChartInputBindings, DragAction, DragBinding, ModifiersReq};
@@ -55,6 +58,7 @@ pub use view::{ChartView, Domain1D, Domain2D};
 
 /// Common imports for chart users.
 pub mod prelude {
+    pub use crate::annotation::ChartAnnotation;
     pub use crate::area::{
         area_chart, area_chart_with_bindings, linked_area_chart, linked_area_chart_with_bindings,
         AreaChartHandle, AreaChartModel, AreaChartStyle,
@@ -117,9 +121,10 @@ pub mod prelude {
     };
     pub use crate::statistics::{
         statistics_chart, statistics_chart_with_bindings, StatisticsChartHandle,
-        StatisticsChartModel, StatisticsChartStyle,
+        StatisticsChartModel, StatisticsChartStyle, StatisticsMode,
     };
     pub use crate::time_series::TimeSeriesF32;
     pub use crate::view::{ChartView, Domain1D, Domain2D};
+    pub use crate::{palette, scale::BandScale, scale::LinearScale, scale::LogScale};
     pub use crate::{ChartInputBindings, DragAction, DragBinding, ModifiersReq};
 }

--- a/crates/blinc_charts/src/network.rs
+++ b/crates/blinc_charts/src/network.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use blinc_core::{Brush, Color, DrawContext, Path, Point, Rect, Stroke, TextStyle};
@@ -6,6 +7,7 @@ use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
 use crate::common::{draw_grid, fill_bg};
+use crate::palette;
 use crate::spatial_index::SpatialIndex;
 use crate::view::{ChartView, Domain1D, Domain2D};
 
@@ -52,6 +54,12 @@ impl Default for NetworkChartStyle {
 #[derive(Clone, Debug)]
 struct GraphLayout {
     node_pos: Vec<Point>, // data coords
+}
+
+#[derive(Clone, Debug, Default)]
+struct SankeyLayout {
+    node_rects: Vec<Rect>,
+    link_paths: Vec<(Path, f32, f32)>, // (path, thickness, alpha)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -290,28 +298,28 @@ impl NetworkChartModel {
                 }
             }
             NetworkMode::Sankey => {
-                // Match the render_sankey node layout exactly.
-                let n = self.labels.len().min(self.style.max_nodes);
-                if n == 0 {
+                let layout = self.build_sankey_layout(px, py, pw, ph);
+                if layout.node_rects.is_empty() {
                     self.hover_node = None;
                     return;
                 }
-                let cols = 3usize;
-                let col_w = pw / cols as f32;
-                let row_h = (ph / ((n as f32 / cols as f32).ceil().max(1.0))).max(24.0);
+
+                let cursor = Point::new(local_x, local_y);
+                if let Some((i, _)) = layout
+                    .node_rects
+                    .iter()
+                    .enumerate()
+                    .find(|(_, r)| r.contains(cursor))
+                {
+                    self.hover_node = Some(i);
+                    return;
+                }
 
                 let mut best = None::<(usize, f32)>;
-                for i in 0..n {
-                    let col = i % cols;
-                    let row = i / cols;
-                    let x = px + col as f32 * col_w + col_w * 0.15;
-                    let y = py + row as f32 * row_h + row_h * 0.15;
-                    let rw = col_w * 0.70;
-                    let rh = row_h * 0.70;
-                    let cx = x + rw * 0.5;
-                    let cy = y + rh * 0.5;
-                    let dx = cx - local_x;
-                    let dy = cy - local_y;
+                for (i, r) in layout.node_rects.iter().enumerate() {
+                    let c = r.center();
+                    let dx = c.x - local_x;
+                    let dy = c.y - local_y;
                     let d2 = dx * dx + dy * dy;
                     if best.map(|b| d2 < b.1).unwrap_or(true) {
                         best = Some((i, d2));
@@ -474,52 +482,26 @@ impl NetworkChartModel {
     }
 
     fn render_sankey(&self, ctx: &mut dyn DrawContext, px: f32, py: f32, pw: f32, ph: f32) {
-        // Deterministic, simple sankey: place nodes by index in 3 columns.
-        let n = self.labels.len().min(self.style.max_nodes);
-        if n == 0 {
+        let layout = self.build_sankey_layout(px, py, pw, ph);
+        if layout.node_rects.is_empty() {
             return;
-        }
-        let cols = 3usize;
-        let col_w = pw / cols as f32;
-        let row_h = (ph / ((n as f32 / cols as f32).ceil().max(1.0))).max(24.0);
-
-        let mut node_rects = Vec::with_capacity(n);
-        for i in 0..n {
-            let col = i % cols;
-            let row = i / cols;
-            let x = px + col as f32 * col_w + col_w * 0.15;
-            let y = py + row as f32 * row_h + row_h * 0.15;
-            let rw = col_w * 0.70;
-            let rh = row_h * 0.70;
-            node_rects.push(Rect::new(x, y, rw.max(6.0), rh.max(6.0)));
         }
 
         let stroke = Stroke::new(1.0);
-        for &(a, b, wv) in self.links.iter().take(self.style.max_links) {
-            if a >= n || b >= n {
-                continue;
-            }
-            let ra = node_rects[a];
-            let rb = node_rects[b];
-            let p0 = Point::new(ra.x() + ra.width(), ra.y() + ra.height() * 0.5);
-            let p1 = Point::new(rb.x(), rb.y() + rb.height() * 0.5);
-            let mx = (p0.x + p1.x) * 0.5;
-            let path = Path::new()
-                .move_to(p0.x, p0.y)
-                .cubic_to(mx, p0.y, mx, p1.y, p1.x, p1.y);
-            let alpha = (wv / 10.0).clamp(0.10, 0.55);
+        for (path, thickness, alpha) in layout.link_paths {
             ctx.stroke_path(
                 &path,
-                &Stroke::new(2.0),
+                &Stroke::new(thickness),
                 Brush::Solid(Color::rgba(0.85, 0.92, 1.0, alpha)),
             );
         }
 
-        for (i, r) in node_rects.iter().enumerate() {
+        for (i, r) in layout.node_rects.iter().enumerate() {
+            let c = self.leaf_color(i);
             ctx.fill_rect(
                 *r,
                 8.0.into(),
-                Brush::Solid(Color::rgba(0.35, 0.65, 1.0, 0.35)),
+                Brush::Solid(Color::rgba(c.r, c.g, c.b, 0.35)),
             );
             ctx.stroke_rect(
                 *r,
@@ -535,6 +517,247 @@ impl NetworkChartModel {
                     &style,
                 );
             }
+        }
+    }
+
+    fn build_sankey_layout(&self, px: f32, py: f32, pw: f32, ph: f32) -> SankeyLayout {
+        let n = self.labels.len().min(self.style.max_nodes);
+        if n == 0 || pw <= 0.0 || ph <= 0.0 {
+            return SankeyLayout::default();
+        }
+
+        let mut links = Vec::new();
+        let mut in_flow = vec![0.0f32; n];
+        let mut out_flow = vec![0.0f32; n];
+        for &(a, b, w) in self.links.iter().take(self.style.max_links) {
+            if a >= n || b >= n || !w.is_finite() || w <= 0.0 {
+                continue;
+            }
+            links.push((a, b, w));
+            out_flow[a] += w;
+            in_flow[b] += w;
+        }
+
+        let mut layer = vec![0usize; n];
+        let mut indegree = vec![0usize; n];
+        let mut adj = vec![Vec::<usize>::new(); n];
+        for &(a, b, _) in &links {
+            indegree[b] += 1;
+            adj[a].push(b);
+        }
+
+        let mut q = VecDeque::new();
+        for (i, &deg) in indegree.iter().enumerate() {
+            if deg == 0 {
+                q.push_back(i);
+            }
+        }
+        let mut visited = 0usize;
+        while let Some(u) = q.pop_front() {
+            visited += 1;
+            for &v in &adj[u] {
+                layer[v] = layer[v].max(layer[u] + 1);
+                indegree[v] -= 1;
+                if indegree[v] == 0 {
+                    q.push_back(v);
+                }
+            }
+        }
+        if visited < n {
+            let fallback_layers = 3usize.min(n.max(1));
+            for i in 0..n {
+                if indegree[i] > 0 {
+                    layer[i] = i % fallback_layers;
+                }
+            }
+        }
+
+        let mut max_layer = *layer.iter().max().unwrap_or(&0);
+        if max_layer == 0 && n > 1 {
+            for i in 0..n {
+                if in_flow[i] == 0.0 && out_flow[i] > 0.0 {
+                    layer[i] = 0;
+                } else if in_flow[i] > 0.0 && out_flow[i] == 0.0 {
+                    layer[i] = 2;
+                } else {
+                    layer[i] = 1;
+                }
+            }
+            max_layer = *layer.iter().max().unwrap_or(&0);
+        }
+        for i in 0..n {
+            if in_flow[i] > 0.0 && out_flow[i] == 0.0 {
+                layer[i] = max_layer.max(1);
+            }
+        }
+        max_layer = *layer.iter().max().unwrap_or(&0);
+
+        let mut layer_nodes = vec![Vec::<usize>::new(); max_layer + 1];
+        for i in 0..n {
+            layer_nodes[layer[i]].push(i);
+        }
+        // Initialize with stable order by flow, then refine with barycentric sweeps.
+        for nodes in &mut layer_nodes {
+            nodes.sort_by(|a, b| {
+                let fa = in_flow[*a] + out_flow[*a];
+                let fb = in_flow[*b] + out_flow[*b];
+                fb.partial_cmp(&fa)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.cmp(b))
+            });
+        }
+        let mut layer_pos = vec![0usize; n];
+        for nodes in &layer_nodes {
+            for (i, &node) in nodes.iter().enumerate() {
+                layer_pos[node] = i;
+            }
+        }
+
+        for _ in 0..4 {
+            // Left -> right sweep using incoming neighbors.
+            for li in 1..=max_layer {
+                let mut scored = Vec::with_capacity(layer_nodes[li].len());
+                for &node in &layer_nodes[li] {
+                    let mut sum = 0.0f32;
+                    let mut cnt = 0usize;
+                    for &(a, b, _w) in &links {
+                        if b == node && layer[a] + 1 == li {
+                            sum += layer_pos[a] as f32;
+                            cnt += 1;
+                        }
+                    }
+                    let bary = if cnt > 0 {
+                        sum / cnt as f32
+                    } else {
+                        layer_pos[node] as f32
+                    };
+                    scored.push((node, bary, layer_pos[node]));
+                }
+                scored.sort_by(|a, b| {
+                    a.1.partial_cmp(&b.1)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then_with(|| a.2.cmp(&b.2))
+                });
+                layer_nodes[li] = scored.into_iter().map(|s| s.0).collect();
+                for (i, &node) in layer_nodes[li].iter().enumerate() {
+                    layer_pos[node] = i;
+                }
+            }
+
+            // Right -> left sweep using outgoing neighbors.
+            if max_layer > 0 {
+                for li in (0..max_layer).rev() {
+                    let mut scored = Vec::with_capacity(layer_nodes[li].len());
+                    for &node in &layer_nodes[li] {
+                        let mut sum = 0.0f32;
+                        let mut cnt = 0usize;
+                        for &(a, b, _w) in &links {
+                            if a == node && layer[b] == li + 1 {
+                                sum += layer_pos[b] as f32;
+                                cnt += 1;
+                            }
+                        }
+                        let bary = if cnt > 0 {
+                            sum / cnt as f32
+                        } else {
+                            layer_pos[node] as f32
+                        };
+                        scored.push((node, bary, layer_pos[node]));
+                    }
+                    scored.sort_by(|a, b| {
+                        a.1.partial_cmp(&b.1)
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                            .then_with(|| a.2.cmp(&b.2))
+                    });
+                    layer_nodes[li] = scored.into_iter().map(|s| s.0).collect();
+                    for (i, &node) in layer_nodes[li].iter().enumerate() {
+                        layer_pos[node] = i;
+                    }
+                }
+            }
+        }
+
+        let layer_count = max_layer + 1;
+        let node_w = (pw / (layer_count as f32 * 8.0)).clamp(10.0, 24.0);
+        let x_step = if layer_count > 1 {
+            (pw - node_w).max(0.0) / (layer_count - 1) as f32
+        } else {
+            0.0
+        };
+
+        let mut node_rects = vec![Rect::ZERO; n];
+        for (li, nodes) in layer_nodes.iter().enumerate() {
+            let m = nodes.len();
+            if m == 0 {
+                continue;
+            }
+            let gap = (ph * 0.03).clamp(6.0, 18.0);
+            let total_gap = gap * (m as f32 + 1.0);
+            let usable_h = (ph - total_gap).max(8.0 * m as f32);
+            let min_h = 8.0f32;
+            let base_h = min_h * m as f32;
+            let extra_h = (usable_h - base_h).max(0.0);
+
+            let layer_flow: f32 = nodes
+                .iter()
+                .map(|&idx| in_flow[idx].max(out_flow[idx]).max(1.0))
+                .sum();
+
+            let x = px + li as f32 * x_step;
+            let mut y = py + gap;
+            for &idx in nodes {
+                let f = in_flow[idx].max(out_flow[idx]).max(1.0);
+                let extra = if layer_flow > 0.0 {
+                    extra_h * (f / layer_flow)
+                } else {
+                    extra_h / m as f32
+                };
+                let h = min_h + extra;
+                node_rects[idx] = Rect::new(x, y, node_w, h.max(min_h));
+                y += h + gap;
+            }
+        }
+
+        links.sort_by_key(|(a, b, _)| (layer[*a], *a, *b));
+        let mut src_offsets = vec![0.0f32; n];
+        let mut dst_offsets = vec![0.0f32; n];
+        let mut link_paths = Vec::with_capacity(links.len());
+
+        for &(a, b, w) in &links {
+            let ra = node_rects[a];
+            let rb = node_rects[b];
+            if ra.width() <= 0.0 || ra.height() <= 0.0 || rb.width() <= 0.0 || rb.height() <= 0.0 {
+                continue;
+            }
+
+            let src_scale = ra.height() / out_flow[a].max(1e-6);
+            let dst_scale = rb.height() / in_flow[b].max(1e-6);
+            let mut thickness = (w * src_scale.min(dst_scale)).clamp(1.0, 24.0);
+            let rem_src = (ra.height() - src_offsets[a]).max(1.0);
+            let rem_dst = (rb.height() - dst_offsets[b]).max(1.0);
+            thickness = thickness.min(rem_src).min(rem_dst).max(1.0);
+
+            let y0 = ra.y() + src_offsets[a] + thickness * 0.5;
+            let y1 = rb.y() + dst_offsets[b] + thickness * 0.5;
+            src_offsets[a] += thickness;
+            dst_offsets[b] += thickness;
+
+            let x0 = ra.x() + ra.width();
+            let x1 = rb.x();
+            let dx = (x1 - x0).abs() * 0.5;
+            let c0x = if x1 >= x0 { x0 + dx } else { x0 - dx };
+            let c1x = if x1 >= x0 { x1 - dx } else { x1 + dx };
+            let path = Path::new()
+                .move_to(x0, y0)
+                .cubic_to(c0x, y0, c1x, y1, x1, y1);
+
+            let alpha = (0.10 + thickness / 26.0).clamp(0.10, 0.62);
+            link_paths.push((path, thickness, alpha));
+        }
+
+        SankeyLayout {
+            node_rects,
+            link_paths,
         }
     }
 
@@ -584,16 +807,7 @@ impl NetworkChartModel {
     }
 
     fn leaf_color(&self, i: usize) -> Color {
-        let hues = [
-            (0.35, 0.65, 1.0),
-            (0.95, 0.55, 0.35),
-            (0.40, 0.85, 0.55),
-            (0.90, 0.75, 0.25),
-            (0.75, 0.55, 0.95),
-            (0.25, 0.80, 0.85),
-        ];
-        let (r, g, b) = hues[i % hues.len()];
-        Color::rgba(r, g, b, 0.85)
+        palette::qualitative(i, 0.85)
     }
 }
 
@@ -717,15 +931,28 @@ mod tests {
         .unwrap();
 
         let (px, py, pw, ph) = model.plot_rect(300.0, 200.0);
-        let cols = 3usize;
-        let col_w = pw / cols as f32;
-        let row_h = (ph / ((3.0f32 / cols as f32).ceil().max(1.0))).max(24.0);
-
-        let x = px + col_w * 0.15 + col_w * 0.70 * 0.5;
-        let y = py + row_h * 0.15 + row_h * 0.70 * 0.5;
+        let layout = model.build_sankey_layout(px, py, pw, ph);
+        let c = layout.node_rects[0].center();
+        let x = c.x;
+        let y = c.y;
         model.on_mouse_move(x, y, 300.0, 200.0);
 
         assert_eq!(model.hover_node, Some(0));
+    }
+
+    #[test]
+    fn sankey_layout_orders_sources_before_sinks() {
+        let model = NetworkChartModel::new_sankey(
+            vec!["src".into(), "mid".into(), "sink".into()],
+            vec![(0, 1, 3.0), (1, 2, 2.0)],
+        )
+        .unwrap();
+
+        let (px, py, pw, ph) = model.plot_rect(320.0, 220.0);
+        let layout = model.build_sankey_layout(px, py, pw, ph);
+        assert!(layout.node_rects[0].x() < layout.node_rects[1].x());
+        assert!(layout.node_rects[1].x() < layout.node_rects[2].x());
+        assert!(!layout.link_paths.is_empty());
     }
 
     #[test]

--- a/crates/blinc_charts/src/palette.rs
+++ b/crates/blinc_charts/src/palette.rs
@@ -1,0 +1,43 @@
+use blinc_core::Color;
+
+pub fn qualitative(index: usize, alpha: f32) -> Color {
+    const HUES: &[(f32, f32, f32)] = &[
+        (0.35, 0.65, 1.0),
+        (0.95, 0.55, 0.35),
+        (0.40, 0.85, 0.55),
+        (0.90, 0.75, 0.25),
+        (0.75, 0.55, 0.95),
+        (0.25, 0.80, 0.85),
+        (0.95, 0.40, 0.60),
+        (0.55, 0.82, 0.28),
+    ];
+    let (r, g, b) = HUES[index % HUES.len()];
+    Color::rgba(r, g, b, alpha.clamp(0.0, 1.0))
+}
+
+pub fn sequential_blue(t: f32, alpha: f32) -> Color {
+    let t = t.clamp(0.0, 1.0);
+    let r = 0.12 + 0.60 * t;
+    let g = 0.22 + 0.58 * t;
+    let b = 0.35 + 0.60 * t;
+    Color::rgba(r, g, b, alpha.clamp(0.0, 1.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qualitative_is_deterministic() {
+        let a = qualitative(3, 0.8);
+        let b = qualitative(3, 0.8);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn sequential_blue_clamps_input() {
+        let c0 = sequential_blue(-1.0, 2.0);
+        let c1 = sequential_blue(0.0, 1.0);
+        assert_eq!(c0, c1);
+    }
+}

--- a/crates/blinc_charts/src/polar.rs
+++ b/crates/blinc_charts/src/polar.rs
@@ -6,6 +6,7 @@ use blinc_layout::stack::stack;
 use blinc_layout::ElementBuilder;
 
 use crate::common::{draw_grid, fill_bg};
+use crate::palette;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum PolarChartMode {
@@ -96,16 +97,7 @@ impl PolarChartModel {
     }
 
     fn series_color(&self, i: usize) -> Color {
-        let hues = [
-            (0.35, 0.65, 1.0),
-            (0.95, 0.55, 0.35),
-            (0.40, 0.85, 0.55),
-            (0.90, 0.75, 0.25),
-            (0.75, 0.55, 0.95),
-            (0.25, 0.80, 0.85),
-        ];
-        let (r, g, b) = hues[i % hues.len()];
-        Color::rgba(r, g, b, 0.85)
+        palette::qualitative(i, 0.85)
     }
 
     pub fn on_mouse_move(&mut self, local_x: f32, local_y: f32, w: f32, h: f32) {

--- a/crates/blinc_charts/src/scale.rs
+++ b/crates/blinc_charts/src/scale.rs
@@ -47,6 +47,92 @@ impl LinearScale {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+pub struct LogScale {
+    domain_min: f32,
+    domain_max: f32,
+    range_min: f32,
+    range_max: f32,
+    base: f32,
+}
+
+impl LogScale {
+    pub fn new(domain_min: f32, domain_max: f32, range_min: f32, range_max: f32) -> Option<Self> {
+        Self::with_base(domain_min, domain_max, range_min, range_max, 10.0)
+    }
+
+    pub fn with_base(
+        domain_min: f32,
+        domain_max: f32,
+        range_min: f32,
+        range_max: f32,
+        base: f32,
+    ) -> Option<Self> {
+        if !(domain_min.is_finite()
+            && domain_max.is_finite()
+            && domain_min > 0.0
+            && domain_max > domain_min
+            && base.is_finite()
+            && base > 1.0)
+        {
+            return None;
+        }
+        Some(Self {
+            domain_min,
+            domain_max,
+            range_min,
+            range_max,
+            base,
+        })
+    }
+
+    fn log(&self, x: f32) -> f32 {
+        x.log(self.base)
+    }
+
+    pub fn map(&self, value: f32) -> f32 {
+        let v = value.max(self.domain_min);
+        let a = self.log(self.domain_min);
+        let b = self.log(self.domain_max);
+        let d = (b - a).max(1e-12);
+        let t = (self.log(v) - a) / d;
+        self.range_min + t * (self.range_max - self.range_min)
+    }
+
+    pub fn invert(&self, px: f32) -> f32 {
+        let r = self.range_max - self.range_min;
+        if r.abs() < 1e-12 {
+            return self.domain_min;
+        }
+        let t = (px - self.range_min) / r;
+        let a = self.log(self.domain_min);
+        let b = self.log(self.domain_max);
+        self.base.powf(a + t * (b - a))
+    }
+
+    pub fn ticks(&self, count: usize) -> Vec<f32> {
+        let min_exp = self.log(self.domain_min).floor() as i32;
+        let max_exp = self.log(self.domain_max).ceil() as i32;
+        let mut out = Vec::new();
+        for e in min_exp..=max_exp {
+            let v = self.base.powi(e);
+            if v >= self.domain_min && v <= self.domain_max {
+                out.push(v);
+            }
+        }
+        if out.is_empty() {
+            return LinearScale::new(
+                self.domain_min,
+                self.domain_max,
+                self.range_min,
+                self.range_max,
+            )
+            .ticks(count);
+        }
+        out
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BandScale {
     count: usize,
     start: f32,
@@ -130,5 +216,18 @@ mod tests {
         let b = BandScale::new(0, 0.0, 100.0, 0.1, 0.05);
         assert_eq!(b.band_width(), 0.0);
         assert!(b.band_start(0).is_none());
+    }
+
+    #[test]
+    fn log_scale_maps_and_inverts() {
+        let s = LogScale::new(1.0, 1000.0, 0.0, 300.0).unwrap();
+        assert!((s.map(10.0) - 100.0).abs() < 1e-4);
+        assert!((s.invert(100.0) - 10.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn log_scale_ticks_use_powers_of_ten() {
+        let s = LogScale::new(1.0, 1000.0, 0.0, 300.0).unwrap();
+        assert_eq!(s.ticks(5), vec![1.0, 10.0, 100.0, 1000.0]);
     }
 }

--- a/crates/blinc_charts/src/stacked_area.rs
+++ b/crates/blinc_charts/src/stacked_area.rs
@@ -6,21 +6,13 @@ use blinc_layout::ElementBuilder;
 use crate::brush::BrushX;
 use crate::common::{draw_grid, fill_bg};
 use crate::link::ChartLinkHandle;
+use crate::palette;
 use crate::time_series::TimeSeriesF32;
 use crate::view::{ChartView, Domain1D, Domain2D};
 use crate::xy_stack::InteractiveXChartModel;
 
 fn series_color(i: usize) -> Color {
-    let hues = [
-        (0.35, 0.65, 1.0),
-        (0.95, 0.55, 0.35),
-        (0.40, 0.85, 0.55),
-        (0.90, 0.75, 0.25),
-        (0.75, 0.55, 0.95),
-        (0.25, 0.80, 0.85),
-    ];
-    let (r, g, b) = hues[i % hues.len()];
-    Color::rgba(r, g, b, 0.85)
+    palette::qualitative(i, 0.85)
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -62,13 +54,14 @@ impl Default for StackedAreaChartStyle {
 struct CacheKey {
     x_min: u32,
     x_max: u32,
+    y_min: u32,
+    y_max: u32,
     plot_x: u32,
     plot_y: u32,
     plot_w: u32,
     plot_h: u32,
     mode: u8,
     series_n: u32,
-    total_y_max: u32,
 }
 
 impl CacheKey {
@@ -81,13 +74,14 @@ impl CacheKey {
         Self {
             x_min: model.view.domain.x.min.to_bits(),
             x_max: model.view.domain.x.max.to_bits(),
+            y_min: model.view.domain.y.min.to_bits(),
+            y_max: model.view.domain.y.max.to_bits(),
             plot_x: px.to_bits(),
             plot_y: py.to_bits(),
             plot_w: pw.to_bits(),
             plot_h: ph.to_bits(),
             mode,
             series_n: series_n as u32,
-            total_y_max: model.total_y_max.to_bits(),
         }
     }
 }
@@ -100,14 +94,12 @@ pub struct StackedAreaChartModel {
     pub crosshair_x: Option<f32>,
     pub hover_x: Option<f32>,
 
-    total_y_max: f32,
-
     last_drag_total_x: Option<f32>,
     brush_x: BrushX,
 
     // Cached geometry (local px) for plot rendering.
     cached_key: Option<CacheKey>,
-    cached_samples: Vec<usize>,
+    cached_sample_xs: Vec<f32>,
     cached_bottoms: Vec<f32>, // [s*sample_n + k]
     cached_tops: Vec<f32>,    // [s*sample_n + k]
     cached_band_paths: Vec<blinc_core::Path>,
@@ -126,50 +118,183 @@ impl StackedAreaChartModel {
             "StackedAreaChartModel requires non-empty series"
         );
 
-        let first = &series[0];
-        let n = first.len();
-        for s in &series[1..] {
-            anyhow::ensure!(s.len() == n, "all series must have the same length");
-            anyhow::ensure!(
-                s.x.iter().zip(first.x.iter()).all(|(a, b)| a == b),
-                "all series must share identical x samples (v1 constraint)"
-            );
-        }
-
-        let (x0, x1) = first.x_min_max();
-        let mut y_max = 0.0f32;
-        for i in 0..n {
-            let mut sum = 0.0f32;
-            for s in &series {
-                let v = s.y[i];
-                if v.is_finite() {
-                    sum += v.max(0.0);
-                }
+        let mut x_min = f32::INFINITY;
+        let mut x_max = f32::NEG_INFINITY;
+        for s in &series {
+            let (sx0, sx1) = s.x_min_max();
+            if sx0.is_finite() {
+                x_min = x_min.min(sx0);
             }
-            y_max = y_max.max(sum);
+            if sx1.is_finite() {
+                x_max = x_max.max(sx1);
+            }
         }
-        if !y_max.is_finite() || y_max <= 0.0 {
-            y_max = 1.0;
+        if !x_min.is_finite()
+            || !x_max.is_finite()
+            || x_max.partial_cmp(&x_min) != Some(std::cmp::Ordering::Greater)
+        {
+            x_min = 0.0;
+            x_max = 1.0;
         }
-
-        let domain = Domain2D::new(Domain1D::new(x0, x1), Domain1D::new(0.0, y_max));
+        let domain = Domain2D::new(Domain1D::new(x_min, x_max), Domain1D::new(-1.0, 1.0));
         Ok(Self {
             series,
             view: ChartView::new(domain),
             style: StackedAreaChartStyle::default(),
             crosshair_x: None,
             hover_x: None,
-            total_y_max: y_max,
             last_drag_total_x: None,
             brush_x: BrushX::default(),
             cached_key: None,
-            cached_samples: Vec::new(),
+            cached_sample_xs: Vec::new(),
             cached_bottoms: Vec::new(),
             cached_tops: Vec::new(),
             cached_band_paths: Vec::new(),
             cached_top_pts: Vec::new(),
             scratch_vals: Vec::new(),
         })
+    }
+
+    fn y_at(series: &TimeSeriesF32, x: f32) -> f32 {
+        if series.is_empty() {
+            return 0.0;
+        }
+        let x_first = series.x[0];
+        let x_last = series.x[series.len() - 1];
+        if x < x_first || x > x_last {
+            return 0.0;
+        }
+
+        let i = series.lower_bound_x(x);
+        if i < series.len() && series.x[i] == x {
+            let v = series.y[i];
+            return if v.is_finite() { v } else { 0.0 };
+        }
+        if i == 0 || i >= series.len() {
+            return 0.0;
+        }
+
+        let x0 = series.x[i - 1];
+        let x1 = series.x[i];
+        let y0 = series.y[i - 1];
+        let y1 = series.y[i];
+        if !x0.is_finite() || !x1.is_finite() || !y0.is_finite() || !y1.is_finite() || x1 <= x0 {
+            return 0.0;
+        }
+        let t = ((x - x0) / (x1 - x0)).clamp(0.0, 1.0);
+        y0 + (y1 - y0) * t
+    }
+
+    fn merged_x_samples(
+        series: &[TimeSeriesF32],
+        x_min: f32,
+        x_max: f32,
+        max_samples: Option<usize>,
+    ) -> Vec<f32> {
+        let mut xs = Vec::new();
+        for s in series {
+            if s.is_empty() {
+                continue;
+            }
+            let mut i0 = s.lower_bound_x(x_min).min(s.len());
+            if i0 > 0 {
+                i0 -= 1;
+            }
+            let mut i1 = s.upper_bound_x(x_max).min(s.len());
+            if i1 < s.len() {
+                i1 += 1;
+            }
+            if i1 <= i0 {
+                continue;
+            }
+            xs.extend(s.x[i0..i1].iter().copied().filter(|x| x.is_finite()));
+        }
+        if xs.is_empty() {
+            return xs;
+        }
+        xs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        xs.dedup_by(|a, b| *a == *b);
+
+        let Some(max_n) = max_samples else {
+            return xs;
+        };
+        if max_n < 2 || xs.len() <= max_n {
+            return xs;
+        }
+
+        let last = xs.len() - 1;
+        let step = last as f32 / (max_n - 1) as f32;
+        let mut out = Vec::with_capacity(max_n);
+        for i in 0..max_n {
+            let idx = ((i as f32 * step).round() as usize).min(last);
+            out.push(xs[idx]);
+        }
+        out.dedup_by(|a, b| *a == *b);
+        if out.len() < 2 {
+            out.push(xs[last]);
+        }
+        out
+    }
+
+    fn compute_mode_bounds(
+        series: &[TimeSeriesF32],
+        mode: StackedAreaMode,
+        x_min: f32,
+        x_max: f32,
+    ) -> (f32, f32) {
+        let xs = Self::merged_x_samples(series, x_min, x_max, Some(2_048));
+        if xs.is_empty() {
+            return (-1.0, 1.0);
+        }
+
+        let mut out_min = f32::INFINITY;
+        let mut out_max = f32::NEG_INFINITY;
+        let mut vals = vec![0.0f32; series.len()];
+        for x in xs {
+            let mut pos_sum = 0.0f32;
+            let mut neg_sum = 0.0f32;
+            for (i, s) in series.iter().enumerate() {
+                let v = Self::y_at(s, x);
+                vals[i] = v;
+                if v >= 0.0 {
+                    pos_sum += v;
+                } else {
+                    neg_sum += v;
+                }
+            }
+
+            match mode {
+                StackedAreaMode::Stacked => {
+                    out_min = out_min.min(neg_sum.min(0.0));
+                    out_max = out_max.max(pos_sum.max(0.0));
+                }
+                StackedAreaMode::Streamgraph => {
+                    let baseline = -0.5 * (pos_sum + neg_sum);
+                    let mut cur = baseline;
+                    out_min = out_min.min(cur);
+                    out_max = out_max.max(cur);
+                    for &v in &vals {
+                        cur += v;
+                        out_min = out_min.min(cur);
+                        out_max = out_max.max(cur);
+                    }
+                }
+            }
+        }
+
+        if !out_min.is_finite() || !out_max.is_finite() || out_max <= out_min {
+            return (-1.0, 1.0);
+        }
+        if out_min > 0.0 {
+            out_min = 0.0;
+        }
+        if out_max < 0.0 {
+            out_max = 0.0;
+        }
+        if out_max <= out_min {
+            out_max = out_min + 1.0;
+        }
+        (out_min, out_max)
     }
 
     fn plot_rect(&self, w: f32, h: f32) -> (f32, f32, f32, f32) {
@@ -283,12 +408,13 @@ impl StackedAreaChartModel {
         }
         draw_grid(ctx, px, py, pw, ph, self.style.grid, 4);
 
-        // Update Y domain based on the chosen stacking baseline.
-        let y_max = self.total_y_max.max(1e-6);
-        self.view.domain.y = match self.style.mode {
-            StackedAreaMode::Stacked => Domain1D::new(0.0, y_max),
-            StackedAreaMode::Streamgraph => Domain1D::new(-y_max * 0.55, y_max * 0.55),
-        };
+        let (y_min, y_max) = Self::compute_mode_bounds(
+            &self.series,
+            self.style.mode,
+            self.view.domain.x.min,
+            self.view.domain.x.max,
+        );
+        self.view.domain.y = Domain1D::new(y_min, y_max);
 
         self.ensure_cached_geometry(w, h);
         if self.cached_band_paths.is_empty() {
@@ -316,7 +442,7 @@ impl StackedAreaChartModel {
         let (px, py, pw, ph) = plot;
         if pw <= 0.0 || ph <= 0.0 {
             self.cached_key = None;
-            self.cached_samples.clear();
+            self.cached_sample_xs.clear();
             self.cached_bottoms.clear();
             self.cached_tops.clear();
             self.cached_band_paths.clear();
@@ -330,7 +456,7 @@ impl StackedAreaChartModel {
             return;
         }
 
-        self.cached_samples.clear();
+        self.cached_sample_xs.clear();
         self.cached_band_paths.clear();
 
         if self.cached_top_pts.len() < series_n {
@@ -342,37 +468,25 @@ impl StackedAreaChartModel {
             top.clear();
         }
 
-        let Some(first) = self.series.first() else {
+        let Some(_first) = self.series.first() else {
             self.cached_key = Some(key);
             return;
         };
 
-        let i0 = first.lower_bound_x(self.view.domain.x.min);
-        let i1 = first.upper_bound_x(self.view.domain.x.max);
-        let i1 = i1.max(i0 + 1).min(first.len());
-        if i1 <= i0 + 1 {
-            self.cached_key = Some(key);
-            return;
-        }
-
         // Sample at ~1-2 points per pixel for smooth fills.
         let max_samples = (pw.ceil() as usize).clamp(64, 2_000);
-        let step = ((i1 - i0) / max_samples.max(1)).max(1);
-
-        self.cached_samples.reserve(((i1 - i0) / step).max(2) + 1);
-        for i in (i0..i1).step_by(step) {
-            self.cached_samples.push(i);
-        }
-        let last = i1 - 1;
-        if self.cached_samples.last().copied() != Some(last) {
-            self.cached_samples.push(last);
-        }
-        if self.cached_samples.len() < 2 {
+        self.cached_sample_xs = Self::merged_x_samples(
+            &self.series[..series_n],
+            self.view.domain.x.min,
+            self.view.domain.x.max,
+            Some(max_samples),
+        );
+        if self.cached_sample_xs.len() < 2 {
             self.cached_key = Some(key);
             return;
         }
 
-        let sample_n = self.cached_samples.len();
+        let sample_n = self.cached_sample_xs.len();
         let needed = series_n * sample_n;
         self.cached_bottoms.resize(needed, 0.0);
         self.cached_tops.resize(needed, 0.0);
@@ -380,24 +494,45 @@ impl StackedAreaChartModel {
         self.scratch_vals.clear();
         self.scratch_vals.resize(series_n, 0.0);
 
-        for (k, &i) in self.cached_samples.iter().enumerate() {
-            let mut sum = 0.0f32;
+        for (k, &x) in self.cached_sample_xs.iter().enumerate() {
+            let mut pos_sum = 0.0f32;
+            let mut neg_sum = 0.0f32;
             for s in 0..series_n {
-                let v = self.series[s].y[i];
-                let v = if v.is_finite() { v.max(0.0) } else { 0.0 };
+                let v = Self::y_at(&self.series[s], x);
                 self.scratch_vals[s] = v;
-                sum += v;
+                if v >= 0.0 {
+                    pos_sum += v;
+                } else {
+                    neg_sum += v;
+                }
             }
 
-            let baseline = match self.style.mode {
-                StackedAreaMode::Stacked => 0.0,
-                StackedAreaMode::Streamgraph => -0.5 * sum,
-            };
-            let mut cur = baseline;
-            for s in 0..series_n {
-                self.cached_bottoms[s * sample_n + k] = cur;
-                cur += self.scratch_vals[s];
-                self.cached_tops[s * sample_n + k] = cur;
+            match self.style.mode {
+                StackedAreaMode::Stacked => {
+                    let mut cur_pos = 0.0f32;
+                    let mut cur_neg = 0.0f32;
+                    for s in 0..series_n {
+                        let v = self.scratch_vals[s];
+                        if v >= 0.0 {
+                            self.cached_bottoms[s * sample_n + k] = cur_pos;
+                            cur_pos += v;
+                            self.cached_tops[s * sample_n + k] = cur_pos;
+                        } else {
+                            self.cached_bottoms[s * sample_n + k] = cur_neg;
+                            cur_neg += v;
+                            self.cached_tops[s * sample_n + k] = cur_neg;
+                        }
+                    }
+                }
+                StackedAreaMode::Streamgraph => {
+                    let baseline = -0.5 * (pos_sum + neg_sum);
+                    let mut cur = baseline;
+                    for s in 0..series_n {
+                        self.cached_bottoms[s * sample_n + k] = cur;
+                        cur += self.scratch_vals[s];
+                        self.cached_tops[s * sample_n + k] = cur;
+                    }
+                }
             }
         }
 
@@ -407,8 +542,7 @@ impl StackedAreaChartModel {
             top_pts.reserve(sample_n);
 
             let mut path: Option<blinc_core::Path> = None;
-            for (k, &i) in self.cached_samples.iter().enumerate() {
-                let x = first.x[i];
+            for (k, &x) in self.cached_sample_xs.iter().enumerate() {
                 let y = self.cached_tops[s * sample_n + k];
                 let p = self.view.data_to_px(Point::new(x, y), px, py, pw, ph);
                 top_pts.push(p);
@@ -421,8 +555,7 @@ impl StackedAreaChartModel {
             let Some(mut path) = path else {
                 continue;
             };
-            for (k, &i) in self.cached_samples.iter().enumerate().rev() {
-                let x = first.x[i];
+            for (k, &x) in self.cached_sample_xs.iter().enumerate().rev() {
                 let y = self.cached_bottoms[s * sample_n + k];
                 let p = self.view.data_to_px(Point::new(x, y), px, py, pw, ph);
                 path = path.line_to(p.x, p.y);
@@ -562,4 +695,62 @@ pub fn linked_stacked_area_chart_with_bindings(
     bindings: crate::ChartInputBindings,
 ) -> impl ElementBuilder {
     crate::xy_stack::linked_x_chart(handle.0, link, bindings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use blinc_core::{RecordingContext, Size};
+
+    #[test]
+    fn new_accepts_misaligned_x_samples() {
+        let a = TimeSeriesF32::new(vec![0.0, 1.0, 2.0], vec![1.0, 2.0, 1.0]).unwrap();
+        let b = TimeSeriesF32::new(vec![0.5, 1.5, 2.5], vec![0.5, 1.5, 0.5]).unwrap();
+        let model = StackedAreaChartModel::new(vec![a, b]).unwrap();
+        assert_eq!(model.view.domain.x.min, 0.0);
+        assert_eq!(model.view.domain.x.max, 2.5);
+        assert!(model.view.domain.y.max > model.view.domain.y.min);
+    }
+
+    #[test]
+    fn render_plot_handles_misaligned_series_without_panic() {
+        let a = TimeSeriesF32::new(vec![0.0, 1.0, 2.0, 3.0], vec![1.0, 2.0, 1.0, 0.5]).unwrap();
+        let b = TimeSeriesF32::new(vec![0.5, 1.5, 2.5], vec![0.8, 1.4, 0.7]).unwrap();
+        let c = TimeSeriesF32::new(vec![0.25, 2.25, 3.25], vec![0.4, 0.9, 0.6]).unwrap();
+        let mut model = StackedAreaChartModel::new(vec![a, b, c]).unwrap();
+        let mut ctx = RecordingContext::new(Size::new(360.0, 220.0));
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            model.render_plot(&mut ctx, 360.0, 220.0);
+        }));
+        assert!(result.is_ok());
+        assert!(model.cached_sample_xs.len() >= 2);
+        assert!(!model.cached_band_paths.is_empty());
+    }
+
+    #[test]
+    fn stacked_mode_supports_negative_values() {
+        let a = TimeSeriesF32::new(vec![0.0, 1.0, 2.0], vec![2.0, -1.5, 1.0]).unwrap();
+        let b = TimeSeriesF32::new(vec![0.5, 1.5, 2.5], vec![-0.8, 1.2, -1.3]).unwrap();
+        let mut model = StackedAreaChartModel::new(vec![a, b]).unwrap();
+        model.style.mode = StackedAreaMode::Stacked;
+
+        let mut ctx = RecordingContext::new(Size::new(360.0, 220.0));
+        model.render_plot(&mut ctx, 360.0, 220.0);
+        assert!(model.view.domain.y.min < 0.0);
+        assert!(model.view.domain.y.max > 0.0);
+    }
+
+    #[test]
+    fn streamgraph_mode_supports_negative_values() {
+        let a = TimeSeriesF32::new(vec![0.0, 1.0, 2.0], vec![1.0, -2.0, 0.8]).unwrap();
+        let b = TimeSeriesF32::new(vec![0.0, 1.0, 2.0], vec![-0.5, 1.6, -1.2]).unwrap();
+        let mut model = StackedAreaChartModel::new(vec![a, b]).unwrap();
+        model.style.mode = StackedAreaMode::Streamgraph;
+
+        let mut ctx = RecordingContext::new(Size::new(360.0, 220.0));
+        model.render_plot(&mut ctx, 360.0, 220.0);
+        assert!(model.view.domain.y.min < 0.0);
+        assert!(model.view.domain.y.max > 0.0);
+    }
 }

--- a/crates/blinc_charts/src/statistics.rs
+++ b/crates/blinc_charts/src/statistics.rs
@@ -1,12 +1,20 @@
 use std::sync::{Arc, Mutex};
 
-use blinc_core::{Brush, Color, DrawContext, Point, Rect, Stroke, TextStyle};
+use blinc_core::{Brush, Color, DrawContext, Path, Point, Rect, Stroke, TextStyle};
 use blinc_layout::ElementBuilder;
 
 use crate::brush::BrushX;
 use crate::common::{draw_grid, fill_bg};
 use crate::view::{ChartView, Domain1D, Domain2D};
 use crate::xy_stack::InteractiveXChartModel;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum StatisticsMode {
+    #[default]
+    Boxplot,
+    Violin,
+    ErrorBand,
+}
 
 #[derive(Clone, Debug)]
 pub struct StatisticsChartStyle {
@@ -15,6 +23,7 @@ pub struct StatisticsChartStyle {
     pub text: Color,
     pub accent: Color,
     pub crosshair: Color,
+    pub mode: StatisticsMode,
 
     pub scroll_zoom_factor: f32,
     pub pinch_zoom_min: f32,
@@ -28,19 +37,23 @@ impl Default for StatisticsChartStyle {
             text: Color::rgba(1.0, 1.0, 1.0, 0.85),
             accent: Color::rgba(0.35, 0.65, 1.0, 0.85),
             crosshair: Color::rgba(1.0, 1.0, 1.0, 0.35),
+            mode: StatisticsMode::Boxplot,
             scroll_zoom_factor: 0.02,
             pinch_zoom_min: 0.01,
         }
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct GroupStats {
     q1: f32,
     med: f32,
     q3: f32,
     lo: f32,
     hi: f32,
+    mean: f32,
+    std: f32,
+    outliers: Vec<f32>,
 }
 
 pub struct StatisticsChartModel {
@@ -148,6 +161,21 @@ impl StatisticsChartModel {
                     break;
                 }
             }
+            let mean = vals.iter().copied().sum::<f32>() / vals.len() as f32;
+            let var = vals
+                .iter()
+                .map(|v| {
+                    let d = *v - mean;
+                    d * d
+                })
+                .sum::<f32>()
+                / vals.len() as f32;
+            let std = var.sqrt();
+            let outliers: Vec<f32> = vals
+                .iter()
+                .copied()
+                .filter(|v| *v < lo_fence || *v > hi_fence)
+                .collect();
 
             self.group_stats.push(Some(GroupStats {
                 q1,
@@ -155,6 +183,9 @@ impl StatisticsChartModel {
                 q3,
                 lo,
                 hi,
+                mean,
+                std,
+                outliers,
             }));
         }
     }
@@ -287,73 +318,207 @@ impl StatisticsChartModel {
             return;
         }
 
+        let mut mean_pts = Vec::<Point>::new();
+        let mut band_top = Vec::<Point>::new();
+        let mut band_bot = Vec::<Point>::new();
+
         for i in i0..i1 {
-            let Some(st) = self.group_stats.get(i).and_then(|s| *s) else {
+            let Some(st) = self.group_stats.get(i).and_then(|s| s.as_ref()) else {
                 continue;
             };
 
             let xc = self.view.x_to_px(i as f32 + 0.5, px, pw);
-            let q1 = self.view.y_to_px(st.q1, py, ph);
-            let q3 = self.view.y_to_px(st.q3, py, ph);
-            let med = self.view.y_to_px(st.med, py, ph);
-            let lo = self.view.y_to_px(st.lo, py, ph);
-            let hi = self.view.y_to_px(st.hi, py, ph);
+            match self.style.mode {
+                StatisticsMode::Boxplot => {
+                    let q1 = self.view.y_to_px(st.q1, py, ph);
+                    let q3 = self.view.y_to_px(st.q3, py, ph);
+                    let med = self.view.y_to_px(st.med, py, ph);
+                    let lo = self.view.y_to_px(st.lo, py, ph);
+                    let hi = self.view.y_to_px(st.hi, py, ph);
 
-            let top = q3.min(q1);
-            let bot = q3.max(q1);
-            let rect = Rect::new(xc - box_w * 0.5, top, box_w, (bot - top).max(1.0));
+                    let top = q3.min(q1);
+                    let bot = q3.max(q1);
+                    let rect = Rect::new(xc - box_w * 0.5, top, box_w, (bot - top).max(1.0));
+                    ctx.fill_rect(
+                        rect,
+                        6.0.into(),
+                        Brush::Solid(Color::rgba(
+                            self.style.accent.r,
+                            self.style.accent.g,
+                            self.style.accent.b,
+                            0.25,
+                        )),
+                    );
+                    ctx.stroke_rect(rect, 6.0.into(), &stroke, Brush::Solid(self.style.accent));
+                    ctx.stroke_polyline(
+                        &[
+                            Point::new(rect.x() + 2.0, med),
+                            Point::new(rect.x() + rect.width() - 2.0, med),
+                        ],
+                        &Stroke::new(2.0),
+                        Brush::Solid(self.style.accent),
+                    );
+                    let xw = xc;
+                    ctx.stroke_polyline(
+                        &[Point::new(xw, lo), Point::new(xw, top)],
+                        &stroke,
+                        Brush::Solid(self.style.accent),
+                    );
+                    ctx.stroke_polyline(
+                        &[Point::new(xw, bot), Point::new(xw, hi)],
+                        &stroke,
+                        Brush::Solid(self.style.accent),
+                    );
+                    let cap = (box_w * 0.4).clamp(6.0, 18.0);
+                    ctx.stroke_polyline(
+                        &[
+                            Point::new(xw - cap * 0.5, lo),
+                            Point::new(xw + cap * 0.5, lo),
+                        ],
+                        &stroke,
+                        Brush::Solid(self.style.accent),
+                    );
+                    ctx.stroke_polyline(
+                        &[
+                            Point::new(xw - cap * 0.5, hi),
+                            Point::new(xw + cap * 0.5, hi),
+                        ],
+                        &stroke,
+                        Brush::Solid(self.style.accent),
+                    );
+                    for &ov in &st.outliers {
+                        ctx.fill_circle(
+                            Point::new(xc, self.view.y_to_px(ov, py, ph)),
+                            2.0,
+                            Brush::Solid(Color::rgba(
+                                self.style.accent.r,
+                                self.style.accent.g,
+                                self.style.accent.b,
+                                0.95,
+                            )),
+                        );
+                    }
+                }
+                StatisticsMode::Violin => {
+                    let vals: Vec<f32> = self.groups[i]
+                        .iter()
+                        .copied()
+                        .filter(|v| v.is_finite())
+                        .collect();
+                    if vals.is_empty() {
+                        continue;
+                    }
+                    let bins = 22usize;
+                    let y_min = self.view.domain.y.min;
+                    let y_max = self.view.domain.y.max;
+                    let span = (y_max - y_min).max(1e-6);
+                    let mut hist = vec![0usize; bins];
+                    for &v in &vals {
+                        let t = ((v - y_min) / span).clamp(0.0, 0.999_999);
+                        let bi = (t * bins as f32) as usize;
+                        hist[bi] += 1;
+                    }
+                    let hmax = hist.iter().copied().max().unwrap_or(1).max(1) as f32;
+                    let half_w = box_w * 0.55;
+                    let mut top_pts = Vec::with_capacity(bins);
+                    let mut bot_pts = Vec::with_capacity(bins);
+                    for (bi, &c) in hist.iter().enumerate() {
+                        let yv = y_min + (bi as f32 + 0.5) / bins as f32 * span;
+                        let y = self.view.y_to_px(yv, py, ph);
+                        let hw = half_w * (c as f32 / hmax).sqrt();
+                        top_pts.push(Point::new(xc + hw, y));
+                        bot_pts.push(Point::new(xc - hw, y));
+                    }
+                    if !top_pts.is_empty() {
+                        let mut path = Path::new().move_to(top_pts[0].x, top_pts[0].y);
+                        for p in &top_pts[1..] {
+                            path = path.line_to(p.x, p.y);
+                        }
+                        for p in bot_pts.iter().rev() {
+                            path = path.line_to(p.x, p.y);
+                        }
+                        path = path.close();
+                        ctx.fill_path(
+                            &path,
+                            Brush::Solid(Color::rgba(
+                                self.style.accent.r,
+                                self.style.accent.g,
+                                self.style.accent.b,
+                                0.24,
+                            )),
+                        );
+                        ctx.stroke_path(&path, &stroke, Brush::Solid(self.style.accent));
+                    }
+                    let med_y = self.view.y_to_px(st.med, py, ph);
+                    ctx.stroke_polyline(
+                        &[
+                            Point::new(xc - box_w * 0.22, med_y),
+                            Point::new(xc + box_w * 0.22, med_y),
+                        ],
+                        &Stroke::new(1.5),
+                        Brush::Solid(self.style.accent),
+                    );
+                }
+                StatisticsMode::ErrorBand => {
+                    let mean = st.mean;
+                    let std = st.std.max(0.0);
+                    let mean_y = self.view.y_to_px(mean, py, ph);
+                    let lo_y = self.view.y_to_px(mean - std, py, ph);
+                    let hi_y = self.view.y_to_px(mean + std, py, ph);
+                    mean_pts.push(Point::new(xc, mean_y));
+                    band_top.push(Point::new(xc, hi_y));
+                    band_bot.push(Point::new(xc, lo_y));
+                    ctx.stroke_polyline(
+                        &[Point::new(xc, lo_y), Point::new(xc, hi_y)],
+                        &stroke,
+                        Brush::Solid(self.style.accent),
+                    );
+                    let cap = (box_w * 0.35).clamp(4.0, 14.0);
+                    ctx.stroke_polyline(
+                        &[
+                            Point::new(xc - cap, lo_y),
+                            Point::new(xc + cap, lo_y),
+                            Point::new(xc + cap, hi_y),
+                            Point::new(xc - cap, hi_y),
+                        ],
+                        &Stroke::new(1.0),
+                        Brush::Solid(Color::rgba(
+                            self.style.accent.r,
+                            self.style.accent.g,
+                            self.style.accent.b,
+                            0.55,
+                        )),
+                    );
+                }
+            }
+        }
 
-            ctx.fill_rect(
-                rect,
-                6.0.into(),
+        if self.style.mode == StatisticsMode::ErrorBand && mean_pts.len() >= 2 {
+            let mut path = Path::new().move_to(band_top[0].x, band_top[0].y);
+            for p in &band_top[1..] {
+                path = path.line_to(p.x, p.y);
+            }
+            for p in band_bot.iter().rev() {
+                path = path.line_to(p.x, p.y);
+            }
+            path = path.close();
+            ctx.fill_path(
+                &path,
                 Brush::Solid(Color::rgba(
                     self.style.accent.r,
                     self.style.accent.g,
                     self.style.accent.b,
-                    0.25,
+                    0.18,
                 )),
             );
-            ctx.stroke_rect(rect, 6.0.into(), &stroke, Brush::Solid(self.style.accent));
-
-            // Median
             ctx.stroke_polyline(
-                &[
-                    Point::new(rect.x() + 2.0, med),
-                    Point::new(rect.x() + rect.width() - 2.0, med),
-                ],
+                &mean_pts,
                 &Stroke::new(2.0),
                 Brush::Solid(self.style.accent),
             );
-
-            // Whiskers + caps
-            let xw = xc;
-            ctx.stroke_polyline(
-                &[Point::new(xw, lo), Point::new(xw, top)],
-                &stroke,
-                Brush::Solid(self.style.accent),
-            );
-            ctx.stroke_polyline(
-                &[Point::new(xw, bot), Point::new(xw, hi)],
-                &stroke,
-                Brush::Solid(self.style.accent),
-            );
-            let cap = (box_w * 0.4).clamp(6.0, 18.0);
-            ctx.stroke_polyline(
-                &[
-                    Point::new(xw - cap * 0.5, lo),
-                    Point::new(xw + cap * 0.5, lo),
-                ],
-                &stroke,
-                Brush::Solid(self.style.accent),
-            );
-            ctx.stroke_polyline(
-                &[
-                    Point::new(xw - cap * 0.5, hi),
-                    Point::new(xw + cap * 0.5, hi),
-                ],
-                &stroke,
-                Brush::Solid(self.style.accent),
-            );
+            for p in &mean_pts {
+                ctx.fill_circle(*p, 2.5, Brush::Solid(self.style.accent));
+            }
         }
     }
 
@@ -383,10 +548,10 @@ impl StatisticsChartModel {
         }
 
         if let Some(i) = self.hover_group {
-            let text = if let Some(st) = self.group_stats.get(i).and_then(|s| *s) {
+            let text = if let Some(st) = self.group_stats.get(i).and_then(|s| s.as_ref()) {
                 format!(
-                    "group={i}  q1={:.2}  med={:.2}  q3={:.2}",
-                    st.q1, st.med, st.q3
+                    "group={i}  q1={:.2}  med={:.2}  q3={:.2}  mean={:.2}  sd={:.2}",
+                    st.q1, st.med, st.q3, st.mean, st.std
                 )
             } else {
                 format!("group={i}")
@@ -494,6 +659,39 @@ mod tests {
             model.render_plot(&mut ctx, 320.0, 200.0);
         }));
 
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn violin_mode_renders_without_panic() {
+        let mut model = StatisticsChartModel::new(vec![
+            vec![1.0, 2.0, 2.2, 2.4, 3.0],
+            vec![0.2, 0.4, 0.9, 1.0, 1.4],
+        ])
+        .unwrap();
+        model.style.mode = StatisticsMode::Violin;
+
+        let mut ctx = RecordingContext::new(Size::new(320.0, 200.0));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            model.render_plot(&mut ctx, 320.0, 200.0);
+        }));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn error_band_mode_renders_without_panic() {
+        let mut model = StatisticsChartModel::new(vec![
+            vec![1.0, 2.0, 3.0, 4.0],
+            vec![2.0, 2.5, 3.5, 4.2],
+            vec![3.0, 3.2, 4.1, 4.6],
+        ])
+        .unwrap();
+        model.style.mode = StatisticsMode::ErrorBand;
+
+        let mut ctx = RecordingContext::new(Size::new(360.0, 220.0));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            model.render_plot(&mut ctx, 360.0, 220.0);
+        }));
         assert!(result.is_ok());
     }
 }

--- a/crates/blinc_charts/tests/d3_gap_modules.rs
+++ b/crates/blinc_charts/tests/d3_gap_modules.rs
@@ -1,8 +1,8 @@
-use blinc_charts::axis::build_bottom_ticks;
+use blinc_charts::axis::{build_bottom_ticks, build_bottom_ticks_log};
 use blinc_charts::format::{format_compact, format_fixed};
 use blinc_charts::interpolate::lerp_f32;
 use blinc_charts::polygon::{point_in_polygon, polygon_area, rect_polygon};
-use blinc_charts::scale::{BandScale, LinearScale};
+use blinc_charts::scale::{BandScale, LinearScale, LogScale};
 use blinc_charts::spatial_index::SpatialIndex;
 use blinc_charts::time_format::format_hms;
 use blinc_charts::transition::ValueTransition;
@@ -22,6 +22,17 @@ fn band_scale_returns_valid_band_metrics() {
     let b = BandScale::new(4, 0.0, 400.0, 0.1, 0.05);
     assert!(b.band_width() > 0.0);
     assert!(b.center(0).unwrap() < b.center(3).unwrap());
+}
+
+#[test]
+fn log_scale_and_axis_ticks_work() {
+    let s = LogScale::new(1.0, 1000.0, 0.0, 300.0).unwrap();
+    assert!((s.map(10.0) - 100.0).abs() < 1e-3);
+    let ticks = build_bottom_ticks_log(Domain1D::new(1.0, 1000.0), 0.0, 300.0, 6, |v| {
+        format!("{v:.0}")
+    });
+    assert_eq!(ticks.first().map(|t| t.value), Some(1.0));
+    assert_eq!(ticks.last().map(|t| t.value), Some(1000.0));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- expand `blinc_charts` with missing parity pieces across stacked-area, network (sankey), hierarchy, statistics, and scale/axis layers
- add shared palette + annotation modules and wire them into chart modules
- improve robustness and behavior coverage with additional unit/integration tests in `d3_gap_modules` and chart-specific suites

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p blinc_charts`
- [x] `cargo check -p blinc_app --example charts_gallery_demo --features windowed`
