### PR TITLE
Merge upstream/main into fork main (2026-03-03)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 # Build for iOS: cargo build --target aarch64-apple-ios -p blinc_platform_ios
 
 [workspace.package]
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/project-blinc/Blinc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/blinc_icons",
     "crates/blinc_debugger",
     "crates/blinc_runtime",
+    "crates/blinc_canvas_kit",
     "crates/blinc_test_suite",
     "extensions/blinc_platform_desktop",
     "extensions/blinc_platform_android",

--- a/README.md
+++ b/README.md
@@ -524,6 +524,10 @@ The book covers:
 - Widget library
 - Architecture deep-dives
 
+### For AI Agents
+
+See [Skills.md](Skills.md) — a concise, example-driven reference optimized for AI code agents building with Blinc.
+
 ## License
 
 Apache License 2.0 - see [LICENSE](LICENSE)

--- a/Skills.md
+++ b/Skills.md
@@ -833,3 +833,4 @@ div().material(Material::Glass(
 10. **`use_spring` returns `f32`** — it's a convenience that sets target and returns current value. Don't try to `.lock()` on it. For `SharedAnimatedValue`, use `use_animated_value_with_config()` instead.
 11. **`#[state]` attribute doesn't exist** — in `#[derive(BlincComponent)]`, unmarked fields are state. Only `#[animation]` is an explicit attribute.
 12. **The trait is `StateTransitions`** (plural) — not `StateTransition`.
+13. **`text()` has no `.class()` method** — use `.id("name")` with `#name { ... }` CSS selectors to style text. If you need class-based styling, wrap in `div().class("name").child(text("..."))`.

--- a/Skills.md
+++ b/Skills.md
@@ -577,6 +577,25 @@ fn counter_btn(count: State<i32>, label: &'static str, delta: i32) -> impl Eleme
 - **Return** a `Div` (builder pattern) — do NOT mutate
 - Outer builder methods (`.id()`, `.class()`) apply to the container
 - Inner `div()` returned from `on_state` is the visual content
+
+### Conditional Rendering with `.when()`
+
+`.when(condition, |div| ...)` conditionally modifies a builder. This only works **inside `on_state` callbacks** where the structure rebuilds on state change — outside of `on_state`, conditions are evaluated once at build time and won't react to changes.
+
+```rust
+fn expandable_section(expanded: State<bool>) -> impl ElementBuilder {
+    stateful::<NoState>()
+        .deps([expanded.signal_id()])
+        .on_state(move |_ctx| {
+            let is_open = expanded.get();
+            div()
+                .child(text("Section Title"))
+                .when(is_open, |d| {
+                    d.child(div().child(text("Expanded content here...")))
+                })
+        })
+}
+```
 ```
 
 ---

--- a/Skills.md
+++ b/Skills.md
@@ -3,6 +3,8 @@
 > Concise, example-driven reference for AI agents generating Blinc UI code.
 > Blinc is a Rust-native GPU-accelerated UI framework with flexbox layout, reactive signals, spring animations, and a CSS styling engine.
 
+> **Do NOT search the web for Blinc APIs.** This file contains verified, up-to-date API references. For anything not covered here, read the source in `crates/` directly.
+
 ---
 
 ## Project Structure

--- a/Skills.md
+++ b/Skills.md
@@ -172,7 +172,16 @@ CSS transitions automatically animate property changes on hover, focus, etc.:
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
 }
 
-/* Layout transitions — width, height, padding animate smoothly */
+/* Transform transitions (FLIP-style — smooth, no layout reflow) */
+.card {
+    transform: translateY(0);
+    transition: transform 300ms ease;
+}
+.card:hover {
+    transform: translateY(-4px) scale(1.02);
+}
+
+/* Layout transitions — width, height, padding (supported but triggers reflow per frame) */
 .expandable {
     width: 100px;
     transition: width 400ms ease;
@@ -642,7 +651,7 @@ motion()
 
 ### FLIP-Style Layout Animations (`animate_bounds`)
 
-For animating layout changes (position, size) that CSS transitions can't reach — such as when elements reorder, accordions expand/collapse, or container sizes change programmatically — use `animate_bounds()` with `VisualAnimationConfig`:
+CSS handles most FLIP-style animations via `transform` transitions (translate, scale, rotate — no layout reflow). For **layout-driven** changes that CSS can't express — such as element reordering, accordion content expanding, or container sizes changing programmatically — use `animate_bounds()` with `VisualAnimationConfig`:
 
 ```rust
 use blinc_layout::visual_animation::VisualAnimationConfig;
@@ -681,6 +690,7 @@ div()
 | Need | Use |
 |------|-----|
 | Hover/focus color change | CSS `transition: all 300ms ease` + `:hover` |
+| FLIP-style lift/scale/slide | CSS `transition: transform 300ms ease` + `:hover` |
 | Continuous looping animation | CSS `@keyframes` + `animation:` |
 | Reveal/clip animation | CSS `@keyframes` with `clip-path` |
 | Accordion expand/collapse | `animate_bounds(VisualAnimationConfig::height())` |

--- a/Skills.md
+++ b/Skills.md
@@ -1,0 +1,835 @@
+# Blinc Framework — Agent Skills Reference
+
+> Concise, example-driven reference for AI agents generating Blinc UI code.
+> Blinc is a Rust-native GPU-accelerated UI framework with flexbox layout, reactive signals, spring animations, and a CSS styling engine.
+
+---
+
+## Project Structure
+
+```
+crates/
+  blinc_app/       # Application framework, WindowedApp, prelude
+  blinc_core/      # Color, Transform, Signal, BlincContextState
+  blinc_layout/    # Div, text, stateful, motion, CSS parser, widgets
+  blinc_animation/ # SpringConfig, AnimatedValue, keyframes
+  blinc_paint/     # Low-level rendering primitives
+  blinc_gpu/       # GPU renderer (wgpu)
+  blinc_theme/     # Theming tokens, ThemeState (auto-injects CSS variables)
+  blinc_cn/        # Component library (shadcn/ui-inspired prebuilt widgets)
+  blinc_text/      # Text shaping and rendering
+  blinc_svg/       # SVG loading and rendering
+  blinc_image/     # Image loading
+  blinc_platform/  # Platform abstraction
+  blinc_macros/    # Derive macros (BlincComponent)
+```
+
+Common imports:
+```rust
+use blinc_app::prelude::*;
+use blinc_app::windowed::{WindowedApp, WindowedContext};
+use blinc_layout::stateful::stateful;
+use blinc_layout::motion::motion;
+use blinc_core::{Color, Transform, BlincContextState};
+```
+
+---
+
+## CSS-First Styling (Preferred Approach)
+
+**Always prefer CSS for all styling and layout.** CSS stylesheets provide consistency, separation of concerns, theme integration via CSS variables, and automatic hover/focus/disabled states without manual state management. Only fall back to builder methods for truly dynamic runtime values (e.g., values computed from signals). Avoid direct `.bg()` calls when a CSS class or ID selector would work.
+
+### Loading a Stylesheet
+
+Call `ctx.add_css()` once (guard with a bool so it doesn't re-add on rebuilds):
+
+```rust
+let mut css_loaded = false;
+
+WindowedApp::run(config, move |ctx| {
+    if !css_loaded {
+        ctx.add_css(r#"
+            #my-card {
+                background: #1e293b;
+                border-radius: 12px;
+                padding: 16px;
+                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            }
+            #my-card:hover {
+                background: #334155;
+                box-shadow: 0 8px 16px rgba(59, 130, 246, 0.3);
+            }
+
+            .btn-primary {
+                background: #3b82f6;
+                border-radius: 8px;
+                cursor: pointer;
+            }
+            .btn-primary:hover {
+                background: #2563eb;
+            }
+        "#);
+        css_loaded = true;
+    }
+    build_ui(ctx)
+});
+```
+
+### Targeting Elements
+
+Use `.id()` for unique elements (matched by `#id`) and `.class()` for reusable styles (matched by `.class`):
+
+```rust
+div().id("my-card")                     // matches #my-card
+    .child(div().class("btn-primary"))  // matches .btn-primary
+```
+
+### Theme CSS Variables
+
+`ThemeState` automatically injects theme tokens as CSS variables. Two ways to access them:
+
+```css
+/* var(--token) — standard CSS variables from ThemeState */
+h1 { color: var(--text-primary); }
+p  { color: var(--text-secondary); }
+.card {
+    background: var(--surface-elevated);
+    border-color: var(--primary);
+}
+svg { fill: var(--text-tertiary); }
+
+/* theme(token) — shorthand function for theme tokens */
+#button-primary {
+    background: theme(primary);
+    border-radius: theme(radius-default);
+    box-shadow: theme(shadow-md);
+}
+```
+
+Custom CSS variables are also supported:
+```css
+:root {
+    --brand-color: #3498db;
+    --card-radius: 12px;
+}
+#card {
+    background: var(--brand-color);
+    border-radius: var(--card-radius);
+}
+```
+
+This is the preferred way to apply colors — via theme variables in CSS — rather than hardcoding `Color::rgba(...)` in builder methods.
+
+### Supported CSS Properties
+
+| Category | Properties |
+|----------|-----------|
+| **Layout** | `width`, `height`, `min-width`, `max-width`, `min-height`, `max-height`, `padding`, `margin`, `gap`, `display: flex`, `flex-direction`, `align-items`, `justify-content`, `flex-grow`, `flex-shrink`, `flex-wrap`, `overflow`, `aspect-ratio` |
+| **Position** | `position: absolute/relative`, `top`, `right`, `bottom`, `left` |
+| **Visual** | `background`, `opacity`, `border-radius`, `box-shadow`, `backdrop-filter: blur()`, `overflow-fade` |
+| **Text** | `color`, `font-size`, `font-weight`, `font-family`, `text-align`, `line-height`, `letter-spacing`, `text-decoration`, `text-decoration-color`, `text-decoration-thickness`, `text-overflow: ellipsis`, `white-space: nowrap` |
+| **Blend/FX** | `mix-blend-mode`, `pointer-events`, `cursor`, `filter: brightness() saturate() contrast()` |
+| **Backdrop** | `backdrop-filter: blur()`, `backdrop-filter: liquid-glass(...)` |
+| **Transition** | `transition: all 300ms ease`, `transition-property`, `transition-duration`, `transition-timing-function` |
+| **Animation** | `@keyframes`, `animation: name duration timing-fn iteration`, `animation-name`, `animation-duration`, `animation-timing-function` |
+| **Clip** | `clip-path: inset(...)`, `clip-path: polygon(...)`, `clip-path: circle(...)` |
+| **SVG** | `fill`, `stroke`, `stroke-width`, `stroke-dasharray`, `stroke-dashoffset`, `d: path(...)` (morphing) |
+| **3D** | `perspective`, `rotate-x`, `rotate-y`, `translate-z`, `shape-3d: box/sphere/cylinder/group`, `depth`, `3d-op: subtract/smooth-union`, `3d-blend` |
+| **Variables** | `:root { --name: value; }`, `var(--name)`, `theme(token)` |
+| **Selectors** | `#id`, `.class`, `tag` (SVG), `:hover`, `:active`, `:focus`, `:disabled`, `::placeholder`, `:first-child`, `:last-child`, `:not()`, `:is()`, `:empty`, `>`, `+`, `~`, `*` |
+
+### CSS Transitions (Preferred for Smooth State Changes)
+
+CSS transitions automatically animate property changes on hover, focus, etc.:
+
+```css
+.card {
+    background: #1e3a5f;
+    border-radius: 12px;
+    transition: all 300ms ease;  /* animates ALL property changes */
+}
+.card:hover {
+    background: #3b82f6;
+    border-radius: 24px;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
+}
+
+/* Filter transitions */
+.filter-card {
+    transition: filter 400ms ease;
+}
+.filter-card:hover {
+    filter: brightness(1.8) saturate(2.0) contrast(1.3);
+}
+
+/* Backdrop-filter transitions (glass morphism) */
+.icon-wrapper {
+    backdrop-filter: blur(12px) saturate(180%) brightness(80%);
+    transition: backdrop-filter 400ms ease;
+}
+.icon-wrapper:hover {
+    backdrop-filter: blur(16px) saturate(200%) brightness(110%);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+/* Layout transitions — width, height, padding animate smoothly */
+.expandable {
+    width: 100px;
+    transition: width 400ms ease;
+}
+.expandable:hover {
+    width: 200px;
+}
+
+/* Overflow fade transitions */
+#fade-container {
+    overflow: clip;
+    overflow-fade: 0px;
+    transition: overflow-fade 500ms ease;
+}
+#fade-container:hover {
+    overflow-fade: 32px;
+}
+
+/* Button states (all in CSS, no Rust code needed!) */
+#btn {
+    background: theme(primary);
+    transition: all 200ms ease;
+}
+#btn:hover { opacity: 0.9; transform: scale(1.02); }
+#btn:active { transform: scale(0.98); }
+#btn:disabled { opacity: 0.5; }
+```
+
+### CSS Keyframe Animations
+
+Define reusable `@keyframes` for complex, multi-step animations:
+
+```css
+/* Looping pulse */
+@keyframes pulse {
+    0% { opacity: 0.5; }
+    50% { opacity: 1.0; }
+    100% { opacity: 0.5; }
+}
+#pulse-element {
+    animation: pulse 2000ms ease-in-out infinite;
+}
+
+/* Multi-stop gradient animation */
+@keyframes track-glow {
+    0%   { background: linear-gradient(90deg, #d0d0d0, #e0e0e0, #ffffff); }
+    33%  { background: linear-gradient(90deg, #d0d0d0, #ffffff, #d0d0d0); }
+    66%  { background: linear-gradient(90deg, #ffffff, #e0e0e0, #d0d0d0); }
+    100% { background: linear-gradient(90deg, #d0d0d0, #e0e0e0, #ffffff); }
+}
+
+/* Clip-path reveal on hover */
+@keyframes clip-reveal {
+    from { clip-path: inset(50% 50% 50% 50%); }
+    to { clip-path: inset(0% 0% 0% 0%); }
+}
+#reveal:hover {
+    animation: clip-reveal 400ms ease-out forwards;
+}
+
+/* SVG stroke-dash line drawing */
+@keyframes draw-circle {
+    0%   { stroke-dashoffset: 251; }
+    100% { stroke-dashoffset: 0; }
+}
+#draw-svg {
+    stroke-dasharray: 251;
+    animation: draw-circle 3s ease-in-out infinite alternate;
+}
+
+/* SVG fill/stroke color cycling */
+@keyframes color-cycle {
+    0%   { fill: #ef4444; stroke: #dc2626; }
+    33%  { fill: #3b82f6; stroke: #2563eb; }
+    66%  { fill: #10b981; stroke: #059669; }
+    100% { fill: #ef4444; stroke: #dc2626; }
+}
+
+/* SVG path morphing */
+@keyframes morph-shape {
+    0%   { d: path("M20,20 L80,20 L80,80 L50,80 L20,80 Z"); }
+    50%  { d: path("M50,10 L90,40 L75,85 L25,85 L10,40 Z"); }
+    100% { d: path("M20,20 L80,20 L80,80 L50,80 L20,80 Z"); }
+}
+
+/* 3D rotation */
+@keyframes spin-y {
+    0% { rotate-y: 0deg; }
+    100% { rotate-y: 360deg; }
+}
+#spinning {
+    perspective: 800px;
+    animation: spin-y 4000ms linear infinite;
+}
+```
+
+### Common CSS Patterns
+
+```css
+/* Text truncation with ellipsis */
+.truncated {
+    width: 250px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+/* Non-interactive overlay */
+.overlay {
+    pointer-events: none;
+    opacity: 0.5;
+}
+
+/* SVG sub-element styling (tag-name selectors) */
+#my-svg path { stroke: #8b5cf6; stroke-width: 5; }
+#my-svg circle { fill: #f3e8ff; stroke: #a78bfa; }
+#my-svg rect { fill: #fef3c7; stroke: #f59e0b; }
+
+/* Liquid glass (advanced glass morphism) */
+#glass-card {
+    backdrop-filter: liquid-glass(blur(18px) saturate(180%) brightness(120%)
+                                  border(4.0) tint(rgba(255, 255, 255, 1.0)));
+    border-radius: 24px;
+    box-shadow: 0 8px 80px rgba(0, 0, 0, 0.60);
+}
+```
+
+### Advanced CSS Selectors
+
+```css
+/* Child combinator */
+#parent > .child { background: #374151; }
+#parent:hover > .child { background: #6366f1; }
+
+/* Adjacent sibling: hover one, style the next */
+.trigger:hover + .target { background: #f59e0b; }
+
+/* General sibling: hover one, style all following siblings */
+.trigger:hover ~ .item { background: #a78bfa; }
+
+/* :not() */
+.item:not(:first-child) { background: #0891b2; }
+
+/* Universal inside parent */
+#container > * { background: #059669; }
+```
+
+### Specificity (Low to High)
+
+1. **CSS stylesheet** (`ctx.add_css()`) — lowest priority
+2. **`css!` / `style!` macros** — inline element styles
+3. **Builder methods** (`.bg()`, `.w()`, etc.) — highest priority, overrides CSS
+
+### Inline Style Macros
+
+Both macros return `ElementStyle`. Apply to elements with `.style()`:
+
+```rust
+use blinc_layout::css;
+use blinc_layout::style;
+
+// css! macro — CSS-like syntax, semicolons, hyphenated properties, Rust values
+let card_style = css! {
+    background: Color::rgba(0.2, 0.3, 0.9, 1.0);
+    border-radius: 12.0;
+    box-shadow: Shadow::new(0.0, 4.0, 8.0, Color::BLACK.with_alpha(0.2));
+    opacity: 0.9;
+};
+div().style(&card_style)
+
+// style! macro — Rust-friendly syntax, commas, underscored properties
+let btn_style = style! {
+    bg: Color::BLUE,
+    rounded: 8.0,
+    shadow_md
+};
+div().style(&btn_style)
+```
+
+### Why CSS First?
+
+- **Hover/focus/disabled states for free** — no `stateful::<ButtonState>()` needed for pure visual changes
+- **Transitions and animations built-in** — `transition: all 300ms ease` and `@keyframes` handle most animation needs without Rust code
+- **Consistent theming** — one stylesheet + `var(--token)` styles the whole app
+- **Rich selector system** — child `>`, sibling `+`/`~`, `:not()`, `:is()`, `:first-child`, etc.
+- **Less code** — no per-element builder chains for every style property
+- **CSS variables** — theme tokens auto-inject as CSS variables from `ThemeState`
+- **Spacing consistency** — CSS uses standard `px` units, while builder spacing methods (`.p()`, `.gap()`, `.m()`) use a 4px unit system (see below)
+- **Clip-path & 3D** — `clip-path`, `perspective`, `rotate-x/y`, `shape-3d` are all CSS-driven
+
+---
+
+## Element Builders
+
+All elements use a fluent builder API. Core elements:
+
+```rust
+// Container
+div().w(200.0).h(100.0).rounded(8.0).id("my-card")  // prefer CSS for bg/colors
+
+// Text
+text("Hello").size(24.0).weight(FontWeight::Bold).color(Color::WHITE)
+
+// Typography helpers
+h1("Title")  h2("Subtitle")  h3("Section")  p("Body")  caption("Small")
+b("Bold")  small("Small")  muted("Muted")  label("Label")
+
+// Stack (overlapping layers)
+stack().child(background).child(foreground)
+
+// Image & SVG
+image("photo.png").w(200.0).cover()
+svg("icon.svg").w(24.0).h(24.0).tint(Color::WHITE)
+
+// Canvas (custom GPU drawing)
+canvas(|ctx, bounds| { /* draw commands */ }).w(200.0).h(100.0)
+```
+
+### Layout (Flexbox)
+
+**IMPORTANT — Builder spacing units:**
+- `.w()`, `.h()`, `.left()`, `.top()`, `.rounded()`, `.size()` use **raw pixels**
+- `.p()`, `.px()`, `.py()`, `.m()`, `.mx()`, `.my()`, `.gap()` use **4px units** (e.g., `.p(4.0)` = 16px, `.gap(2.0)` = 8px)
+
+**To avoid confusion, prefer CSS for layout sizing** where values are always in standard `px`:
+```css
+.card { padding: 16px; margin: 8px; gap: 12px; }
+```
+
+Builder methods (when CSS is not practical):
+```rust
+div()
+    .flex_col()          // Vertical layout
+    .flex_row()          // Horizontal layout
+    .gap(4.0)            // 4.0 * 4 = 16px gap between children
+    .justify_center()    // Main axis center
+    .items_center()      // Cross axis center
+    .flex_center()       // Both axes centered
+    .flex_wrap()         // Wrap children
+    .p(4.0)              // 4.0 * 4 = 16px padding all sides
+    .px(4.0).py(2.0)     // Horizontal 16px / vertical 8px padding
+    .m(2.0)              // 2.0 * 4 = 8px margin all sides
+    .flex_1()            // flex: 1 1 0%
+    .flex_grow()         // flex-grow: 1
+    .w(200.0)            // 200px width (raw pixels)
+    .h(100.0)            // 100px height (raw pixels)
+    .w_full().h_full()   // 100% width/height
+    .absolute()          // position: absolute
+    .left(10.0)          // 10px left (raw pixels)
+    .top(10.0)           // 10px top (raw pixels)
+```
+
+---
+
+## App Entry Point
+
+```rust
+fn main() -> Result<()> {
+    let config = WindowConfig {
+        title: "My App".to_string(),
+        width: 800,
+        height: 600,
+        resizable: true,
+        ..Default::default()
+    };
+
+    WindowedApp::run(config, |ctx| build_ui(ctx))
+}
+
+fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
+    div()
+        .w(ctx.width)
+        .h(ctx.height)
+        .id("root")  // prefer CSS for styling
+        .flex_col()
+        .items_center()
+        .justify_center()
+        .child(text("Hello Blinc").size(32.0).color(Color::WHITE))
+}
+```
+
+---
+
+## Reactive State (Signals)
+
+### Creating State
+
+```rust
+// Keyed state — persists across UI rebuilds
+let count = ctx.use_state_keyed("counter", || 0i32);
+
+// Read
+let value = count.get();
+
+// Write
+count.set(5);
+count.update(|v| v + 1);
+
+// Get signal ID for dependency tracking
+let id = count.signal_id();
+```
+
+`State<T>` is `Copy` — capture directly in closures, no need to clone.
+
+### Using State in Closures
+
+```rust
+use blinc_core::BlincContextState;
+
+div().on_click(move |_| {
+    // BlincContextState provides thread-safe access from event handlers
+    BlincContextState::get().update(count, |v| v + 1);
+})
+```
+
+### Dependency Tracking with `stateful`
+
+Elements that need to re-render when signals change use `stateful::<S>()` with `.deps()`:
+
+```rust
+fn count_display(count: State<i32>) -> impl ElementBuilder {
+    stateful::<NoState>()
+        .deps([count.signal_id()])
+        .on_state(move |_ctx| {
+            let current = count.get();
+            div().child(text(&format!("{}", current)).size(64.0).color(Color::WHITE))
+        })
+}
+```
+
+---
+
+## Stateful Containers
+
+`stateful::<S>()` creates elements with automatic state transitions. `S` must implement `StateTransitions`.
+
+### Built-in States
+
+| State | Variants | Auto-transitions |
+|-------|----------|------------------|
+| `ButtonState` | `Idle`, `Hovered`, `Pressed`, `Disabled` | Hover enter/leave, press/release |
+| `ToggleState` | `Off`, `On` | Click toggles |
+| `NoState` | (unit struct) | None — used only for `.deps()` reactive tracking |
+
+### Counter Example
+
+A practical example combining signals, stateful dependency tracking, and events:
+
+```rust
+fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
+    let count = ctx.use_state_keyed("counter", || 0i32);
+
+    div()
+        .w(ctx.width).h(ctx.height).id("root")
+        .flex_col().items_center().justify_center()
+        // Display updates reactively via .deps()
+        .child(count_display(count))
+        // Buttons use CSS for hover styling (no manual ButtonState needed)
+        .child(
+            div().flex_row().gap(4.0)
+                .child(counter_btn(count, "-", -1))
+                .child(counter_btn(count, "+", 1))
+        )
+}
+
+fn count_display(count: State<i32>) -> impl ElementBuilder {
+    stateful::<NoState>()
+        .deps([count.signal_id()])  // re-run on_state when count changes
+        .on_state(move |_ctx| {
+            let current = count.get();
+            div().child(
+                text(&format!("{}", current))
+                    .size(64.0).weight(FontWeight::Bold).color(Color::WHITE)
+            )
+        })
+}
+
+fn counter_btn(count: State<i32>, label: &'static str, delta: i32) -> impl ElementBuilder {
+    // Prefer CSS for hover/press styling:
+    // #counter-btn { background: #333; } #counter-btn:hover { background: #555; }
+    div()
+        .class("counter-btn")
+        .on_click(move |_| { count.update(|v| v + delta); })
+        .child(text(label).size(28.0).weight(FontWeight::Bold).color(Color::WHITE))
+}
+```
+
+**Key principle:** Use CSS for hover/press visual effects. Use `stateful::<NoState>()` with `.deps()` for signal-driven reactive updates. Only reach for `stateful::<ButtonState>()` with `on_state` when you need runtime logic that CSS can't express.
+
+**Rules for `on_state` callback:**
+- Callback signature: `Fn(&StateContext<S>) -> Div`
+- Read state via `ctx.state()` (returns `S` by copy)
+- **Return** a `Div` (builder pattern) — do NOT mutate
+- Outer builder methods (`.id()`, `.class()`) apply to the container
+- Inner `div()` returned from `on_state` is the visual content
+```
+
+---
+
+## Spring Animations
+
+### Spring Presets
+
+```rust
+use blinc_animation::SpringConfig;
+
+SpringConfig::stiff()   // Fast, no overshoot (buttons, toggles)
+SpringConfig::snappy()  // Quick with slight bounce
+SpringConfig::gentle()  // Soft, slow settle (modals, overlays)
+SpringConfig::wobbly()  // Bouncy, playful
+SpringConfig::new(stiffness, damping, mass)  // Custom (f32, f32, f32)
+```
+
+### Using Springs in StateContext
+
+`ctx.use_spring()` is a convenience method that sets the target and returns the current animated value as `f32`:
+
+```rust
+fn animated_button() -> impl ElementBuilder {
+    stateful::<ButtonState>()
+        .on_state(|ctx| {
+            // use_spring(name, target, config) -> f32
+            // Set target based on current state; returns current interpolated value
+            let target = match ctx.state() {
+                ButtonState::Hovered => 1.05,
+                ButtonState::Pressed => 0.95,
+                _ => 1.0,
+            };
+            let s = ctx.use_spring("scale", target, SpringConfig::snappy());
+            div().bg(Color::rgba(0.3, 0.5, 0.9, 1.0)).scale(s)
+        })
+}
+```
+
+For more control, use `ctx.use_animated_value_with_config()` which returns `SharedAnimatedValue` (`Arc<Mutex<AnimatedValue>>`):
+
+```rust
+let scale = ctx.use_animated_value_with_config("scale", 1.0, SpringConfig::snappy());
+scale.lock().unwrap().set_target(1.05);
+let current = scale.lock().unwrap().get();
+```
+
+### Motion Containers
+
+`motion()` wraps content with enter/exit/stagger animations:
+
+```rust
+use blinc_layout::motion::motion;
+
+// Fade in on enter
+motion().fade_in(300).child(content)
+
+// Slide in from direction
+motion().slide_in(SlideDirection::Right, 200).child(content)
+
+// Stagger children (delay_ms between each, animation preset)
+motion()
+    .stagger(StaggerConfig::new(50, AnimationPreset::fade_in(300)))
+    .child(list_items)
+
+// Combined enter animations
+motion()
+    .fade_in(300)
+    .slide_in(SlideDirection::Up, 200)
+    .child(modal_content)
+```
+
+### FLIP-Style Layout Animations (`animate_bounds`)
+
+For animating layout changes (position, size) that CSS transitions can't reach — such as when elements reorder, accordions expand/collapse, or container sizes change programmatically — use `animate_bounds()` with `VisualAnimationConfig`:
+
+```rust
+use blinc_layout::visual_animation::VisualAnimationConfig;
+
+// Accordion: animate height changes
+div()
+    .animate_bounds(VisualAnimationConfig::height().with_key("accordion-1"))
+    .overflow_clip()
+    .child(expandable_content)
+
+// Reorder list: animate position changes
+div()
+    .animate_bounds(VisualAnimationConfig::position())
+    .child(sortable_item)
+
+// Animate all bounds with custom spring
+div()
+    .animate_bounds(
+        VisualAnimationConfig::all()
+            .with_spring(SpringConfig::wobbly())
+            .with_key("card")
+    )
+    .child(content)
+```
+
+**VisualAnimationConfig presets:**
+- `::height()` — accordion/collapsible (most common)
+- `::width()` — sidebars
+- `::size()` — both width and height
+- `::position()` — reordering (no clipping)
+- `::all()` — position + size
+- Chain `.gentle()`, `.wobbly()`, `.stiff()`, `.snappy()` for spring presets
+- Use `.with_key("stable-id")` inside `stateful` components for persistence across rebuilds
+
+**When to use what:**
+| Need | Use |
+|------|-----|
+| Hover/focus color change | CSS `transition: all 300ms ease` + `:hover` |
+| Continuous looping animation | CSS `@keyframes` + `animation:` |
+| Reveal/clip animation | CSS `@keyframes` with `clip-path` |
+| Accordion expand/collapse | `animate_bounds(VisualAnimationConfig::height())` |
+| Sortable list reorder | `animate_bounds(VisualAnimationConfig::position())` |
+| Enter/exit/stagger | `motion().fade_in(300)` |
+| Spring-physics per state | `ctx.use_spring()` inside `on_state` |
+
+---
+
+## Events
+
+```rust
+div()
+    .on_click(|ctx| { /* ctx.local_x, ctx.local_y */ })
+    .on_hover_enter(|ctx| { /* mouse entered */ })
+    .on_hover_leave(|ctx| { /* mouse left */ })
+    .on_key_down(|ctx| {
+        if (ctx.ctrl || ctx.meta) && ctx.key_code == 83 { /* Ctrl/Cmd+S */ }
+    })
+    .on_drag(|ctx| { /* ctx.drag_delta_x, ctx.drag_delta_y */ })
+    .on_scroll(|ctx| { /* ctx.scroll_delta_x, ctx.scroll_delta_y */ })
+    .on_focus(|ctx| { /* element focused */ })
+    .on_blur(|ctx| { /* element blurred */ })
+    .on_mount(|ctx| { /* added to tree */ })
+    .on_unmount(|ctx| { /* removed from tree */ })
+```
+
+All handlers receive `EventContext` with fields: `mouse_x`, `mouse_y`, `local_x`, `local_y`, `key_code`, `key_char`, `shift`, `ctrl`, `alt`, `meta`, `drag_delta_x`, `drag_delta_y`, `scroll_delta_x`, `scroll_delta_y`.
+
+---
+
+## Widgets
+
+Built-in widgets in `blinc_layout::widgets`. Note: `text_input` and `text_area` take shared state handles, not raw strings.
+
+```rust
+use blinc_layout::widgets::*;
+
+// Text input — create shared state first, then pass reference
+let input_data = text_input_data_with_placeholder("Enter name...");
+text_input(&input_data).id("my-input").on_change(|val| { /* val: &str */ })
+
+// Text area — same pattern
+let area_state = text_area_state_with_placeholder("Enter description...");
+text_area(&area_state).id("my-area").rows(5)
+
+// Scroll container
+scroll().w(400.0).h(300.0).child(long_content)
+
+// Radio group — takes &State<String>
+let selected = ctx.use_state_keyed("radio", || "opt1".to_string());
+radio_group(&selected)
+    .option("opt1", "Option 1")
+    .option("opt2", "Option 2")
+
+// Checkbox — takes &State<bool>
+let checked = ctx.use_state_keyed("check", || false);
+checkbox(&checked).label("Enable feature")
+```
+
+---
+
+## Component Patterns
+
+### Function Components
+
+```rust
+fn card(title: &str) -> Div {
+    div()
+        .id("card")  // style via CSS: #card { padding: 16px; border-radius: 12px; ... }
+        .child(text(title).size(18.0).weight(FontWeight::SemiBold).color(Color::WHITE))
+}
+```
+
+### Components with Children
+
+```rust
+fn card_with_content<E: ElementBuilder>(title: &str, content: E) -> Div {
+    div()
+        .class("card")  // style via CSS: .card { padding: 16px; ... }
+        .flex_col()
+        .child(text(title).size(18.0).weight(FontWeight::SemiBold).color(Color::WHITE))
+        .child(content)
+}
+```
+
+### BlincComponent Derive
+
+For type-safe hooks (state + animation) that prevent key collisions:
+
+```rust
+use blinc_macros::BlincComponent;
+
+#[derive(BlincComponent)]
+struct Counter {
+    count: i32,        // unmarked fields → State<T> (generates Counter::use_count)
+    #[animation]
+    scale: f32,        // #[animation] fields → SharedAnimatedValue (generates Counter::use_scale)
+}
+
+fn counter_demo(ctx: &WindowedContext) -> impl ElementBuilder {
+    let count = Counter::use_count(ctx, 0);
+    let scale = Counter::use_scale(ctx, 1.0, SpringConfig::snappy());
+    // ...
+}
+```
+
+Note: There is no `#[state]` attribute. Fields without any attribute are automatically state fields.
+
+---
+
+## Glass Material
+
+```rust
+div().glass()  // Default frosted glass effect
+
+// Presets
+use blinc_layout::element::GlassMaterial;
+
+div().material(Material::Glass(GlassMaterial::ultra_thin()))
+div().material(Material::Glass(GlassMaterial::thin()))
+div().material(Material::Glass(GlassMaterial::regular()))
+div().material(Material::Glass(GlassMaterial::thick()))
+div().material(Material::Glass(GlassMaterial::frosted()))
+div().material(Material::Glass(GlassMaterial::card()))
+
+// Custom
+div().material(Material::Glass(
+    GlassMaterial::new()
+        .blur(20.0)
+        .tint(Color::rgba(1.0, 1.0, 1.0, 0.1))
+        .saturation(1.2)
+        .noise(0.03)
+))
+```
+
+---
+
+## Common Pitfalls
+
+1. **Don't use `stateful(handle)`** — this is the deprecated API. Use `stateful::<S>()`.
+2. **`on_state` returns `Div`** — it's a builder, not mutation. Return `div().bg(bg)`, don't call `div.set_bg()`.
+3. **Signal is `Copy`** — capture directly in closures, no need to clone.
+4. **`BlincContextState::get()`** — use this for signal updates inside event closures, not `ctx`.
+5. **CSS loaded once** — guard `ctx.add_css()` with a boolean flag to avoid re-adding on each rebuild.
+6. **`blinc_cn` is a component library** — NOT a className utility. It provides prebuilt shadcn/ui-style widgets.
+7. **Prefer CSS for all styling** — use `#id:hover { ... }` and `var(--token)` in a stylesheet instead of hardcoding colors in builder methods. Use `stateful::<ButtonState>()` only when you need runtime logic (not just visual changes).
+8. **Spacing units differ from pixels** — `.p()`, `.px()`, `.py()`, `.m()`, `.mx()`, `.my()`, `.gap()` use **4px units** (`.p(4.0)` = 16px). `.w()`, `.h()`, `.left()`, `.top()` use raw pixels. **Prefer CSS for spacing** (`padding: 16px; gap: 12px;`) to avoid this confusion.
+9. **Widget constructors take shared state** — `text_input(&data)` and `text_area(&state)` take `&SharedTextInputData` / `&SharedTextAreaState`, not strings. Create state first with `text_input_data_with_placeholder("...")`.
+10. **`use_spring` returns `f32`** — it's a convenience that sets target and returns current value. Don't try to `.lock()` on it. For `SharedAnimatedValue`, use `use_animated_value_with_config()` instead.
+11. **`#[state]` attribute doesn't exist** — in `#[derive(BlincComponent)]`, unmarked fields are state. Only `#[animation]` is an explicit attribute.
+12. **The trait is `StateTransitions`** (plural) — not `StateTransition`.

--- a/crates/blinc_animation/Cargo.toml
+++ b/crates/blinc_animation/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 zrtl-plugin = []  # Enable ZRTL plugin exports (for when Zyntax Grammar2 is ready)
 
 [dependencies]
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
 
 # Data structures
 slotmap.workspace = true

--- a/crates/blinc_app/CHANGELOG.md
+++ b/crates/blinc_app/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `blinc_app` will be documented in this file.
 
+## [0.1.14] - 2026-02-24
+
+### Added
+
+- `css_debug` example updated with stateful container tests for CSS var(), percentage, color inheritance, and inner child click persistence
+
 ## [0.1.13] - 2026-02-18
 
 ### Added

--- a/crates/blinc_app/Cargo.toml
+++ b/crates/blinc_app/Cargo.toml
@@ -75,6 +75,7 @@ image.workspace = true
 tracing-subscriber.workspace = true
 blinc_cn = { path = "../blinc_cn", version = "0.1.14" }
 blinc_icons = { path = "../blinc_icons", version = "0.1.14" }
+blinc_canvas_kit = { path = "../blinc_canvas_kit", version = "0.1.14" }
 
 [features]
 default = ["windowed"]

--- a/crates/blinc_app/Cargo.toml
+++ b/crates/blinc_app/Cargo.toml
@@ -17,16 +17,16 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("fuchsia
 crate-type = ["rlib", "staticlib"]
 
 [dependencies]
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
-blinc_layout = { path = "../blinc_layout", version = "0.1.13" }
-blinc_gpu = { path = "../blinc_gpu", version = "0.1.13", default-features = false }
-blinc_svg = { path = "../blinc_svg", version = "0.1.13" }
-blinc_text = { path = "../blinc_text", version = "0.1.13" }
-blinc_image = { path = "../blinc_image", version = "0.1.13" }
-blinc_platform = { path = "../blinc_platform", version = "0.1.13" }
-blinc_animation = { path = "../blinc_animation", version = "0.1.13" }
-blinc_macros = { path = "../blinc_macros", version = "0.1.13" }
-blinc_theme = { path = "../blinc_theme", version = "0.1.13" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
+blinc_layout = { path = "../blinc_layout", version = "0.1.14" }
+blinc_gpu = { path = "../blinc_gpu", version = "0.1.14", default-features = false }
+blinc_svg = { path = "../blinc_svg", version = "0.1.14" }
+blinc_text = { path = "../blinc_text", version = "0.1.14" }
+blinc_image = { path = "../blinc_image", version = "0.1.14" }
+blinc_platform = { path = "../blinc_platform", version = "0.1.14" }
+blinc_animation = { path = "../blinc_animation", version = "0.1.14" }
+blinc_macros = { path = "../blinc_macros", version = "0.1.14" }
+blinc_theme = { path = "../blinc_theme", version = "0.1.14" }
 
 # GPU
 wgpu.workspace = true
@@ -50,10 +50,10 @@ lru = { workspace = true }
 
 # Desktop platform - exclude mobile/embedded targets
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_os = "fuchsia")))'.dependencies]
-blinc_platform_desktop = { path = "../../extensions/blinc_platform_desktop", version = "0.1.13", optional = true }
+blinc_platform_desktop = { path = "../../extensions/blinc_platform_desktop", version = "0.1.14", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
-blinc_platform_android = { path = "../../extensions/blinc_platform_android", version = "0.1.13", optional = true }
+blinc_platform_android = { path = "../../extensions/blinc_platform_android", version = "0.1.14", optional = true }
 android-activity = { workspace = true, optional = true }
 ndk = { workspace = true, optional = true }
 jni = { workspace = true, optional = true }
@@ -63,18 +63,18 @@ tracing-android = { version = "0.2", optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-blinc_platform_ios = { path = "../../extensions/blinc_platform_ios", version = "0.1.13", optional = true }
+blinc_platform_ios = { path = "../../extensions/blinc_platform_ios", version = "0.1.14", optional = true }
 
 
 # HarmonyOS uses "ohos" as target_os
 # [target.'cfg(target_os = "ohos")'.dependencies]
-# blinc_platform_harmony = { path = "../../extensions/blinc_platform_harmony", version = "0.1.13", optional = true }
+# blinc_platform_harmony = { path = "../../extensions/blinc_platform_harmony", version = "0.1.14", optional = true }
 
 [dev-dependencies]
 image.workspace = true
 tracing-subscriber.workspace = true
-blinc_cn = { path = "../blinc_cn", version = "0.1.13" }
-blinc_icons = { path = "../blinc_icons", version = "0.1.13" }
+blinc_cn = { path = "../blinc_cn", version = "0.1.14" }
+blinc_icons = { path = "../blinc_icons", version = "0.1.14" }
 
 [features]
 default = ["windowed"]

--- a/crates/blinc_app/Cargo.toml
+++ b/crates/blinc_app/Cargo.toml
@@ -27,6 +27,7 @@ blinc_platform = { path = "../blinc_platform", version = "0.1.14" }
 blinc_animation = { path = "../blinc_animation", version = "0.1.14" }
 blinc_macros = { path = "../blinc_macros", version = "0.1.14" }
 blinc_theme = { path = "../blinc_theme", version = "0.1.14" }
+blinc_i18n = { path = "../blinc_i18n", version = "0.1.14" }
 
 # GPU
 wgpu.workspace = true
@@ -42,6 +43,10 @@ pollster.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
 # Logging
 tracing.workspace = true
 
@@ -54,6 +59,7 @@ blinc_platform_desktop = { path = "../../extensions/blinc_platform_desktop", ver
 
 [target.'cfg(target_os = "android")'.dependencies]
 blinc_platform_android = { path = "../../extensions/blinc_platform_android", version = "0.1.14", optional = true }
+blinc_sensors = { path = "../blinc_sensors", version = "0.1.14" }
 android-activity = { workspace = true, optional = true }
 ndk = { workspace = true, optional = true }
 jni = { workspace = true, optional = true }
@@ -64,6 +70,7 @@ tracing-subscriber = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "ios")'.dependencies]
 blinc_platform_ios = { path = "../../extensions/blinc_platform_ios", version = "0.1.14", optional = true }
+blinc_sensors = { path = "../blinc_sensors", version = "0.1.14" }
 
 
 # HarmonyOS uses "ohos" as target_os
@@ -76,6 +83,7 @@ tracing-subscriber.workspace = true
 blinc_cn = { path = "../blinc_cn", version = "0.1.14" }
 blinc_icons = { path = "../blinc_icons", version = "0.1.14" }
 blinc_canvas_kit = { path = "../blinc_canvas_kit", version = "0.1.14" }
+blinc_charts = { path = "../blinc_charts", version = "0.1.14" }
 
 [features]
 default = ["windowed"]

--- a/crates/blinc_app/examples/canvas_kit_demo.rs
+++ b/crates/blinc_app/examples/canvas_kit_demo.rs
@@ -1,0 +1,745 @@
+//! Canvas Kit Interactive Demo
+//!
+//! Demonstrates `blinc_canvas_kit` features:
+//! - Pan (drag background) and zoom (scroll wheel) on an infinite canvas
+//! - `kit.element()` builder with auto-wired event handlers
+//! - `kit.handler()` for custom event wiring
+//! - Hit testing via `kit.hit_rect()` inside draw callbacks
+//! - Click, drag, and hover callbacks on canvas-drawn elements
+//! - Viewport state HUD overlay
+//!
+//! Run with: cargo run -p blinc_app --example canvas_kit_demo --features windowed
+
+use blinc_app::prelude::*;
+use blinc_app::windowed::{WindowedApp, WindowedContext};
+use blinc_canvas_kit::prelude::*;
+use blinc_core::draw::Stroke;
+use blinc_core::{
+    BlincContextState, Brush, Color, CornerRadius, DrawContext, Gradient, Point, Rect, State,
+};
+use std::f32::consts::PI;
+
+// ─── Node Data ──────────────────────────────────────────────────────────────
+
+/// (x, y, w, h, label_color, bg_color)
+type NodeDef = (f32, f32, f32, f32, Color, Color);
+
+const NODE_COUNT: usize = 6;
+
+fn initial_nodes() -> [NodeDef; NODE_COUNT] {
+    [
+        (
+            100.0,
+            150.0,
+            140.0,
+            70.0,
+            Color::rgba(0.4, 0.85, 1.0, 1.0),
+            Color::rgba(0.15, 0.25, 0.35, 0.95),
+        ),
+        (
+            350.0,
+            80.0,
+            140.0,
+            70.0,
+            Color::rgba(0.4, 1.0, 0.7, 1.0),
+            Color::rgba(0.15, 0.3, 0.2, 0.95),
+        ),
+        (
+            350.0,
+            240.0,
+            140.0,
+            70.0,
+            Color::rgba(1.0, 0.7, 0.4, 1.0),
+            Color::rgba(0.35, 0.2, 0.1, 0.95),
+        ),
+        (
+            600.0,
+            160.0,
+            140.0,
+            70.0,
+            Color::rgba(0.85, 0.5, 1.0, 1.0),
+            Color::rgba(0.25, 0.15, 0.35, 0.95),
+        ),
+        (
+            200.0,
+            400.0,
+            140.0,
+            70.0,
+            Color::rgba(1.0, 0.85, 0.4, 1.0),
+            Color::rgba(0.35, 0.3, 0.1, 0.95),
+        ),
+        (
+            500.0,
+            380.0,
+            140.0,
+            70.0,
+            Color::rgba(1.0, 0.4, 0.6, 1.0),
+            Color::rgba(0.35, 0.1, 0.15, 0.95),
+        ),
+    ]
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    let config = WindowConfig {
+        title: "Canvas Kit Demo".to_string(),
+        width: 900,
+        height: 700,
+        ..Default::default()
+    };
+
+    WindowedApp::run(config, |ctx| build_ui(ctx))
+}
+
+fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
+    div()
+        .w(ctx.width)
+        .h(ctx.height)
+        .bg(Color::rgba(0.08, 0.08, 0.12, 1.0))
+        .flex_col()
+        .child(header_bar())
+        .child(
+            div()
+                .flex_row()
+                .flex_grow()
+                .w_full()
+                .child(builder_demo_panel())
+                .child(handler_demo_panel()),
+        )
+}
+
+// ─── Header ──────────────────────────────────────────────────────────────────
+
+fn header_bar() -> Div {
+    div()
+        .w_full()
+        .h(50.0)
+        .bg(Color::rgba(0.12, 0.12, 0.18, 1.0))
+        .flex_row()
+        .items_center()
+        .justify_center()
+        .gap(20.0)
+        .child(
+            text("Canvas Kit Demo")
+                .size(22.0)
+                .weight(FontWeight::Bold)
+                .color(Color::WHITE),
+        )
+        .child(
+            text("Drag nodes to move, scroll to zoom, drag background to pan")
+                .size(13.0)
+                .color(Color::rgba(0.5, 0.5, 0.6, 1.0)),
+        )
+}
+
+// ─── Demo 1: Builder API — Draggable Node Graph ─────────────────────────────
+
+fn builder_demo_panel() -> Div {
+    let mut kit = CanvasKit::new("builder_demo");
+    kit.set_background(CanvasBackground::dots().with_zoom_adaptive(0.3, 5));
+
+    // Persistent node positions — [[x, y, w, h]; NODE_COUNT]
+    let bctx = BlincContextState::get();
+    let nodes_state: State<Vec<[f32; 4]>> = bctx.use_state_keyed("builder_nodes", || {
+        initial_nodes()
+            .iter()
+            .map(|(x, y, w, h, _, _)| [*x, *y, *w, *h])
+            .collect()
+    });
+
+    // Wire up callbacks
+    let nodes_drag = nodes_state.clone();
+    kit.on_element_drag(move |evt| {
+        let mut nodes = nodes_drag.get();
+        // Parse node index from region ID like "node_0"
+        if let Some(idx) = evt
+            .region_id
+            .strip_prefix("node_")
+            .and_then(|s| s.parse::<usize>().ok())
+        {
+            if idx < nodes.len() {
+                nodes[idx][0] += evt.content_delta.x;
+                nodes[idx][1] += evt.content_delta.y;
+                nodes_drag.set(nodes);
+            }
+        }
+    });
+
+    kit.on_element_click(move |evt| {
+        if let Some(ref id) = evt.region_id {
+            tracing::info!(
+                "Clicked {id} at content ({:.0}, {:.0})",
+                evt.content_point.x,
+                evt.content_point.y
+            );
+        }
+    });
+
+    kit.on_element_hover(move |evt| match &evt.region_id {
+        Some(id) => tracing::debug!("Hover → {id}"),
+        None => tracing::debug!("Hover → background"),
+    });
+
+    let kit_hud = kit.clone();
+    let kit_reset = kit.clone();
+    let kit_interaction = kit.clone();
+    let nodes_render = nodes_state.clone();
+    let nodes_reset = nodes_state.clone();
+
+    div()
+        .flex_grow()
+        .flex_col()
+        .m(6.0)
+        .rounded(12.0)
+        .bg(Color::rgba(0.1, 0.1, 0.15, 1.0))
+        .overflow_clip()
+        .child(panel_title("kit.element() — Draggable Node Graph"))
+        .child(
+            div()
+                .flex_grow()
+                .w_full()
+                .overflow_clip()
+                .child(kit.element(move |ctx, _bounds| {
+                    draw_interactive_node_graph(ctx, &kit_interaction, &nodes_render);
+                }))
+                .child(viewport_hud(kit_hud, "builder_hud"))
+                .child(reset_button(kit_reset, nodes_reset, "reset_button_1")),
+        )
+}
+
+// ─── Demo 2: Handler API — Interactive Shapes ───────────────────────────────
+
+fn handler_demo_panel() -> Div {
+    let mut kit = CanvasKit::new("handler_demo");
+    kit.set_background(
+        CanvasBackground::grid()
+            .with_spacing(40.0)
+            .with_zoom_adaptive(0.3, 5),
+    );
+
+    kit.on_element_click(move |evt| {
+        if let Some(ref id) = evt.region_id {
+            tracing::info!("Shape clicked: {id}");
+        }
+    });
+
+    kit.on_element_hover(move |evt| match &evt.region_id {
+        Some(id) => tracing::debug!("Shape hover → {id}"),
+        None => tracing::debug!("Shape hover → background"),
+    });
+
+    let kit_hud = kit.clone();
+    let kit_reset = kit.clone();
+    let kit_render = kit.clone();
+
+    div()
+        .flex_grow()
+        .flex_col()
+        .m(6.0)
+        .rounded(12.0)
+        .bg(Color::rgba(0.1, 0.1, 0.15, 1.0))
+        .overflow_clip()
+        .child(panel_title("kit.element() — Shape Canvas"))
+        .child(
+            div()
+                .flex_grow()
+                .w_full()
+                .overflow_clip()
+                .child(kit.element(move |ctx, _bounds| {
+                    draw_interactive_shapes(ctx, &kit_render);
+                }))
+                .child(viewport_hud(kit_hud, "handler_hud"))
+                .child(reset_button_simple(kit_reset, "reset_button_2")),
+        )
+}
+
+// ─── Drawing: Interactive Node Graph ────────────────────────────────────────
+
+fn draw_interactive_node_graph(
+    ctx: &mut dyn DrawContext,
+    kit: &CanvasKit,
+    nodes_state: &State<Vec<[f32; 4]>>,
+) {
+    let defs = initial_nodes();
+    let positions = nodes_state.get();
+    let interaction = kit.interaction();
+
+    // Connections: (from_node, to_node)
+    let connections = [(0, 1), (0, 2), (1, 3), (2, 3), (4, 5), (2, 5)];
+
+    // Draw connections first (behind nodes)
+    for (from, to) in &connections {
+        let fp = &positions[*from];
+        let tp = &positions[*to];
+
+        let start_x = fp[0] + fp[2]; // x + w
+        let start_y = fp[1] + fp[3] / 2.0; // y + h/2
+        let end_x = tp[0];
+        let end_y = tp[1] + tp[3] / 2.0;
+
+        let steps = 20;
+        for i in 0..steps {
+            let t = i as f32 / steps as f32;
+            let t_next = (i + 1) as f32 / steps as f32;
+            let mid_x = (start_x + end_x) / 2.0;
+            let x1 = bezier_cubic(t, start_x, mid_x, mid_x, end_x);
+            let y1 = bezier_cubic(t, start_y, start_y, end_y, end_y);
+            let x2 = bezier_cubic(t_next, start_x, mid_x, mid_x, end_x);
+            let y2 = bezier_cubic(t_next, start_y, start_y, end_y, end_y);
+
+            ctx.fill_rect(
+                Rect::new(
+                    x1.min(x2),
+                    y1.min(y2),
+                    (x2 - x1).abs().max(2.0),
+                    (y2 - y1).abs().max(2.0),
+                ),
+                CornerRadius::uniform(1.0),
+                Brush::Solid(Color::rgba(0.4, 0.5, 0.6, 0.4 + 0.3 * t)),
+            );
+        }
+
+        // Connection endpoints (ports)
+        let port_r = 5.0;
+        ctx.fill_rect(
+            Rect::new(
+                start_x - port_r,
+                start_y - port_r,
+                port_r * 2.0,
+                port_r * 2.0,
+            ),
+            CornerRadius::uniform(port_r),
+            Brush::Solid(Color::rgba(0.5, 0.7, 0.9, 1.0)),
+        );
+        ctx.fill_rect(
+            Rect::new(end_x - port_r, end_y - port_r, port_r * 2.0, port_r * 2.0),
+            CornerRadius::uniform(port_r),
+            Brush::Solid(Color::rgba(0.5, 0.7, 0.9, 1.0)),
+        );
+    }
+
+    // Draw nodes with hit regions
+    for (i, (pos, def)) in positions.iter().zip(defs.iter()).enumerate() {
+        let (x, y, w, h) = (pos[0], pos[1], pos[2], pos[3]);
+        let (_, _, _, _, label_color, bg_color) = def;
+        let node_id = format!("node_{i}");
+
+        let is_hovered = interaction.hovered.as_deref() == Some(node_id.as_str());
+        let is_active = interaction.active.as_deref() == Some(node_id.as_str());
+
+        // Shadow (deeper when active)
+        let shadow_offset = if is_active { 6.0 } else { 3.0 };
+        let shadow_alpha = if is_active { 0.5 } else { 0.3 };
+        ctx.fill_rect(
+            Rect::new(x + shadow_offset, y + shadow_offset, w, h),
+            CornerRadius::uniform(10.0),
+            Brush::Solid(Color::rgba(0.0, 0.0, 0.0, shadow_alpha)),
+        );
+
+        // Node body — brighter on hover
+        let hover_boost = if is_hovered || is_active { 0.08 } else { 0.0 };
+        let body_color = Color::rgba(
+            (bg_color.r + hover_boost).min(1.0),
+            (bg_color.g + hover_boost).min(1.0),
+            (bg_color.b + hover_boost).min(1.0),
+            bg_color.a,
+        );
+        ctx.fill_rect(
+            Rect::new(x, y, w, h),
+            CornerRadius::uniform(10.0),
+            Brush::Solid(body_color),
+        );
+
+        // Hover outline
+        if is_hovered || is_active {
+            let outline_alpha = if is_active { 0.6 } else { 0.3 };
+            ctx.stroke_rect(
+                Rect::new(x - 1.0, y - 1.0, w + 2.0, h + 2.0),
+                CornerRadius::uniform(11.0),
+                &Stroke::new(2.0),
+                Brush::Solid(Color::rgba(
+                    label_color.r,
+                    label_color.g,
+                    label_color.b,
+                    outline_alpha,
+                )),
+            );
+        }
+
+        // Top bar
+        ctx.fill_rect(
+            Rect::new(x, y, w, 22.0),
+            CornerRadius {
+                top_left: 10.0,
+                top_right: 10.0,
+                bottom_left: 0.0,
+                bottom_right: 0.0,
+            },
+            Brush::Solid(Color::rgba(
+                label_color.r,
+                label_color.g,
+                label_color.b,
+                0.2,
+            )),
+        );
+
+        // Status indicator dot
+        let dot_r = 4.0;
+        ctx.fill_rect(
+            Rect::new(x + 10.0, y + 7.0, dot_r * 2.0, dot_r * 2.0),
+            CornerRadius::uniform(dot_r),
+            Brush::Solid(*label_color),
+        );
+
+        // Content bars
+        for row in 0..2 {
+            let bar_y = y + 30.0 + row as f32 * 14.0;
+            let bar_w = w - 30.0 - (row as f32 * 20.0);
+            ctx.fill_rect(
+                Rect::new(x + 12.0, bar_y, bar_w, 6.0),
+                CornerRadius::uniform(3.0),
+                Brush::Solid(Color::rgba(1.0, 1.0, 1.0, 0.1)),
+            );
+        }
+
+        // Register hit region for this node
+        let node_rect = Rect::new(x, y, w, h);
+        kit.hit_rect(&node_id, node_rect);
+    }
+}
+
+// ─── Drawing: Interactive Shapes ────────────────────────────────────────────
+
+fn draw_interactive_shapes(ctx: &mut dyn DrawContext, kit: &CanvasKit) {
+    let interaction = kit.interaction();
+
+    // Circles
+    let circles: &[(&str, f32, f32, f32, Color)] = &[
+        (
+            "circle_0",
+            200.0,
+            200.0,
+            60.0,
+            Color::rgba(0.3, 0.6, 1.0, 0.7),
+        ),
+        (
+            "circle_1",
+            400.0,
+            150.0,
+            40.0,
+            Color::rgba(1.0, 0.4, 0.5, 0.7),
+        ),
+        (
+            "circle_2",
+            300.0,
+            350.0,
+            80.0,
+            Color::rgba(0.3, 0.9, 0.5, 0.5),
+        ),
+        (
+            "circle_3",
+            550.0,
+            300.0,
+            50.0,
+            Color::rgba(0.9, 0.7, 0.2, 0.6),
+        ),
+        (
+            "circle_4",
+            150.0,
+            420.0,
+            35.0,
+            Color::rgba(0.7, 0.3, 1.0, 0.6),
+        ),
+    ];
+
+    for (id, cx, cy, r, color) in circles {
+        let is_hovered = interaction.hovered.as_deref() == Some(*id);
+
+        // Shadow
+        ctx.fill_rect(
+            Rect::new(cx - r + 4.0, cy - r + 4.0, r * 2.0, r * 2.0),
+            CornerRadius::uniform(*r),
+            Brush::Solid(Color::rgba(0.0, 0.0, 0.0, 0.2)),
+        );
+
+        // Circle — boost alpha on hover
+        let alpha = if is_hovered {
+            (color.a + 0.3).min(1.0)
+        } else {
+            color.a
+        };
+        let draw_color = Color::rgba(color.r, color.g, color.b, alpha);
+        ctx.fill_rect(
+            Rect::new(cx - r, cy - r, r * 2.0, r * 2.0),
+            CornerRadius::uniform(*r),
+            Brush::Gradient(Gradient::linear(
+                Point::new(cx - r, cy - r),
+                Point::new(cx + r, cy + r),
+                draw_color,
+                Color::rgba(
+                    draw_color.r * 0.6,
+                    draw_color.g * 0.6,
+                    draw_color.b * 0.6,
+                    draw_color.a,
+                ),
+            )),
+        );
+
+        // Hover outline
+        if is_hovered {
+            ctx.stroke_rect(
+                Rect::new(cx - r - 2.0, cy - r - 2.0, r * 2.0 + 4.0, r * 2.0 + 4.0),
+                CornerRadius::uniform(r + 2.0),
+                &Stroke::new(2.0),
+                Brush::Solid(Color::rgba(1.0, 1.0, 1.0, 0.4)),
+            );
+        }
+
+        // Hit region (bounding box of the circle)
+        kit.hit_rect(*id, Rect::new(cx - r, cy - r, r * 2.0, r * 2.0));
+    }
+
+    // Rectangles
+    let rects: &[(&str, f32, f32, f32, f32, Color)] = &[
+        (
+            "rect_0",
+            80.0,
+            100.0,
+            100.0,
+            60.0,
+            Color::rgba(1.0, 0.6, 0.2, 0.6),
+        ),
+        (
+            "rect_1",
+            450.0,
+            400.0,
+            120.0,
+            80.0,
+            Color::rgba(0.2, 0.7, 0.9, 0.6),
+        ),
+        (
+            "rect_2",
+            600.0,
+            100.0,
+            80.0,
+            120.0,
+            Color::rgba(0.8, 0.3, 0.8, 0.6),
+        ),
+    ];
+
+    for (id, x, y, w, h, color) in rects {
+        let is_hovered = interaction.hovered.as_deref() == Some(*id);
+
+        ctx.fill_rect(
+            Rect::new(x + 3.0, y + 3.0, *w, *h),
+            CornerRadius::uniform(8.0),
+            Brush::Solid(Color::rgba(0.0, 0.0, 0.0, 0.2)),
+        );
+
+        let alpha = if is_hovered {
+            (color.a + 0.3).min(1.0)
+        } else {
+            color.a
+        };
+        ctx.fill_rect(
+            Rect::new(*x, *y, *w, *h),
+            CornerRadius::uniform(8.0),
+            Brush::Solid(Color::rgba(color.r, color.g, color.b, alpha)),
+        );
+
+        if is_hovered {
+            ctx.stroke_rect(
+                Rect::new(x - 2.0, y - 2.0, w + 4.0, h + 4.0),
+                CornerRadius::uniform(10.0),
+                &Stroke::new(2.0),
+                Brush::Solid(Color::rgba(1.0, 1.0, 1.0, 0.4)),
+            );
+        }
+
+        kit.hit_rect(*id, Rect::new(*x, *y, *w, *h));
+    }
+
+    // Star
+    draw_star(
+        ctx,
+        350.0,
+        280.0,
+        45.0,
+        20.0,
+        5,
+        Color::rgba(1.0, 0.9, 0.3, 0.8),
+    );
+    kit.hit_rect("star", Rect::new(350.0 - 45.0, 280.0 - 45.0, 90.0, 90.0));
+
+    // Crosshair at origin
+    let cross_color = Brush::Solid(Color::rgba(1.0, 0.3, 0.3, 0.5));
+    ctx.fill_rect(
+        Rect::new(-1.0, -20.0, 2.0, 40.0),
+        0.0.into(),
+        cross_color.clone(),
+    );
+    ctx.fill_rect(Rect::new(-20.0, -1.0, 40.0, 2.0), 0.0.into(), cross_color);
+}
+
+// ─── Drawing Helpers ────────────────────────────────────────────────────────
+
+fn draw_star(
+    ctx: &mut dyn DrawContext,
+    cx: f32,
+    cy: f32,
+    outer_r: f32,
+    _inner_r: f32,
+    points: usize,
+    color: Color,
+) {
+    for i in 0..points {
+        let angle = (i as f32 / points as f32) * PI * 2.0 - PI / 2.0;
+        let ox = cx + outer_r * angle.cos();
+        let oy = cy + outer_r * angle.sin();
+        let w = 6.0;
+
+        ctx.fill_rect(
+            Rect::new(
+                cx.min(ox) - w / 2.0,
+                cy.min(oy) - w / 2.0,
+                (ox - cx).abs() + w,
+                (oy - cy).abs() + w,
+            ),
+            CornerRadius::uniform(w / 2.0),
+            Brush::Solid(color),
+        );
+    }
+
+    ctx.fill_rect(
+        Rect::new(cx - 8.0, cy - 8.0, 16.0, 16.0),
+        CornerRadius::uniform(8.0),
+        Brush::Solid(color),
+    );
+}
+
+fn bezier_cubic(t: f32, p0: f32, p1: f32, p2: f32, p3: f32) -> f32 {
+    let mt = 1.0 - t;
+    mt * mt * mt * p0 + 3.0 * mt * mt * t * p1 + 3.0 * mt * t * t * p2 + t * t * t * p3
+}
+
+// ─── UI Overlays ─────────────────────────────────────────────────────────────
+
+fn panel_title(label: &str) -> Div {
+    div()
+        .w_full()
+        .h(32.0)
+        .bg(Color::rgba(0.15, 0.15, 0.22, 1.0))
+        .flex_row()
+        .items_center()
+        .px(12.0)
+        .child(
+            text(label)
+                .size(13.0)
+                .weight(FontWeight::SemiBold)
+                .color(Color::rgba(0.7, 0.7, 0.8, 1.0)),
+        )
+}
+
+fn viewport_hud(kit: CanvasKit, unique_key: &str) -> Stateful<NoState> {
+    let signal = kit.viewport_signal();
+    stateful_with_key::<NoState>(unique_key)
+        .deps([signal])
+        .on_state(move |_ctx| {
+            let vp = kit.viewport();
+            let zoom_pct = (vp.zoom * 100.0) as i32;
+
+            div()
+                .absolute()
+                .left(8.0)
+                .top(40.0)
+                .bg(Color::rgba(0.0, 0.0, 0.0, 0.6))
+                .rounded(6.0)
+                .px(8.0)
+                .py(4.0)
+                .flex_col()
+                .gap(2.0)
+                .child(
+                    text(format!("Zoom: {}%", zoom_pct))
+                        .size(11.0)
+                        .color(Color::rgba(0.6, 0.8, 1.0, 1.0)),
+                )
+                .child(
+                    text(format!("Pan: ({:.0}, {:.0})", vp.pan_x, vp.pan_y))
+                        .size(11.0)
+                        .color(Color::rgba(0.6, 0.8, 1.0, 1.0)),
+                )
+        })
+}
+
+fn reset_button(
+    kit: CanvasKit,
+    nodes_state: State<Vec<[f32; 4]>>,
+    unique_key: &str,
+) -> Stateful<ButtonState> {
+    stateful_with_key::<ButtonState>(unique_key).on_state(move |ctx| {
+        let bg = match ctx.state() {
+            ButtonState::Idle => Color::rgba(0.2, 0.2, 0.3, 0.8),
+            ButtonState::Hovered => Color::rgba(0.3, 0.3, 0.45, 0.9),
+            _ => Color::rgba(0.15, 0.15, 0.25, 0.8),
+        };
+
+        if let Some(evt) = ctx.event() {
+            if evt.event_type == blinc_core::events::event_types::POINTER_UP {
+                kit.update_viewport(|vp| vp.reset());
+                // Also reset node positions
+                let reset_positions: Vec<[f32; 4]> = initial_nodes()
+                    .iter()
+                    .map(|(x, y, w, h, _, _)| [*x, *y, *w, *h])
+                    .collect();
+                nodes_state.set(reset_positions);
+            }
+        }
+
+        div()
+            .absolute()
+            .left(8.0)
+            .top(120.0)
+            .bg(bg)
+            .rounded(6.0)
+            .px(10.0)
+            .py(4.0)
+            .child(
+                text("Reset")
+                    .size(11.0)
+                    .color(Color::rgba(0.8, 0.8, 0.9, 1.0)),
+            )
+    })
+}
+
+fn reset_button_simple(kit: CanvasKit, unique_key: &str) -> Stateful<ButtonState> {
+    stateful_with_key::<ButtonState>(unique_key).on_state(move |ctx| {
+        let bg = match ctx.state() {
+            ButtonState::Idle => Color::rgba(0.2, 0.2, 0.3, 0.8),
+            ButtonState::Hovered => Color::rgba(0.3, 0.3, 0.45, 0.9),
+            _ => Color::rgba(0.15, 0.15, 0.25, 0.8),
+        };
+
+        if let Some(evt) = ctx.event() {
+            if evt.event_type == blinc_core::events::event_types::POINTER_UP {
+                kit.update_viewport(|vp| vp.reset());
+            }
+        }
+
+        div()
+            .absolute()
+            .left(8.0)
+            .top(120.0)
+            .bg(bg)
+            .rounded(6.0)
+            .px(10.0)
+            .py(4.0)
+            .child(
+                text("Reset")
+                    .size(11.0)
+                    .color(Color::rgba(0.8, 0.8, 0.9, 1.0)),
+            )
+    })
+}

--- a/crates/blinc_app/examples/css_debug.rs
+++ b/crates/blinc_app/examples/css_debug.rs
@@ -1,0 +1,286 @@
+//! CSS Debug Example
+//!
+//! Tests three known CSS issues:
+//! 1. var() not picking up values from :root
+//! 2. width/height percentage not working
+//! 3. Text not inheriting color from parent div
+//!
+//! Run with: cargo run -p blinc_app --example css_debug --features windowed
+
+use blinc_app::prelude::*;
+use blinc_app::windowed::{WindowedApp, WindowedContext};
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .init();
+
+    let config = WindowConfig {
+        title: "CSS Debug — var(), %, color inheritance".to_string(),
+        width: 900,
+        height: 700,
+        resizable: true,
+        ..Default::default()
+    };
+
+    let mut css_loaded = false;
+    WindowedApp::run(config, move |ctx| {
+        if !css_loaded {
+            ctx.add_css(STYLESHEET);
+            css_loaded = true;
+        }
+        build_ui(ctx)
+    })
+}
+
+const STYLESHEET: &str = r#"
+        :root {
+            --brand-color: #3b82f6;
+            --accent-color: #f59e0b;
+            --text-color: #ffffff;
+            --card-radius: 16px;
+            --card-padding: 24px;
+        }
+
+        /* === TEST 1: var() from :root === */
+        #var-test {
+            background: var(--brand-color);
+            border-radius: var(--card-radius);
+            padding: var(--card-padding);
+        }
+
+        #var-test-accent {
+            background: var(--accent-color);
+            border-radius: 12px;
+            padding: 16px;
+        }
+
+        #var-test-fallback {
+            background: var(--nonexistent, #ef4444);
+            border-radius: 12px;
+            padding: 16px;
+        }
+
+        /* === TEST 2: Percentage width/height === */
+        #percent-container {
+            background: #1e293b;
+            border-radius: 12px;
+            padding: 16px;
+        }
+
+        #percent-half {
+            width: 50%;
+            background: #3b82f6;
+            border-radius: 8px;
+            padding: 12px;
+        }
+
+        #percent-full {
+            width: 100%;
+            background: #8b5cf6;
+            border-radius: 8px;
+            padding: 12px;
+        }
+
+        #percent-third {
+            width: 33.3%;
+            background: #10b981;
+            border-radius: 8px;
+            padding: 12px;
+        }
+
+        /* === TEST 3: Text color inheritance === */
+        #inherit-parent {
+            color: #3b82f6;
+            background: #1e293b;
+            border-radius: 12px;
+            padding: 16px;
+        }
+
+        #inherit-nested {
+            color: #f59e0b;
+        }
+
+        .white-text {
+            color: #ffffff;
+        }
+
+        /* Section styles */
+        #root {
+            background: #0f172a;
+        }
+
+        .section {
+            background: #1e293b;
+            border-radius: 16px;
+            padding: 24px;
+        }
+"#;
+
+fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
+    div()
+        .w(ctx.width)
+        .h(ctx.height)
+        .id("root")
+        .flex_col()
+        .gap(5.0)
+        .p(5.0)
+        .overflow_y_scroll()
+        .child(
+            text("CSS Debug Tests")
+                .size(28.0)
+                .weight(FontWeight::Bold)
+                .color(Color::WHITE),
+        )
+        .child(test_var_from_root())
+        .child(test_percentage_dimensions())
+        .child(test_color_inheritance())
+}
+
+/// TEST 1: var() should resolve values defined in :root
+fn test_var_from_root() -> impl ElementBuilder {
+    div()
+        .class("section")
+        .flex_col()
+        .gap(3.0)
+        .child(
+            div().child(
+                text("Test 1: var() from :root")
+                    .size(20.0)
+                    .weight(FontWeight::Bold)
+                    .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
+            ),
+        )
+        .child(
+            div()
+                .flex_row()
+                .gap(3.0)
+                // Should be blue (#3b82f6) from --brand-color
+                .child(
+                    div().id("var-test").child(
+                        text("var(--brand-color)\nExpect: Blue bg")
+                            .size(14.0)
+                            .color(Color::WHITE),
+                    ),
+                )
+                // Should be amber (#f59e0b) from --accent-color
+                .child(
+                    div().id("var-test-accent").child(
+                        text("var(--accent-color)\nExpect: Amber bg")
+                            .size(14.0)
+                            .color(Color::WHITE),
+                    ),
+                )
+                // Should be red (#ef4444) from fallback
+                .child(
+                    div().id("var-test-fallback").child(
+                        text("var(--nonexistent, #ef4444)\nExpect: Red bg (fallback)")
+                            .size(14.0)
+                            .color(Color::WHITE),
+                    ),
+                ),
+        )
+}
+
+/// TEST 2: Percentage width/height should work in CSS
+fn test_percentage_dimensions() -> impl ElementBuilder {
+    div()
+        .class("section")
+        .flex_col()
+        .gap(3.0)
+        .child(
+            div().child(
+                text("Test 2: Percentage Width")
+                    .size(20.0)
+                    .weight(FontWeight::Bold)
+                    .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
+            ),
+        )
+        .child(
+            div()
+                .id("percent-container")
+                .w_full()
+                .flex_col()
+                .gap(2.0)
+                // 50% width
+                .child(
+                    div().id("percent-half").child(
+                        text("width: 50% — should be half")
+                            .size(14.0)
+                            .color(Color::WHITE),
+                    ),
+                )
+                // 100% width
+                .child(
+                    div().id("percent-full").child(
+                        text("width: 100% — should be full")
+                            .size(14.0)
+                            .color(Color::WHITE),
+                    ),
+                )
+                // 33.3% width
+                .child(
+                    div().id("percent-third").child(
+                        text("width: 33.3% — should be one-third")
+                            .size(14.0)
+                            .color(Color::WHITE),
+                    ),
+                ),
+        )
+}
+
+/// TEST 3: Text should inherit color from parent div
+fn test_color_inheritance() -> impl ElementBuilder {
+    div()
+        .class("section")
+        .flex_col()
+        .gap(3.0)
+        .child(
+            div().child(
+                text("Test 3: Text Color Inheritance")
+                    .size(20.0)
+                    .weight(FontWeight::Bold)
+                    .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
+            ),
+        )
+        .child(
+            div()
+                .flex_col()
+                .gap(2.0)
+                // Parent has color: blue — child text should inherit it
+                .child(
+                    div()
+                        .id("inherit-parent")
+                        .flex_col()
+                        .gap(2.0)
+                        .child(
+                            text("This text should be BLUE (inherited from parent #inherit-parent { color: #3b82f6 })")
+                                .size(14.0),
+                        )
+                        // Nested div with its own color
+                        .child(
+                            div()
+                                .id("inherit-nested")
+                                .child(
+                                    text("This text should be AMBER (inherited from #inherit-nested { color: #f59e0b })")
+                                        .size(14.0),
+                                ),
+                        ),
+                )
+                // Class-based color
+                .child(
+                    div()
+                        .class("white-text")
+                        .child(
+                            text("This text should be WHITE (inherited from .white-text { color: #fff })")
+                                .size(14.0),
+                        ),
+                )
+                // Control: direct color on text (should always work)
+                .child(
+                    text("Control: direct .color(Color::GREEN) — should be green")
+                        .size(14.0)
+                        .color(Color::GREEN),
+                ),
+        )
+}

--- a/crates/blinc_app/examples/css_debug.rs
+++ b/crates/blinc_app/examples/css_debug.rs
@@ -9,6 +9,7 @@
 
 use blinc_app::prelude::*;
 use blinc_app::windowed::{WindowedApp, WindowedContext};
+use blinc_core::State;
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -115,9 +116,51 @@ const STYLESHEET: &str = r#"
             border-radius: 16px;
             padding: 24px;
         }
+
+        /* === TEST 4: CSS inside stateful containers === */
+        #sf-var-test {
+            background: var(--brand-color);
+            border-radius: 12px;
+            padding: 16px;
+        }
+
+        #sf-percent-container {
+            background: #1e293b;
+            border-radius: 8px;
+            padding: 12px;
+        }
+
+        #sf-percent-half {
+            width: 50%;
+            background: #3b82f6;
+            border-radius: 8px;
+            padding: 12px;
+        }
+
+        #sf-percent-third {
+            width: 33.3%;
+            background: #10b981;
+            border-radius: 8px;
+            padding: 12px;
+        }
+
+        #sf-color-parent {
+            color: #10b981;
+            background: #1e293b;
+            border-radius: 8px;
+            padding: 12px;
+        }
+
+        .sf-card {
+            background: #7c3aed;
+            border-radius: 12px;
+            padding: 16px;
+        }
 "#;
 
 fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
+    let count = ctx.use_state_keyed("rebuild-trigger", || 0i32);
+
     div()
         .w(ctx.width)
         .h(ctx.height)
@@ -127,160 +170,334 @@ fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
         .p(5.0)
         .overflow_y_scroll()
         .child(
-            text("CSS Debug Tests")
-                .size(28.0)
-                .weight(FontWeight::Bold)
-                .color(Color::WHITE),
-        )
-        .child(test_var_from_root())
-        .child(test_percentage_dimensions())
-        .child(test_color_inheritance())
-}
-
-/// TEST 1: var() should resolve values defined in :root
-fn test_var_from_root() -> impl ElementBuilder {
-    div()
-        .class("section")
-        .flex_col()
-        .gap(3.0)
-        .child(
-            div().child(
-                text("Test 1: var() from :root")
-                    .size(20.0)
-                    .weight(FontWeight::Bold)
-                    .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
-            ),
-        )
-        .child(
             div()
                 .flex_row()
+                .items_center()
+                .gap(4.0)
+                .child(
+                    text("CSS Debug Tests (inside stateful containers)")
+                        .size(28.0)
+                        .weight(FontWeight::Bold)
+                        .color(Color::WHITE),
+                )
+                // Button to trigger rebuild
+                .child(rebuild_button(count.clone())),
+        )
+        // All tests wrapped in stateful containers
+        .child(test_var_from_root_stateful(count.clone()))
+        .child(test_percentage_stateful(count.clone()))
+        .child(test_color_inheritance_stateful(count.clone()))
+        .child(test_layout_stateful())
+        .child(test_inner_click_persistence(ctx, count.clone()))
+}
+
+/// Rebuild trigger button — click to force stateful containers to re-run on_state
+fn rebuild_button(count: State<i32>) -> impl ElementBuilder {
+    let count_click = count.clone();
+    stateful::<NoState>()
+        .deps([count.signal_id()])
+        .on_state(move |_ctx| {
+            let n = count.get();
+            div()
+                .bg(Color::rgba(0.23, 0.51, 0.96, 1.0))
+                .rounded(8.0)
+                .p(2.0)
+                .px(4.0)
+                .child(
+                    text(&format!("Rebuild ({})", n))
+                        .size(16.0)
+                        .weight(FontWeight::Bold)
+                        .color(Color::WHITE),
+                )
+        })
+        .on_click(move |_| {
+            count_click.set(count_click.get() + 1);
+        })
+}
+
+/// TEST 1: var() from :root inside stateful
+fn test_var_from_root_stateful(count: State<i32>) -> impl ElementBuilder {
+    stateful::<NoState>()
+        .deps([count.signal_id()])
+        .on_state(move |_ctx| {
+            div()
+                .class("section")
+                .flex_col()
                 .gap(3.0)
-                // Should be blue (#3b82f6) from --brand-color
                 .child(
-                    div().id("var-test").child(
-                        text("var(--brand-color)\nExpect: Blue bg")
-                            .size(14.0)
-                            .color(Color::WHITE),
+                    div().child(
+                        text("Test 1: var() from :root (stateful)")
+                            .size(20.0)
+                            .weight(FontWeight::Bold)
+                            .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
                     ),
                 )
-                // Should be amber (#f59e0b) from --accent-color
-                .child(
-                    div().id("var-test-accent").child(
-                        text("var(--accent-color)\nExpect: Amber bg")
-                            .size(14.0)
-                            .color(Color::WHITE),
-                    ),
-                )
-                // Should be red (#ef4444) from fallback
-                .child(
-                    div().id("var-test-fallback").child(
-                        text("var(--nonexistent, #ef4444)\nExpect: Red bg (fallback)")
-                            .size(14.0)
-                            .color(Color::WHITE),
-                    ),
-                ),
-        )
-}
-
-/// TEST 2: Percentage width/height should work in CSS
-fn test_percentage_dimensions() -> impl ElementBuilder {
-    div()
-        .class("section")
-        .flex_col()
-        .gap(3.0)
-        .child(
-            div().child(
-                text("Test 2: Percentage Width")
-                    .size(20.0)
-                    .weight(FontWeight::Bold)
-                    .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
-            ),
-        )
-        .child(
-            div()
-                .id("percent-container")
-                .w_full()
-                .flex_col()
-                .gap(2.0)
-                // 50% width
-                .child(
-                    div().id("percent-half").child(
-                        text("width: 50% — should be half")
-                            .size(14.0)
-                            .color(Color::WHITE),
-                    ),
-                )
-                // 100% width
-                .child(
-                    div().id("percent-full").child(
-                        text("width: 100% — should be full")
-                            .size(14.0)
-                            .color(Color::WHITE),
-                    ),
-                )
-                // 33.3% width
-                .child(
-                    div().id("percent-third").child(
-                        text("width: 33.3% — should be one-third")
-                            .size(14.0)
-                            .color(Color::WHITE),
-                    ),
-                ),
-        )
-}
-
-/// TEST 3: Text should inherit color from parent div
-fn test_color_inheritance() -> impl ElementBuilder {
-    div()
-        .class("section")
-        .flex_col()
-        .gap(3.0)
-        .child(
-            div().child(
-                text("Test 3: Text Color Inheritance")
-                    .size(20.0)
-                    .weight(FontWeight::Bold)
-                    .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
-            ),
-        )
-        .child(
-            div()
-                .flex_col()
-                .gap(2.0)
-                // Parent has color: blue — child text should inherit it
                 .child(
                     div()
-                        .id("inherit-parent")
+                        .flex_row()
+                        .gap(3.0)
+                        .child(
+                            div().id("var-test").child(
+                                text("var(--brand-color)\nExpect: Blue bg")
+                                    .size(14.0)
+                                    .color(Color::WHITE),
+                            ),
+                        )
+                        .child(
+                            div().id("var-test-accent").child(
+                                text("var(--accent-color)\nExpect: Amber bg")
+                                    .size(14.0)
+                                    .color(Color::WHITE),
+                            ),
+                        )
+                        .child(
+                            div().id("var-test-fallback").child(
+                                text("var(--nonexistent, #ef4444)\nExpect: Red bg (fallback)")
+                                    .size(14.0)
+                                    .color(Color::WHITE),
+                            ),
+                        ),
+                )
+        })
+}
+
+/// TEST 2: Percentage width inside stateful
+fn test_percentage_stateful(count: State<i32>) -> impl ElementBuilder {
+    stateful::<NoState>()
+        .deps([count.signal_id()])
+        .on_state(move |_ctx| {
+            div()
+                .class("section")
+                .flex_col()
+                .gap(3.0)
+                .child(
+                    div().child(
+                        text("Test 2: Percentage Width (stateful)")
+                            .size(20.0)
+                            .weight(FontWeight::Bold)
+                            .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
+                    ),
+                )
+                .child(
+                    div()
+                        .id("percent-container")
+                        .w_full()
                         .flex_col()
                         .gap(2.0)
                         .child(
-                            text("This text should be BLUE (inherited from parent #inherit-parent { color: #3b82f6 })")
-                                .size(14.0),
+                            div().id("percent-half").child(
+                                text("width: 50% — should be half")
+                                    .size(14.0)
+                                    .color(Color::WHITE),
+                            ),
                         )
-                        // Nested div with its own color
                         .child(
-                            div()
-                                .id("inherit-nested")
-                                .child(
-                                    text("This text should be AMBER (inherited from #inherit-nested { color: #f59e0b })")
-                                        .size(14.0),
-                                ),
+                            div().id("percent-full").child(
+                                text("width: 100% — should be full")
+                                    .size(14.0)
+                                    .color(Color::WHITE),
+                            ),
+                        )
+                        .child(
+                            div().id("percent-third").child(
+                                text("width: 33.3% — should be one-third")
+                                    .size(14.0)
+                                    .color(Color::WHITE),
+                            ),
                         ),
                 )
-                // Class-based color
+        })
+}
+
+/// TEST 3: Text color inheritance inside stateful
+fn test_color_inheritance_stateful(count: State<i32>) -> impl ElementBuilder {
+    stateful::<NoState>()
+        .deps([count.signal_id()])
+        .on_state(move |_ctx| {
+            div()
+                .class("section")
+                .flex_col()
+                .gap(3.0)
+                .child(
+                    div().child(
+                        text("Test 3: Color Inheritance (stateful)")
+                            .size(20.0)
+                            .weight(FontWeight::Bold)
+                            .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
+                    ),
+                )
                 .child(
                     div()
-                        .class("white-text")
+                        .flex_col()
+                        .gap(2.0)
                         .child(
-                            text("This text should be WHITE (inherited from .white-text { color: #fff })")
+                            div()
+                                .id("inherit-parent")
+                                .flex_col()
+                                .gap(2.0)
+                                .child(
+                                    text("Should be BLUE (inherited from #inherit-parent { color: #3b82f6 })")
+                                        .size(14.0),
+                                )
+                                .child(
+                                    div()
+                                        .id("inherit-nested")
+                                        .child(
+                                            text("Should be AMBER (inherited from #inherit-nested { color: #f59e0b })")
+                                                .size(14.0),
+                                        ),
+                                ),
+                        )
+                        .child(
+                            div()
+                                .class("white-text")
+                                .child(
+                                    text("Should be WHITE (inherited from .white-text { color: #fff })")
+                                        .size(14.0),
+                                ),
+                        )
+                        .child(
+                            text("Control: direct .color(Color::GREEN) — should be green")
+                                .size(14.0)
+                                .color(Color::GREEN),
+                        ),
+                )
+        })
+}
+
+/// TEST 4: CSS layout properties inside stateful (no hover — pure layout test)
+fn test_layout_stateful() -> impl ElementBuilder {
+    stateful::<NoState>()
+        .on_state(|_ctx| {
+            div()
+                .class("section")
+                .flex_col()
+                .gap(3.0)
+                .child(
+                    div().child(
+                        text("Test 4: CSS Layout in stateful (class, var, %, color)")
+                            .size(20.0)
+                            .weight(FontWeight::Bold)
+                            .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
+                    ),
+                )
+                // var() test
+                .child(
+                    div()
+                        .id("sf-var-test")
+                        .child(
+                            text("var(--brand-color) bg inside stateful")
+                                .size(14.0)
+                                .color(Color::WHITE),
+                        ),
+                )
+                // Percentage width test
+                .child(
+                    div()
+                        .id("sf-percent-container")
+                        .flex_col()
+                        .gap(2.0)
+                        .child(
+                            div().id("sf-percent-half").child(
+                                text("width: 50% inside stateful")
+                                    .size(14.0)
+                                    .color(Color::WHITE),
+                            ),
+                        )
+                        .child(
+                            div().id("sf-percent-third").child(
+                                text("width: 33.3% inside stateful")
+                                    .size(14.0)
+                                    .color(Color::WHITE),
+                            ),
+                        ),
+                )
+                // Color inheritance test
+                .child(
+                    div()
+                        .id("sf-color-parent")
+                        .child(
+                            text("Should be GREEN (inherited from #sf-color-parent { color: #10b981 })")
                                 .size(14.0),
                         ),
                 )
-                // Control: direct color on text (should always work)
+                // Class-based styling test
                 .child(
-                    text("Control: direct .color(Color::GREEN) — should be green")
+                    div()
+                        .class("sf-card")
+                        .child(
+                            text(".sf-card class styling inside stateful")
+                                .size(14.0)
+                                .color(Color::WHITE),
+                        ),
+                )
+        })
+}
+
+/// TEST 5: Inner child click handlers persist across stateful rebuilds
+///
+/// This tests that on_click handlers attached to children INSIDE on_state
+/// callbacks survive when the parent stateful container rebuilds due to
+/// signal changes. The inner buttons should remain clickable after pressing
+/// the main "Rebuild" button.
+fn test_inner_click_persistence(ctx: &WindowedContext, count: State<i32>) -> impl ElementBuilder {
+    let inner_count = ctx.use_state_keyed("inner-click-count", || 0i32);
+    let inner_count_for_state = inner_count.clone();
+    let inner_count_click = inner_count.clone();
+
+    stateful::<NoState>()
+        .deps([count.signal_id(), inner_count.signal_id()])
+        .on_state(move |_ctx| {
+            let n = count.get();
+            let clicks = inner_count_for_state.get();
+            div()
+                .class("section")
+                .flex_col()
+                .gap(3.0)
+                .child(
+                    div().child(
+                        text("Test 5: Inner Child Click Persistence")
+                            .size(20.0)
+                            .weight(FontWeight::Bold)
+                            .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
+                    ),
+                )
+                .child(
+                    div().child(
+                        text(&format!(
+                            "Parent rebuild count: {} | Inner click count: {}",
+                            n, clicks
+                        ))
                         .size(14.0)
-                        .color(Color::GREEN),
-                ),
-        )
+                        .color(Color::WHITE),
+                    ),
+                )
+                // Inner clickable button — this handler should persist across rebuilds
+                .child(
+                    div()
+                        .bg(Color::rgba(0.08, 0.65, 0.51, 1.0))
+                        .rounded(8.0)
+                        .p(3.0)
+                        .px(4.0)
+                        .child(
+                            text("Click me (inner child handler)")
+                                .size(16.0)
+                                .weight(FontWeight::Bold)
+                                .color(Color::WHITE),
+                        )
+                        .on_click({
+                            let ic = inner_count_click.clone();
+                            move |_| {
+                                ic.set(ic.get() + 1);
+                            }
+                        }),
+                )
+                .child(
+                    div().child(
+                        text("After pressing 'Rebuild', this inner button should still work")
+                            .size(12.0)
+                            .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
+                    ),
+                )
+        })
 }

--- a/crates/blinc_app/examples/css_debug.rs
+++ b/crates/blinc_app/examples/css_debug.rs
@@ -367,71 +367,64 @@ fn test_color_inheritance_stateful(count: State<i32>) -> impl ElementBuilder {
 
 /// TEST 4: CSS layout properties inside stateful (no hover — pure layout test)
 fn test_layout_stateful() -> impl ElementBuilder {
-    stateful::<NoState>()
-        .on_state(|_ctx| {
-            div()
-                .class("section")
-                .flex_col()
-                .gap(3.0)
-                .child(
-                    div().child(
-                        text("Test 4: CSS Layout in stateful (class, var, %, color)")
-                            .size(20.0)
-                            .weight(FontWeight::Bold)
-                            .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
+    stateful::<NoState>().on_state(|_ctx| {
+        div()
+            .class("section")
+            .flex_col()
+            .gap(3.0)
+            .child(
+                div().child(
+                    text("Test 4: CSS Layout in stateful (class, var, %, color)")
+                        .size(20.0)
+                        .weight(FontWeight::Bold)
+                        .color(Color::rgba(0.58, 0.64, 0.72, 1.0)),
+                ),
+            )
+            // var() test
+            .child(
+                div().id("sf-var-test").child(
+                    text("var(--brand-color) bg inside stateful")
+                        .size(14.0)
+                        .color(Color::WHITE),
+                ),
+            )
+            // Percentage width test
+            .child(
+                div()
+                    .id("sf-percent-container")
+                    .flex_col()
+                    .gap(2.0)
+                    .child(
+                        div().id("sf-percent-half").child(
+                            text("width: 50% inside stateful")
+                                .size(14.0)
+                                .color(Color::WHITE),
+                        ),
+                    )
+                    .child(
+                        div().id("sf-percent-third").child(
+                            text("width: 33.3% inside stateful")
+                                .size(14.0)
+                                .color(Color::WHITE),
+                        ),
                     ),
-                )
-                // var() test
-                .child(
-                    div()
-                        .id("sf-var-test")
-                        .child(
-                            text("var(--brand-color) bg inside stateful")
-                                .size(14.0)
-                                .color(Color::WHITE),
-                        ),
-                )
-                // Percentage width test
-                .child(
-                    div()
-                        .id("sf-percent-container")
-                        .flex_col()
-                        .gap(2.0)
-                        .child(
-                            div().id("sf-percent-half").child(
-                                text("width: 50% inside stateful")
-                                    .size(14.0)
-                                    .color(Color::WHITE),
-                            ),
-                        )
-                        .child(
-                            div().id("sf-percent-third").child(
-                                text("width: 33.3% inside stateful")
-                                    .size(14.0)
-                                    .color(Color::WHITE),
-                            ),
-                        ),
-                )
-                // Color inheritance test
-                .child(
-                    div()
-                        .id("sf-color-parent")
-                        .child(
-                            text("Should be GREEN (inherited from #sf-color-parent { color: #10b981 })")
-                                .size(14.0),
-                        ),
-                )
-                // Class-based styling test
-                .child(
-                    div()
-                        .class("sf-card")
-                        .child(
-                            text(".sf-card class styling inside stateful")
-                                .size(14.0)
-                                .color(Color::WHITE),
-                        ),
-                )
-        })
+            )
+            // Color inheritance test
+            .child(
+                div().id("sf-color-parent").child(
+                    text("Should be GREEN (inherited from #sf-color-parent { color: #10b981 })")
+                        .size(14.0),
+                ),
+            )
+            // Class-based styling test
+            .child(
+                div().class("sf-card").child(
+                    text(".sf-card class styling inside stateful")
+                        .size(14.0)
+                        .color(Color::WHITE),
+                ),
+            )
+    })
 }
 
 /// TEST 5: Inner child click handlers persist across stateful rebuilds

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -498,7 +498,10 @@ pub type SharedAnimationScheduler = Arc<Mutex<AnimationScheduler>>;
 
 // SharedAnimatedValue and SharedAnimatedTimeline are re-exported from blinc_animation
 
-#[cfg(all(feature = "windowed", not(target_os = "android")))]
+#[cfg(all(
+    feature = "windowed",
+    not(any(target_os = "android", target_os = "ios", target_os = "fuchsia"))
+))]
 use blinc_platform_desktop::DesktopPlatform;
 
 /// Shared dirty flag type for element refs
@@ -1968,7 +1971,10 @@ impl WindowedApp {
     ///
     /// On desktop, this sets up a filesystem-based loader.
     /// On Android, this would use the NDK AssetManager.
-    #[cfg(all(feature = "windowed", not(target_os = "android")))]
+    #[cfg(all(
+        feature = "windowed",
+        not(any(target_os = "android", target_os = "ios", target_os = "fuchsia"))
+    ))]
     fn init_asset_loader() {
         use blinc_platform::assets::{set_global_asset_loader, FilesystemAssetLoader};
 
@@ -1985,7 +1991,10 @@ impl WindowedApp {
     /// - Platform-appropriate theme bundle (macOS, Windows, Linux, etc.)
     /// - System color scheme detection (light/dark mode)
     /// - Redraw callback to trigger UI updates on theme changes
-    #[cfg(all(feature = "windowed", not(target_os = "android")))]
+    #[cfg(all(
+        feature = "windowed",
+        not(any(target_os = "android", target_os = "ios", target_os = "fuchsia"))
+    ))]
     fn init_theme() {
         use blinc_theme::{
             detect_system_color_scheme, platform_theme_bundle, set_redraw_callback, ThemeState,
@@ -2009,7 +2018,10 @@ impl WindowedApp {
         });
     }
 
-    #[cfg(all(feature = "windowed", not(target_os = "android")))]
+    #[cfg(all(
+        feature = "windowed",
+        not(any(target_os = "android", target_os = "ios", target_os = "fuchsia"))
+    ))]
     fn init_i18n() {
         use blinc_i18n::I18nState;
 
@@ -2068,7 +2080,10 @@ impl WindowedApp {
     ///         )
     /// })
     /// ```
-    #[cfg(all(feature = "windowed", not(target_os = "android")))]
+    #[cfg(all(
+        feature = "windowed",
+        not(any(target_os = "android", target_os = "ios", target_os = "fuchsia"))
+    ))]
     pub fn run<F, E>(config: WindowConfig, ui_builder: F) -> Result<()>
     where
         F: FnMut(&mut WindowedContext) -> E + 'static,
@@ -2077,7 +2092,10 @@ impl WindowedApp {
         Self::run_desktop(config, ui_builder)
     }
 
-    #[cfg(all(feature = "windowed", not(target_os = "android")))]
+    #[cfg(all(
+        feature = "windowed",
+        not(any(target_os = "android", target_os = "ios", target_os = "fuchsia"))
+    ))]
     fn run_desktop<F, E>(config: WindowConfig, mut ui_builder: F) -> Result<()>
     where
         F: FnMut(&mut WindowedContext) -> E + 'static,
@@ -3995,7 +4013,10 @@ impl WindowedApp {
 }
 
 /// Convert platform mouse button to layout mouse button
-#[cfg(all(feature = "windowed", not(target_os = "android")))]
+#[cfg(all(
+    feature = "windowed",
+    not(any(target_os = "android", target_os = "ios", target_os = "fuchsia"))
+))]
 fn convert_mouse_button(button: blinc_platform::MouseButton) -> MouseButton {
     match button {
         blinc_platform::MouseButton::Left => MouseButton::Left,
@@ -4008,7 +4029,10 @@ fn convert_mouse_button(button: blinc_platform::MouseButton) -> MouseButton {
 }
 
 /// Convert layout cursor style to platform cursor
-#[cfg(all(feature = "windowed", not(target_os = "android")))]
+#[cfg(all(
+    feature = "windowed",
+    not(any(target_os = "android", target_os = "ios", target_os = "fuchsia"))
+))]
 fn convert_cursor_style(cursor: CursorStyle) -> blinc_platform::Cursor {
     match cursor {
         CursorStyle::Default => blinc_platform::Cursor::Default,
@@ -4030,7 +4054,10 @@ fn convert_cursor_style(cursor: CursorStyle) -> blinc_platform::Cursor {
 }
 
 /// Convenience function to run a windowed app with default configuration
-#[cfg(all(feature = "windowed", not(target_os = "android")))]
+#[cfg(all(
+    feature = "windowed",
+    not(any(target_os = "android", target_os = "ios", target_os = "fuchsia"))
+))]
 pub fn run_windowed<F, E>(ui_builder: F) -> Result<()>
 where
     F: FnMut(&mut WindowedContext) -> E + 'static,
@@ -4040,7 +4067,10 @@ where
 }
 
 /// Convenience function to run a windowed app with a title
-#[cfg(all(feature = "windowed", not(target_os = "android")))]
+#[cfg(all(
+    feature = "windowed",
+    not(any(target_os = "android", target_os = "ios", target_os = "fuchsia"))
+))]
 pub fn run_windowed_with_title<F, E>(title: &str, ui_builder: F) -> Result<()>
 where
     F: FnMut(&mut WindowedContext) -> E + 'static,

--- a/crates/blinc_canvas_kit/Cargo.toml
+++ b/crates/blinc_canvas_kit/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "blinc_canvas_kit"
+description = "Blinc canvas toolkit - pan, zoom, and viewport management for interactive canvases"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/blinc_canvas_kit"
+rust-version.workspace = true
+keywords = ["ui", "gui", "canvas", "pan", "zoom"]
+categories = ["gui"]
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
+blinc_layout = { path = "../blinc_layout", version = "0.1.14" }
+blinc_animation = { path = "../blinc_animation", version = "0.1.14" }

--- a/crates/blinc_canvas_kit/Cargo.toml
+++ b/crates/blinc_canvas_kit/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "blinc_canvas_kit"
-description = "Blinc canvas toolkit - pan, zoom, and viewport management for interactive canvases"
+description = "Interactive canvas toolkit for game editors and node graphs — pan, zoom, spatial indexing, multi-select, marquee, and snap-to-grid"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "README.md"
 documentation = "https://docs.rs/blinc_canvas_kit"
 rust-version.workspace = true
-keywords = ["ui", "gui", "canvas", "pan", "zoom"]
-categories = ["gui"]
+keywords = ["ui", "gui", "canvas", "editor", "node-graph"]
+categories = ["gui", "game-development"]
 
 [lib]
 crate-type = ["lib"]
@@ -16,4 +17,3 @@ crate-type = ["lib"]
 [dependencies]
 blinc_core = { path = "../blinc_core", version = "0.1.14" }
 blinc_layout = { path = "../blinc_layout", version = "0.1.14" }
-blinc_animation = { path = "../blinc_animation", version = "0.1.14" }

--- a/crates/blinc_canvas_kit/README.md
+++ b/crates/blinc_canvas_kit/README.md
@@ -1,0 +1,146 @@
+# blinc_canvas_kit
+
+> **Part of the [Blinc UI Framework](https://project-blinc.github.io/Blinc)**
+>
+> This crate is a component of Blinc, a GPU-accelerated UI framework for Rust.
+> For full documentation and guides, visit the [Blinc documentation](https://project-blinc.github.io/Blinc).
+
+Interactive canvas toolkit for game editors and node graphs — pan, zoom, spatial indexing, multi-select, marquee selection, and snap-to-grid.
+
+## Overview
+
+`blinc_canvas_kit` provides everything needed to build interactive infinite canvas applications:
+
+- **Viewport Management**: Pan (with momentum), zoom (scroll + pinch), coordinate conversion between screen-space and content-space
+- **Spatial Indexing**: Uniform-grid spatial hash for O(1) hit testing and fast range queries, scaling to thousands of elements
+- **Multi-Select**: Shift+click to add, Cmd/Ctrl+click to toggle, with selection change callbacks
+- **Marquee Selection**: Box-select via tool mode or Shift+drag, with live preview and additive mode
+- **Snap-to-Grid**: Round content-space positions to configurable grid spacing
+- **Background Patterns**: Infinite viewport-aware dot grid, line grid, and crosshatch patterns with zoom-adaptive density
+- **Viewport Culling**: Skip rendering off-screen elements with a simple visibility check
+- **Hit Regions**: Register interactive bounding boxes during drawing, with click/hover/drag callbacks
+
+## Quick Start
+
+```rust
+use blinc_canvas_kit::prelude::*;
+
+let mut kit = CanvasKit::new("editor")
+    .with_background(CanvasBackground::dots().with_spacing(25.0))
+    .with_snap(25.0);
+
+kit.on_element_click(|evt| {
+    if let Some(id) = &evt.region_id {
+        println!("Clicked {id}");
+    }
+});
+
+kit.on_element_drag(|evt| {
+    println!("Dragging {} by ({}, {})", evt.region_id, evt.content_delta.x, evt.content_delta.y);
+});
+
+kit.on_selection_change(|evt| {
+    println!("Selected: {:?}", evt.selected);
+});
+
+// Returns a fully-wired Div with canvas + event handlers
+kit.element(|ctx, _bounds| {
+    let rect = Rect::new(100.0, 100.0, 200.0, 150.0);
+    ctx.fill_rect(rect, 8.0.into(), Brush::Solid(Color::BLUE));
+    kit.hit_rect("my_node", rect);
+})
+```
+
+## Features
+
+### Tool Modes
+
+```rust
+// Pan mode (default): background drag pans, Shift+drag for marquee
+kit.set_tool(CanvasTool::Pan);
+
+// Select mode: background drag draws marquee
+kit.set_tool(CanvasTool::Select);
+```
+
+### Selection
+
+```rust
+// Query selection state
+let sel = kit.selection();
+for id in &sel.selected {
+    println!("Selected: {id}");
+}
+
+// Check individual items (useful in render callbacks for visual feedback)
+if kit.is_selected("node_1") {
+    // Draw highlight
+}
+
+// Programmatic selection
+kit.set_selection(HashSet::from(["a".into(), "b".into()]));
+kit.clear_selection();
+```
+
+### Snap-to-Grid
+
+```rust
+// Enable snapping
+let kit = CanvasKit::new("editor").with_snap(25.0);
+
+// Use in drag callbacks for precise positioning
+kit.on_element_drag(|evt| {
+    let target = Point::new(base_x + evt.content_delta.x, base_y + evt.content_delta.y);
+    let snapped = kit.snap_point(target);
+    // Apply snapped position to your element
+});
+```
+
+### Viewport Culling
+
+```rust
+kit.element(|ctx, _bounds| {
+    for node in &all_nodes {
+        // Skip rendering off-screen elements
+        if kit.is_visible(node.rect) {
+            ctx.fill_rect(node.rect, corner_radius, brush);
+            kit.hit_rect(&node.id, node.rect);
+        }
+    }
+});
+```
+
+### Background Patterns
+
+```rust
+// Dot grid (default)
+CanvasBackground::dots()
+
+// Line grid
+CanvasBackground::grid().with_spacing(40.0)
+
+// Crosshatch (diagonal lines)
+CanvasBackground::crosshatch()
+
+// Customized with zoom-adaptive density
+CanvasBackground::dots()
+    .with_spacing(30.0)
+    .with_color(Color::rgba(0.3, 0.3, 0.4, 0.5))
+    .with_size(3.0)
+    .with_zoom_adaptive(0.3, 5) // Below 30% zoom, show every 5th dot
+```
+
+## Architecture
+
+All state persists across UI rebuilds via `BlincContextState` keyed storage. The spatial index is rebuilt each frame during the render callback (via `hit_rect()` calls), while selection, viewport, and interaction state persist.
+
+| Module | Purpose |
+|--------|---------|
+| `viewport` | Pan/zoom state, coordinate conversion, visibility testing |
+| `pan` | Momentum panning with EMA velocity tracking |
+| `zoom` | Scroll and pinch zoom handlers |
+| `spatial` | Uniform-grid spatial hash for hit testing and range queries |
+| `selection` | Multi-select state, marquee drag, tool modes |
+| `snap` | Grid snapping for content-space coordinates |
+| `background` | Infinite viewport-aware pattern rendering |
+| `hit` | Hit region types and event structs |

--- a/crates/blinc_canvas_kit/src/background.rs
+++ b/crates/blinc_canvas_kit/src/background.rs
@@ -1,0 +1,445 @@
+//! Viewport-aware infinite canvas background patterns.
+//!
+//! Renders only the visible portion of the pattern — extends infinitely
+//! in all directions including negative coordinates.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! let mut kit = CanvasKit::new("graph");
+//! kit.set_background(CanvasBackground::dots().with_spacing(50.0));
+//! ```
+
+use blinc_core::draw::{Path, Stroke};
+use blinc_core::layer::{Color, CornerRadius, Point, Rect};
+use blinc_core::{Brush, DrawContext};
+
+use crate::viewport::CanvasViewport;
+
+/// Background pattern for an infinite canvas.
+///
+/// Set via `kit.set_background()` or `kit.with_background()`.
+/// Drawn automatically by `kit.element()` before the user's render callback.
+#[derive(Clone, Debug)]
+pub enum CanvasBackground {
+    /// No background pattern.
+    None,
+    /// Dot grid at regular spacing.
+    Dots(PatternConfig),
+    /// Horizontal + vertical lines.
+    Grid(PatternConfig),
+    /// Diagonal lines at ±45°.
+    Crosshatch(PatternConfig),
+}
+
+/// Configuration for a background pattern.
+#[derive(Clone, Debug)]
+pub struct PatternConfig {
+    /// Spacing between pattern elements in content-space pixels.
+    pub spacing: f32,
+    /// Color of the pattern elements.
+    pub color: Color,
+    /// Dot diameter (Dots) or line width (Grid/Crosshatch).
+    pub size: f32,
+    /// Zoom-adaptive level-of-detail.
+    pub zoom_adaptive: Option<ZoomAdaptive>,
+}
+
+/// When zoomed far out, reduce pattern density to maintain performance.
+#[derive(Clone, Debug)]
+pub struct ZoomAdaptive {
+    /// Below this zoom level, switch to coarse pattern.
+    pub zoom_threshold: f32,
+    /// Show every Nth element at coarse level.
+    pub coarse_factor: u32,
+}
+
+// ── Constructors & Builders ─────────────────────────────────────────────
+
+impl CanvasBackground {
+    /// Dot grid with defaults: spacing=50, light gray, size=2.
+    pub fn dots() -> Self {
+        Self::Dots(PatternConfig {
+            spacing: 50.0,
+            color: Color::rgba(0.25, 0.25, 0.3, 0.5),
+            size: 2.0,
+            zoom_adaptive: None,
+        })
+    }
+
+    /// Line grid with defaults: spacing=50, light gray, size=1.
+    pub fn grid() -> Self {
+        Self::Grid(PatternConfig {
+            spacing: 50.0,
+            color: Color::rgba(0.25, 0.25, 0.3, 0.3),
+            size: 1.0,
+            zoom_adaptive: None,
+        })
+    }
+
+    /// Crosshatch with defaults: spacing=40, light gray, size=1.
+    pub fn crosshatch() -> Self {
+        Self::Crosshatch(PatternConfig {
+            spacing: 40.0,
+            color: Color::rgba(0.25, 0.25, 0.3, 0.25),
+            size: 1.0,
+            zoom_adaptive: None,
+        })
+    }
+
+    /// Customize spacing.
+    pub fn with_spacing(mut self, spacing: f32) -> Self {
+        if let Some(c) = self.config_mut() {
+            c.spacing = spacing;
+        }
+        self
+    }
+
+    /// Customize color.
+    pub fn with_color(mut self, color: Color) -> Self {
+        if let Some(c) = self.config_mut() {
+            c.color = color;
+        }
+        self
+    }
+
+    /// Customize dot size or line width.
+    pub fn with_size(mut self, size: f32) -> Self {
+        if let Some(c) = self.config_mut() {
+            c.size = size;
+        }
+        self
+    }
+
+    /// Enable zoom-adaptive rendering.
+    ///
+    /// Below `threshold` zoom, show every `coarse_factor`-th element.
+    pub fn with_zoom_adaptive(mut self, threshold: f32, coarse_factor: u32) -> Self {
+        if let Some(c) = self.config_mut() {
+            c.zoom_adaptive = Some(ZoomAdaptive {
+                zoom_threshold: threshold,
+                coarse_factor: coarse_factor.max(1),
+            });
+        }
+        self
+    }
+
+    fn config_mut(&mut self) -> Option<&mut PatternConfig> {
+        match self {
+            Self::None => None,
+            Self::Dots(c) | Self::Grid(c) | Self::Crosshatch(c) => Some(c),
+        }
+    }
+}
+
+// ── Rendering ───────────────────────────────────────────────────────────
+
+/// Max primitives per pattern per frame (safety cap).
+const MAX_PRIMITIVES: usize = 10_000;
+
+impl CanvasBackground {
+    /// Draw the background pattern for the visible viewport region.
+    ///
+    /// Called with the viewport transform already pushed on DrawContext.
+    /// `screen_w` / `screen_h` come from `CanvasBounds`.
+    pub fn draw(
+        &self,
+        ctx: &mut dyn DrawContext,
+        viewport: &CanvasViewport,
+        screen_w: f32,
+        screen_h: f32,
+    ) {
+        match self {
+            Self::None => {}
+            Self::Dots(config) => draw_dots(ctx, viewport, screen_w, screen_h, config),
+            Self::Grid(config) => draw_grid_lines(ctx, viewport, screen_w, screen_h, config),
+            Self::Crosshatch(config) => draw_crosshatch(ctx, viewport, screen_w, screen_h, config),
+        }
+    }
+}
+
+// ── Viewport math ───────────────────────────────────────────────────────
+
+/// Visible content-space rectangle from viewport + screen size.
+/// Returns (left, top, right, bottom).
+fn visible_content_rect(vp: &CanvasViewport, screen_w: f32, screen_h: f32) -> (f32, f32, f32, f32) {
+    let tl = vp.screen_to_content(Point::new(0.0, 0.0));
+    let br = vp.screen_to_content(Point::new(screen_w, screen_h));
+    (tl.x, tl.y, br.x, br.y)
+}
+
+/// Compute start, end, step for iterating grid cells within a range.
+fn cell_range(content_min: f32, content_max: f32, spacing: f32, coarse: u32) -> (f32, f32, f32) {
+    let step = spacing * coarse as f32;
+    let first = (content_min / step).floor() * step;
+    let last = (content_max / step).ceil() * step;
+    (first, last, step)
+}
+
+fn effective_coarse(config: &PatternConfig, zoom: f32) -> u32 {
+    match &config.zoom_adaptive {
+        Some(za) if zoom < za.zoom_threshold => za.coarse_factor,
+        _ => 1,
+    }
+}
+
+// ── Dot pattern ─────────────────────────────────────────────────────────
+
+fn draw_dots(
+    ctx: &mut dyn DrawContext,
+    viewport: &CanvasViewport,
+    screen_w: f32,
+    screen_h: f32,
+    config: &PatternConfig,
+) {
+    let (left, top, right, bottom) = visible_content_rect(viewport, screen_w, screen_h);
+    let coarse = effective_coarse(config, viewport.zoom);
+    let (first_x, last_x, step) = cell_range(left, right, config.spacing, coarse);
+    let (first_y, last_y, _) = cell_range(top, bottom, config.spacing, coarse);
+
+    let brush = Brush::Solid(config.color);
+    let half = config.size / 2.0;
+    let radius = CornerRadius::uniform(half);
+
+    let mut count = 0;
+    let mut x = first_x;
+    while x <= last_x {
+        let mut y = first_y;
+        while y <= last_y {
+            if count >= MAX_PRIMITIVES {
+                return;
+            }
+            ctx.fill_rect(
+                Rect::new(x - half, y - half, config.size, config.size),
+                radius,
+                brush.clone(),
+            );
+            count += 1;
+            y += step;
+        }
+        x += step;
+    }
+}
+
+// ── Grid line pattern ───────────────────────────────────────────────────
+
+fn draw_grid_lines(
+    ctx: &mut dyn DrawContext,
+    viewport: &CanvasViewport,
+    screen_w: f32,
+    screen_h: f32,
+    config: &PatternConfig,
+) {
+    let (left, top, right, bottom) = visible_content_rect(viewport, screen_w, screen_h);
+    let coarse = effective_coarse(config, viewport.zoom);
+    let (first_x, last_x, step) = cell_range(left, right, config.spacing, coarse);
+    let (first_y, last_y, _) = cell_range(top, bottom, config.spacing, coarse);
+
+    let brush = Brush::Solid(config.color);
+    let lw = config.size;
+    let half = lw / 2.0;
+    let height = bottom - top;
+    let width = right - left;
+
+    // Vertical lines
+    let mut x = first_x;
+    while x <= last_x {
+        ctx.fill_rect(
+            Rect::new(x - half, top, lw, height),
+            CornerRadius::uniform(0.0),
+            brush.clone(),
+        );
+        x += step;
+    }
+
+    // Horizontal lines
+    let mut y = first_y;
+    while y <= last_y {
+        ctx.fill_rect(
+            Rect::new(left, y - half, width, lw),
+            CornerRadius::uniform(0.0),
+            brush.clone(),
+        );
+        y += step;
+    }
+}
+
+// ── Crosshatch pattern ──────────────────────────────────────────────────
+
+fn draw_crosshatch(
+    ctx: &mut dyn DrawContext,
+    viewport: &CanvasViewport,
+    screen_w: f32,
+    screen_h: f32,
+    config: &PatternConfig,
+) {
+    let (left, top, right, bottom) = visible_content_rect(viewport, screen_w, screen_h);
+    let coarse = effective_coarse(config, viewport.zoom);
+    let step = config.spacing * coarse as f32;
+
+    let brush = Brush::Solid(config.color);
+    let stroke = Stroke::new(config.size);
+
+    let mut count = 0;
+
+    // +45° diagonals: y = x - d, parameterized by d = x - y
+    let d_min = ((left - bottom) / step).floor() * step;
+    let d_max = ((right - top) / step).ceil() * step;
+
+    let mut d = d_min;
+    while d <= d_max {
+        if count >= MAX_PRIMITIVES {
+            return;
+        }
+        // Clip line y = x - d to visible rect
+        let x0 = left.max(d + top);
+        let y0 = x0 - d;
+        let x1 = right.min(d + bottom);
+        let y1 = x1 - d;
+
+        if x0 < x1 {
+            let path = Path::new().move_to(x0, y0).line_to(x1, y1);
+            ctx.stroke_path(&path, &stroke, brush.clone());
+            count += 1;
+        }
+        d += step;
+    }
+
+    // -45° diagonals: y = -x + d, parameterized by d = x + y
+    let d_min = ((left + top) / step).floor() * step;
+    let d_max = ((right + bottom) / step).ceil() * step;
+
+    let mut d = d_min;
+    while d <= d_max {
+        if count >= MAX_PRIMITIVES {
+            return;
+        }
+        // Clip line y = -x + d to visible rect
+        let x0 = left.max(d - bottom);
+        let y0 = -x0 + d;
+        let x1 = right.min(d - top);
+        let y1 = -x1 + d;
+
+        if x0 < x1 {
+            let path = Path::new().move_to(x0, y0).line_to(x1, y1);
+            ctx.stroke_path(&path, &stroke, brush.clone());
+            count += 1;
+        }
+        d += step;
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_visible_content_rect_identity() {
+        let vp = CanvasViewport::new(); // pan=0, zoom=1
+        let (l, t, r, b) = visible_content_rect(&vp, 800.0, 600.0);
+        assert!((l - 0.0).abs() < 1e-3);
+        assert!((t - 0.0).abs() < 1e-3);
+        assert!((r - 800.0).abs() < 1e-3);
+        assert!((b - 600.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_visible_content_rect_zoomed() {
+        let mut vp = CanvasViewport::new();
+        vp.zoom = 2.0; // 2x zoom: visible area halved
+        let (l, t, r, b) = visible_content_rect(&vp, 800.0, 600.0);
+        assert!((r - l - 400.0).abs() < 1e-2);
+        assert!((b - t - 300.0).abs() < 1e-2);
+    }
+
+    #[test]
+    fn test_visible_content_rect_panned() {
+        let mut vp = CanvasViewport::new();
+        vp.pan_x = 100.0; // panned right in content space
+        vp.pan_y = -50.0;
+        let (l, t, _r, _b) = visible_content_rect(&vp, 800.0, 600.0);
+        // screen(0,0) → content(-100, 50) (inverted pan)
+        assert!((l - (-100.0)).abs() < 1e-2);
+        assert!((t - 50.0).abs() < 1e-2);
+    }
+
+    #[test]
+    fn test_cell_range_positive() {
+        let (first, last, step) = cell_range(75.0, 250.0, 50.0, 1);
+        assert_eq!(step, 50.0);
+        assert_eq!(first, 50.0); // floor(75/50)*50
+        assert_eq!(last, 250.0); // ceil(250/50)*50
+    }
+
+    #[test]
+    fn test_cell_range_negative() {
+        let (first, last, step) = cell_range(-120.0, -30.0, 50.0, 1);
+        assert_eq!(step, 50.0);
+        assert_eq!(first, -150.0); // floor(-120/50)*50 = floor(-2.4)*50 = -3*50
+        assert_eq!(last, 0.0); // ceil(-30/50)*50 = ceil(-0.6)*50 = 0*50
+    }
+
+    #[test]
+    fn test_cell_range_coarse() {
+        let (first, last, step) = cell_range(0.0, 500.0, 50.0, 5);
+        assert_eq!(step, 250.0); // 50*5
+        assert_eq!(first, 0.0);
+        assert_eq!(last, 500.0);
+    }
+
+    #[test]
+    fn test_effective_coarse_below_threshold() {
+        let config = PatternConfig {
+            spacing: 50.0,
+            color: Color::rgba(1.0, 1.0, 1.0, 1.0),
+            size: 2.0,
+            zoom_adaptive: Some(ZoomAdaptive {
+                zoom_threshold: 0.5,
+                coarse_factor: 5,
+            }),
+        };
+        assert_eq!(effective_coarse(&config, 0.3), 5);
+        assert_eq!(effective_coarse(&config, 0.5), 1); // at threshold = fine
+        assert_eq!(effective_coarse(&config, 1.0), 1);
+    }
+
+    #[test]
+    fn test_effective_coarse_no_adaptive() {
+        let config = PatternConfig {
+            spacing: 50.0,
+            color: Color::rgba(1.0, 1.0, 1.0, 1.0),
+            size: 2.0,
+            zoom_adaptive: None,
+        };
+        assert_eq!(effective_coarse(&config, 0.1), 1);
+    }
+
+    #[test]
+    fn test_builder_chaining() {
+        let bg = CanvasBackground::dots()
+            .with_spacing(30.0)
+            .with_color(Color::rgba(1.0, 0.0, 0.0, 1.0))
+            .with_size(4.0)
+            .with_zoom_adaptive(0.3, 5);
+
+        match bg {
+            CanvasBackground::Dots(c) => {
+                assert_eq!(c.spacing, 30.0);
+                assert_eq!(c.size, 4.0);
+                assert!(c.zoom_adaptive.is_some());
+                let za = c.zoom_adaptive.unwrap();
+                assert_eq!(za.zoom_threshold, 0.3);
+                assert_eq!(za.coarse_factor, 5);
+            }
+            _ => panic!("Expected Dots"),
+        }
+    }
+
+    #[test]
+    fn test_none_builder_noop() {
+        let bg = CanvasBackground::None.with_spacing(30.0).with_size(5.0);
+        assert!(matches!(bg, CanvasBackground::None));
+    }
+}

--- a/crates/blinc_canvas_kit/src/hit.rs
+++ b/crates/blinc_canvas_kit/src/hit.rs
@@ -1,0 +1,120 @@
+use blinc_core::layer::{Point, Rect};
+
+/// Content-space bounding box registered as an interactive region.
+///
+/// Register during the draw callback via `kit.hit_rect(id, rect)`.
+/// Z-order matches draw order: last registered = topmost.
+#[derive(Clone, Debug)]
+pub struct HitRegion {
+    pub id: String,
+    pub rect: Rect,
+}
+
+impl HitRegion {
+    pub fn new(id: impl Into<String>, rect: Rect) -> Self {
+        Self {
+            id: id.into(),
+            rect,
+        }
+    }
+}
+
+/// Tracks current pointer interaction state.
+#[derive(Clone, Debug, Default)]
+pub struct InteractionState {
+    /// Region currently under the pointer (hover).
+    pub hovered: Option<String>,
+    /// Region being dragged (set on POINTER_DOWN over a region).
+    pub active: Option<String>,
+    /// Content-space point where the current drag started.
+    pub drag_start: Option<Point>,
+    /// Whether a DRAG event has fired since POINTER_DOWN (distinguishes click from drag).
+    pub did_drag: bool,
+}
+
+/// Event passed to click and hover callbacks.
+#[derive(Clone, Debug)]
+pub struct CanvasEvent {
+    /// Mouse position in content-space.
+    pub content_point: Point,
+    /// Mouse position in screen-space.
+    pub screen_point: Point,
+    /// Hit region ID, or `None` if the pointer is over the background.
+    pub region_id: Option<String>,
+}
+
+/// Event passed to element drag callbacks.
+#[derive(Clone, Debug)]
+pub struct CanvasDragEvent {
+    /// Current mouse position in content-space.
+    pub content_point: Point,
+    /// Drag delta in content-space since last event.
+    pub content_delta: Point,
+    /// Current mouse position in screen-space.
+    pub screen_point: Point,
+    /// The region being dragged.
+    pub region_id: String,
+}
+
+/// Hit-test a point against regions in reverse order (topmost first).
+///
+/// Returns the ID of the first region whose bounding rect contains the point.
+pub fn hit_test(regions: &[HitRegion], content_point: Point) -> Option<String> {
+    regions
+        .iter()
+        .rev()
+        .find(|r| r.rect.contains(content_point))
+        .map(|r| r.id.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hit_test_empty() {
+        assert!(hit_test(&[], Point::new(0.0, 0.0)).is_none());
+    }
+
+    #[test]
+    fn test_hit_test_single_hit() {
+        let regions = vec![HitRegion::new("a", Rect::new(10.0, 10.0, 50.0, 50.0))];
+        assert_eq!(hit_test(&regions, Point::new(20.0, 20.0)), Some("a".into()));
+    }
+
+    #[test]
+    fn test_hit_test_miss() {
+        let regions = vec![HitRegion::new("a", Rect::new(10.0, 10.0, 50.0, 50.0))];
+        assert!(hit_test(&regions, Point::new(100.0, 100.0)).is_none());
+    }
+
+    #[test]
+    fn test_hit_test_topmost_wins() {
+        let regions = vec![
+            HitRegion::new("bottom", Rect::new(0.0, 0.0, 100.0, 100.0)),
+            HitRegion::new("top", Rect::new(20.0, 20.0, 60.0, 60.0)),
+        ];
+        // Point inside both — "top" (last registered) wins
+        assert_eq!(
+            hit_test(&regions, Point::new(30.0, 30.0)),
+            Some("top".into())
+        );
+    }
+
+    #[test]
+    fn test_hit_test_non_overlapping() {
+        let regions = vec![
+            HitRegion::new("left", Rect::new(0.0, 0.0, 50.0, 50.0)),
+            HitRegion::new("right", Rect::new(100.0, 0.0, 50.0, 50.0)),
+        ];
+        assert_eq!(
+            hit_test(&regions, Point::new(25.0, 25.0)),
+            Some("left".into())
+        );
+        assert_eq!(
+            hit_test(&regions, Point::new(125.0, 25.0)),
+            Some("right".into())
+        );
+        assert!(hit_test(&regions, Point::new(75.0, 25.0)).is_none());
+    }
+}

--- a/crates/blinc_canvas_kit/src/lib.rs
+++ b/crates/blinc_canvas_kit/src/lib.rs
@@ -1,0 +1,234 @@
+//! Canvas toolkit for interactive pan/zoom canvases.
+//!
+//! `blinc_canvas_kit` provides viewport management (pan, zoom, coordinate
+//! conversion) for `blinc_layout::Canvas` elements. All state persists across
+//! UI rebuilds via `BlincContextState`.
+//!
+//! # Usage
+//!
+//! ## Builder (zero boilerplate)
+//!
+//! ```ignore
+//! use blinc_canvas_kit::prelude::*;
+//!
+//! fn my_canvas() -> Div {
+//!     let kit = CanvasKit::new("diagram");
+//!     kit.element(|ctx, bounds| {
+//!         // Draw in content-space (viewport transform pre-applied)
+//!         ctx.fill_rect(Rect::new(100.0, 100.0, 200.0, 150.0), 8.0.into(), Brush::Solid(Color::BLUE));
+//!     })
+//! }
+//! ```
+//!
+//! ## Handler (custom wiring)
+//!
+//! ```ignore
+//! use blinc_canvas_kit::prelude::*;
+//!
+//! fn my_canvas() -> Div {
+//!     let kit = CanvasKit::new("custom");
+//!     let h = kit.handler();
+//!     div()
+//!         .on_drag(h.clone())
+//!         .on_scroll(h.clone())
+//!         .child(canvas(move |ctx, bounds| {
+//!             ctx.push_transform(kit.transform().into());
+//!             // draw ...
+//!             ctx.pop_transform();
+//!         }))
+//! }
+//! ```
+
+pub mod pan;
+pub mod viewport;
+pub mod zoom;
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use blinc_core::events::event_types;
+use blinc_core::layer::{Affine2D, Point};
+use blinc_core::{BlincContextState, SignalId, State};
+use blinc_layout::canvas::{canvas, CanvasBounds};
+use blinc_layout::div::{div, Div};
+use blinc_layout::event_handler::EventContext;
+
+pub use pan::PanController;
+pub use viewport::{affine_inverse, CanvasViewport};
+pub use zoom::ZoomController;
+
+/// Prelude for convenient imports.
+pub mod prelude {
+    pub use crate::pan::PanController;
+    pub use crate::viewport::{affine_inverse, CanvasViewport};
+    pub use crate::zoom::ZoomController;
+    pub use crate::CanvasKit;
+}
+
+/// Interactive canvas toolkit — receives events, manages viewport state.
+///
+/// Create one per canvas via `CanvasKit::new("key")`. All state persists
+/// across UI rebuilds via `BlincContextState`.
+///
+/// Two ways to use:
+/// - `kit.element(render_fn)` — returns a Div with Canvas + event handlers pre-wired
+/// - `kit.handler()` — returns a closure to attach to any element
+#[derive(Clone)]
+pub struct CanvasKit {
+    viewport: State<CanvasViewport>,
+    pan: State<PanController>,
+    zoom_controller: ZoomController,
+}
+
+impl CanvasKit {
+    /// Create a canvas kit with persistent state keyed by name.
+    pub fn new(key: &str) -> Self {
+        let ctx = BlincContextState::get();
+        Self {
+            viewport: ctx.use_state_keyed(&format!("{key}_vp"), CanvasViewport::new),
+            pan: ctx.use_state_keyed(&format!("{key}_pan"), PanController::new),
+            zoom_controller: ZoomController::new(),
+        }
+    }
+
+    /// Create with custom zoom controller settings.
+    pub fn with_zoom_controller(mut self, zc: ZoomController) -> Self {
+        self.zoom_controller = zc;
+        self
+    }
+
+    // ── Event Processing ──────────────────────────────────────────
+
+    /// Process an EventContext directly. Dispatches to pan/zoom based on event_type.
+    pub fn handle_event(&self, evt: &EventContext) {
+        match evt.event_type {
+            event_types::DRAG => {
+                let dx = evt.drag_delta_x;
+                let dy = evt.drag_delta_y;
+                // Update pan controller (velocity tracking) and viewport together
+                self.pan.update(|mut pan| {
+                    let mut vp = self.viewport.get();
+                    pan.on_drag(&mut vp, dx, dy);
+                    self.viewport.set(vp);
+                    pan
+                });
+            }
+            event_types::DRAG_END => {
+                self.pan.update(|mut pan| {
+                    pan.on_drag_end();
+                    pan
+                });
+            }
+            event_types::SCROLL => {
+                let delta_y = evt.scroll_delta_y;
+                let cursor = Point::new(evt.local_x, evt.local_y);
+                let zc = self.zoom_controller.clone();
+                self.viewport.update(|mut vp| {
+                    zc.on_scroll(&mut vp, delta_y, cursor);
+                    vp
+                });
+            }
+            event_types::PINCH => {
+                let scale = evt.pinch_scale;
+                let center = Point::new(evt.pinch_center_x, evt.pinch_center_y);
+                let zc = self.zoom_controller.clone();
+                self.viewport.update(|mut vp| {
+                    zc.on_pinch(&mut vp, scale, center);
+                    vp
+                });
+            }
+            _ => {}
+        }
+    }
+
+    /// Returns a handler closure suitable for attaching to any element.
+    ///
+    /// The returned closure handles DRAG, DRAG_END, SCROLL, and PINCH events.
+    ///
+    /// ```ignore
+    /// let kit = CanvasKit::new("my_canvas");
+    /// let h = kit.handler();
+    /// div().on_drag(h.clone()).on_scroll(h.clone()).on_drag_end(h.clone())
+    /// ```
+    pub fn handler(&self) -> Arc<dyn Fn(&EventContext) + Send + Sync + 'static> {
+        let kit = self.clone();
+        Arc::new(move |evt: &EventContext| {
+            kit.handle_event(evt);
+        })
+    }
+
+    // ── Builder ───────────────────────────────────────────────────
+
+    /// Build a fully-wired Div containing a Canvas with all event handlers.
+    ///
+    /// The render callback receives `DrawContext` with the viewport transform
+    /// already applied — draw in content-space coordinates directly.
+    ///
+    /// The returned Div is `w_full().h_full()`. Chain additional builder
+    /// methods to customize sizing.
+    pub fn element<F>(&self, render_fn: F) -> Div
+    where
+        F: Fn(&mut dyn blinc_core::DrawContext, CanvasBounds) + 'static,
+    {
+        let kit_render = self.clone();
+        let render = Rc::new(render_fn);
+
+        let h_drag = self.handler();
+        let h_drag_end = self.handler();
+        let h_scroll = self.handler();
+        let h_pinch = self.handler();
+
+        div()
+            .w_full()
+            .h_full()
+            .on_drag(move |evt| h_drag(evt))
+            .on_drag_end(move |evt| h_drag_end(evt))
+            .on_scroll(move |evt| h_scroll(evt))
+            .on_event(event_types::PINCH, move |evt| h_pinch(evt))
+            .child(
+                canvas(move |ctx, bounds| {
+                    let transform = kit_render.transform();
+                    ctx.push_transform(transform.into());
+                    render(ctx, bounds);
+                    ctx.pop_transform();
+                })
+                .w_full()
+                .h_full(),
+            )
+    }
+
+    // ── Viewport Access ───────────────────────────────────────────
+
+    /// Current viewport transform (content → screen).
+    pub fn transform(&self) -> Affine2D {
+        self.viewport.get().transform()
+    }
+
+    /// Current viewport state.
+    pub fn viewport(&self) -> CanvasViewport {
+        self.viewport.get()
+    }
+
+    /// Update the viewport via a mutation closure.
+    pub fn update_viewport(&self, f: impl FnOnce(&mut CanvasViewport)) {
+        self.viewport.update(|mut vp| {
+            f(&mut vp);
+            vp
+        });
+    }
+
+    /// Signal ID for reactive dependency tracking (e.g. `stateful().deps()`).
+    pub fn viewport_signal(&self) -> SignalId {
+        self.viewport.signal_id()
+    }
+
+    /// Convert screen-space point to content-space.
+    pub fn screen_to_content(&self, screen: Point) -> Point {
+        self.viewport.get().screen_to_content(screen)
+    }
+
+    /// Convert content-space point to screen-space.
+    pub fn content_to_screen(&self, content: Point) -> Point {
+        self.viewport.get().content_to_screen(content)
+    }
+}

--- a/crates/blinc_canvas_kit/src/lib.rs
+++ b/crates/blinc_canvas_kit/src/lib.rs
@@ -1,71 +1,77 @@
-//! Canvas toolkit for interactive pan/zoom canvases.
+//! Canvas toolkit for interactive pan/zoom canvases with hit testing.
 //!
 //! `blinc_canvas_kit` provides viewport management (pan, zoom, coordinate
-//! conversion) for `blinc_layout::Canvas` elements. All state persists across
-//! UI rebuilds via `BlincContextState`.
+//! conversion) and element interaction (click, drag, hover) for
+//! `blinc_layout::Canvas` elements. All state persists across UI rebuilds
+//! via `BlincContextState`.
 //!
 //! # Usage
 //!
-//! ## Builder (zero boilerplate)
-//!
 //! ```ignore
 //! use blinc_canvas_kit::prelude::*;
 //!
-//! fn my_canvas() -> Div {
-//!     let kit = CanvasKit::new("diagram");
-//!     kit.element(|ctx, bounds| {
-//!         // Draw in content-space (viewport transform pre-applied)
-//!         ctx.fill_rect(Rect::new(100.0, 100.0, 200.0, 150.0), 8.0.into(), Brush::Solid(Color::BLUE));
-//!     })
-//! }
-//! ```
+//! let kit = CanvasKit::new("diagram");
 //!
-//! ## Handler (custom wiring)
+//! kit.on_element_click(|evt| {
+//!     tracing::info!("Clicked {:?}", evt.region_id);
+//! });
 //!
-//! ```ignore
-//! use blinc_canvas_kit::prelude::*;
-//!
-//! fn my_canvas() -> Div {
-//!     let kit = CanvasKit::new("custom");
-//!     let h = kit.handler();
-//!     div()
-//!         .on_drag(h.clone())
-//!         .on_scroll(h.clone())
-//!         .child(canvas(move |ctx, bounds| {
-//!             ctx.push_transform(kit.transform().into());
-//!             // draw ...
-//!             ctx.pop_transform();
-//!         }))
-//! }
+//! kit.element(|ctx, bounds| {
+//!     let r = Rect::new(100.0, 100.0, 200.0, 150.0);
+//!     ctx.fill_rect(r, 8.0.into(), Brush::Solid(Color::BLUE));
+//!     kit.hit_rect("my_node", r);
+//! })
 //! ```
 
+pub mod background;
+pub mod hit;
 pub mod pan;
+pub mod selection;
+pub mod snap;
+pub mod spatial;
 pub mod viewport;
 pub mod zoom;
 
+use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use blinc_core::draw::Stroke;
 use blinc_core::events::event_types;
-use blinc_core::layer::{Affine2D, Point};
-use blinc_core::{BlincContextState, SignalId, State};
+use blinc_core::layer::{Affine2D, Color, CornerRadius, Point, Rect};
+use blinc_core::{BlincContextState, Brush, SignalId, State};
 use blinc_layout::canvas::{canvas, CanvasBounds};
 use blinc_layout::div::{div, Div};
 use blinc_layout::event_handler::EventContext;
 
+pub use background::{CanvasBackground, PatternConfig, ZoomAdaptive};
+pub use hit::{CanvasDragEvent, CanvasEvent, HitRegion, InteractionState};
 pub use pan::PanController;
+pub use selection::{CanvasTool, MarqueeState, SelectionChangeEvent, SelectionState};
+pub use snap::SnapController;
+pub use spatial::SpatialIndex;
 pub use viewport::{affine_inverse, CanvasViewport};
 pub use zoom::ZoomController;
 
 /// Prelude for convenient imports.
 pub mod prelude {
+    pub use crate::background::{CanvasBackground, PatternConfig, ZoomAdaptive};
+    pub use crate::hit::{CanvasDragEvent, CanvasEvent, HitRegion, InteractionState};
     pub use crate::pan::PanController;
+    pub use crate::selection::{CanvasTool, MarqueeState, SelectionChangeEvent, SelectionState};
+    pub use crate::snap::SnapController;
+    pub use crate::spatial::SpatialIndex;
     pub use crate::viewport::{affine_inverse, CanvasViewport};
     pub use crate::zoom::ZoomController;
     pub use crate::CanvasKit;
 }
 
-/// Interactive canvas toolkit — receives events, manages viewport state.
+type EventCallback = Arc<dyn Fn(&CanvasEvent) + Send + Sync>;
+type DragCallback = Arc<dyn Fn(&CanvasDragEvent) + Send + Sync>;
+type SelectionCallback = Arc<dyn Fn(&SelectionChangeEvent) + Send + Sync>;
+
+/// Interactive canvas toolkit — receives events, manages viewport state,
+/// and provides hit testing for canvas-drawn elements.
 ///
 /// Create one per canvas via `CanvasKit::new("key")`. All state persists
 /// across UI rebuilds via `BlincContextState`.
@@ -78,6 +84,18 @@ pub struct CanvasKit {
     viewport: State<CanvasViewport>,
     pan: State<PanController>,
     zoom_controller: ZoomController,
+    hit_regions: State<SpatialIndex>,
+    interaction: State<InteractionState>,
+    selection: State<SelectionState>,
+    tool: State<CanvasTool>,
+    screen_bounds: State<(f32, f32)>,
+    snap: SnapController,
+    background: CanvasBackground,
+    on_click_cb: Option<EventCallback>,
+    on_hover_cb: Option<EventCallback>,
+    on_drag_cb: Option<DragCallback>,
+    on_drag_end_cb: Option<EventCallback>,
+    on_selection_change_cb: Option<SelectionCallback>,
 }
 
 impl CanvasKit {
@@ -88,6 +106,18 @@ impl CanvasKit {
             viewport: ctx.use_state_keyed(&format!("{key}_vp"), CanvasViewport::new),
             pan: ctx.use_state_keyed(&format!("{key}_pan"), PanController::new),
             zoom_controller: ZoomController::new(),
+            hit_regions: ctx.use_state_keyed(&format!("{key}_hit"), || SpatialIndex::new(100.0)),
+            interaction: ctx.use_state_keyed(&format!("{key}_ia"), InteractionState::default),
+            selection: ctx.use_state_keyed(&format!("{key}_sel"), SelectionState::new),
+            tool: ctx.use_state_keyed(&format!("{key}_tool"), CanvasTool::default),
+            screen_bounds: ctx.use_state_keyed(&format!("{key}_sb"), || (0.0, 0.0)),
+            snap: SnapController::disabled(),
+            background: CanvasBackground::None,
+            on_click_cb: None,
+            on_hover_cb: None,
+            on_drag_cb: None,
+            on_drag_end_cb: None,
+            on_selection_change_cb: None,
         }
     }
 
@@ -97,59 +127,518 @@ impl CanvasKit {
         self
     }
 
+    /// Set the canvas background pattern (builder).
+    pub fn with_background(mut self, bg: CanvasBackground) -> Self {
+        self.background = bg;
+        self
+    }
+
+    /// Set the canvas background pattern.
+    pub fn set_background(&mut self, bg: CanvasBackground) {
+        self.background = bg;
+    }
+
+    /// Set the spatial index cell size (builder). Default: 100.0.
+    pub fn with_spatial_cell_size(self, cell_size: f32) -> Self {
+        self.hit_regions.update(|_| SpatialIndex::new(cell_size));
+        self
+    }
+
+    /// Set the canvas tool mode (builder).
+    pub fn with_tool(self, tool: CanvasTool) -> Self {
+        self.tool.set(tool);
+        self
+    }
+
+    /// Set the canvas tool mode.
+    pub fn set_tool(&self, tool: CanvasTool) {
+        self.tool.set(tool);
+    }
+
+    /// Current tool mode.
+    pub fn tool(&self) -> CanvasTool {
+        self.tool.get()
+    }
+
+    /// Enable snap-to-grid with the given spacing (builder).
+    pub fn with_snap(mut self, spacing: f32) -> Self {
+        self.snap = SnapController::new(spacing);
+        self
+    }
+
+    /// Set snap-to-grid enabled/disabled.
+    pub fn set_snap_enabled(&mut self, enabled: bool) {
+        self.snap.enabled = enabled;
+    }
+
+    /// Set snap-to-grid spacing.
+    pub fn set_snap_spacing(&mut self, spacing: f32) {
+        self.snap.spacing = spacing.max(1.0);
+    }
+
+    /// Whether snap-to-grid is enabled.
+    pub fn snap_enabled(&self) -> bool {
+        self.snap.enabled
+    }
+
+    /// Snap a content-space point to the nearest grid intersection.
+    ///
+    /// Returns the point unchanged if snapping is disabled.
+    pub fn snap_point(&self, pt: Point) -> Point {
+        self.snap.snap_point(pt)
+    }
+
+    /// Snap a content-space rect's origin to the nearest grid intersection.
+    pub fn snap_rect(&self, rect: Rect) -> Rect {
+        let snapped = self.snap.snap_point(Point::new(rect.x(), rect.y()));
+        Rect::new(snapped.x, snapped.y, rect.width(), rect.height())
+    }
+
+    // ── Callback Builders ────────────────────────────────────────────
+
+    /// Set callback for clicks on hit regions.
+    pub fn on_element_click(&mut self, cb: impl Fn(&CanvasEvent) + Send + Sync + 'static) {
+        self.on_click_cb = Some(Arc::new(cb));
+    }
+
+    /// Set callback for hover changes (region enter/leave).
+    pub fn on_element_hover(&mut self, cb: impl Fn(&CanvasEvent) + Send + Sync + 'static) {
+        self.on_hover_cb = Some(Arc::new(cb));
+    }
+
+    /// Set callback for dragging a hit region.
+    pub fn on_element_drag(&mut self, cb: impl Fn(&CanvasDragEvent) + Send + Sync + 'static) {
+        self.on_drag_cb = Some(Arc::new(cb));
+    }
+
+    /// Set callback for drag end on a hit region.
+    pub fn on_element_drag_end(&mut self, cb: impl Fn(&CanvasEvent) + Send + Sync + 'static) {
+        self.on_drag_end_cb = Some(Arc::new(cb));
+    }
+
+    /// Set callback for selection changes (multi-select, marquee).
+    pub fn on_selection_change(
+        &mut self,
+        cb: impl Fn(&SelectionChangeEvent) + Send + Sync + 'static,
+    ) {
+        self.on_selection_change_cb = Some(Arc::new(cb));
+    }
+
+    // ── Selection ───────────────────────────────────────────────────
+
+    /// Current selection state.
+    pub fn selection(&self) -> SelectionState {
+        self.selection.get()
+    }
+
+    /// Signal ID for the selection state (for reactive deps).
+    pub fn selection_signal(&self) -> SignalId {
+        self.selection.signal_id()
+    }
+
+    /// Set the selection to specific IDs, firing the selection change callback.
+    pub fn set_selection(&self, ids: HashSet<String>) {
+        let old = self.selection.get();
+        let added: HashSet<_> = ids.difference(&old.selected).cloned().collect();
+        let removed: HashSet<_> = old.selected.difference(&ids).cloned().collect();
+
+        if added.is_empty() && removed.is_empty() {
+            return;
+        }
+
+        self.selection.update(|mut s| {
+            s.selected = ids.clone();
+            s
+        });
+
+        if let Some(ref cb) = self.on_selection_change_cb {
+            cb(&SelectionChangeEvent {
+                selected: ids,
+                added,
+                removed,
+            });
+        }
+    }
+
+    /// Clear the selection.
+    pub fn clear_selection(&self) {
+        self.set_selection(HashSet::new());
+    }
+
+    /// Check if a region is currently selected.
+    pub fn is_selected(&self, id: &str) -> bool {
+        self.selection.get().is_selected(id)
+    }
+
+    // ── Hit Region Registration ──────────────────────────────────────
+
+    /// Register a content-space hit region. Call during the draw callback.
+    ///
+    /// Regions are tested in reverse order (last registered = topmost).
+    pub fn hit_rect(&self, id: impl Into<String>, rect: Rect) {
+        self.hit_regions.update(|mut index| {
+            index.insert(HitRegion::new(id, rect));
+            index
+        });
+    }
+
+    /// Clear all hit regions. Called automatically by `element()` before each render.
+    pub fn begin_frame(&self) {
+        self.hit_regions.update(|mut index| {
+            index.clear();
+            index
+        });
+    }
+
+    /// Hit-test a content-space point against registered regions.
+    pub fn hit_test(&self, content_point: Point) -> Option<String> {
+        self.hit_regions.get().hit_test(content_point)
+    }
+
+    /// Range query: find all region IDs intersecting a content-space rect.
+    ///
+    /// Used internally for marquee selection, also available for user queries.
+    pub fn query_rect(&self, rect: Rect) -> HashSet<String> {
+        self.hit_regions.get().query_rect(&rect)
+    }
+
+    // ── Viewport Culling ─────────────────────────────────────────────
+
+    /// Check if a content-space rectangle is visible in the current viewport.
+    ///
+    /// Uses screen bounds from the most recent render. Returns `true` if
+    /// screen bounds are not yet known (conservative default).
+    pub fn is_visible(&self, rect: Rect) -> bool {
+        let (sw, sh) = self.screen_bounds.get();
+        if sw <= 0.0 || sh <= 0.0 {
+            return true;
+        }
+        let vp = self.viewport.get();
+        vp.is_visible(rect.x(), rect.y(), rect.width(), rect.height(), sw, sh)
+    }
+
     // ── Event Processing ──────────────────────────────────────────
 
-    /// Process an EventContext directly. Dispatches to pan/zoom based on event_type.
+    /// Process an EventContext. Dispatches to hit testing, pan/zoom,
+    /// selection, marquee, and callbacks.
     pub fn handle_event(&self, evt: &EventContext) {
+        let screen_pt = Point::new(evt.local_x, evt.local_y);
+
         match evt.event_type {
+            event_types::POINTER_DOWN => {
+                self.handle_pointer_down(evt, screen_pt);
+            }
+
+            event_types::POINTER_MOVE => {
+                let vp = self.viewport.get();
+                let content_pt = vp.screen_to_content(screen_pt);
+                let hit = self.hit_test(content_pt);
+
+                let mut ia = self.interaction.get();
+                let changed = ia.hovered != hit;
+                ia.hovered = hit;
+                self.interaction.set(ia);
+
+                if changed {
+                    if let Some(ref cb) = self.on_hover_cb {
+                        let ia = self.interaction.get();
+                        cb(&CanvasEvent {
+                            content_point: content_pt,
+                            screen_point: screen_pt,
+                            region_id: ia.hovered.clone(),
+                        });
+                    }
+                }
+            }
+
+            event_types::POINTER_UP => {
+                self.handle_pointer_up(evt, screen_pt);
+            }
+
             event_types::DRAG => {
-                let dx = evt.drag_delta_x;
-                let dy = evt.drag_delta_y;
-                // Update pan controller (velocity tracking) and viewport together
-                self.pan.update(|mut pan| {
-                    let mut vp = self.viewport.get();
-                    pan.on_drag(&mut vp, dx, dy);
-                    self.viewport.set(vp);
-                    pan
+                self.handle_drag(evt, screen_pt);
+            }
+
+            event_types::DRAG_END => {
+                self.handle_drag_end(evt, screen_pt);
+            }
+
+            event_types::SCROLL => {
+                let cursor = screen_pt;
+                let zc = self.zoom_controller.clone();
+                self.viewport.update(|mut vp| {
+                    zc.on_scroll(&mut vp, evt.scroll_delta_y, cursor);
+                    vp
                 });
             }
-            event_types::DRAG_END => {
+
+            event_types::PINCH => {
+                let center = Point::new(evt.pinch_center_x, evt.pinch_center_y);
+                let zc = self.zoom_controller.clone();
+                self.viewport.update(|mut vp| {
+                    zc.on_pinch(&mut vp, evt.pinch_scale, center);
+                    vp
+                });
+            }
+
+            _ => {}
+        }
+    }
+
+    fn handle_pointer_down(&self, evt: &EventContext, screen_pt: Point) {
+        let vp = self.viewport.get();
+        let content_pt = vp.screen_to_content(screen_pt);
+        let hit = self.hit_test(content_pt);
+        let tool = self.tool.get();
+
+        if let Some(ref region_id) = hit {
+            // Clicked on an element — update selection based on modifiers
+            let sel = self.selection.get();
+
+            if evt.meta || evt.ctrl {
+                // Cmd/Ctrl+Click: toggle individual item
+                let mut new_sel = sel.selected.clone();
+                if new_sel.contains(region_id) {
+                    new_sel.remove(region_id);
+                } else {
+                    new_sel.insert(region_id.clone());
+                }
+                self.set_selection(new_sel);
+            } else if evt.shift {
+                // Shift+Click: add to selection
+                let mut new_sel = sel.selected.clone();
+                new_sel.insert(region_id.clone());
+                self.set_selection(new_sel);
+            } else if !sel.is_selected(region_id) {
+                // Plain click on unselected item: replace selection
+                let mut new_sel = HashSet::new();
+                new_sel.insert(region_id.clone());
+                self.set_selection(new_sel);
+            }
+            // If plain click on already-selected item, defer to POINTER_UP
+            // (allows dragging multi-selection without losing it)
+
+            self.interaction.set(InteractionState {
+                hovered: self.interaction.get().hovered,
+                active: hit,
+                drag_start: Some(content_pt),
+                did_drag: false,
+            });
+        } else {
+            // Clicked on background
+            let should_marquee = tool == CanvasTool::Select || evt.shift;
+
+            if should_marquee {
+                // Start marquee selection
+                let additive = evt.shift;
+                self.selection.update(|mut s| {
+                    s.marquee = Some(MarqueeState {
+                        anchor: content_pt,
+                        current: content_pt,
+                        additive,
+                        base_selection: if additive {
+                            s.selected.clone()
+                        } else {
+                            HashSet::new()
+                        },
+                    });
+                    s
+                });
+            }
+
+            if !evt.shift && !evt.meta && !evt.ctrl && tool != CanvasTool::Select {
+                // Plain background click in Pan mode: clear selection
+                self.clear_selection();
+            }
+
+            self.interaction.set(InteractionState {
+                hovered: self.interaction.get().hovered,
+                active: None,
+                drag_start: Some(content_pt),
+                did_drag: false,
+            });
+        }
+    }
+
+    fn handle_pointer_up(&self, evt: &EventContext, screen_pt: Point) {
+        let ia = self.interaction.get();
+        let sel = self.selection.get();
+
+        if ia.active.is_some() && !ia.did_drag {
+            // Click (pointer down + up without drag)
+            if let Some(ref cb) = self.on_click_cb {
+                let vp = self.viewport.get();
+                let content_pt = vp.screen_to_content(screen_pt);
+                cb(&CanvasEvent {
+                    content_point: content_pt,
+                    screen_point: screen_pt,
+                    region_id: ia.active.clone(),
+                });
+            }
+
+            // Plain click on already-selected item in multi-selection:
+            // narrow to just that item
+            if !evt.shift && !evt.meta && !evt.ctrl {
+                if let Some(ref id) = ia.active {
+                    if sel.selected.len() > 1 {
+                        let mut new_sel = HashSet::new();
+                        new_sel.insert(id.clone());
+                        self.set_selection(new_sel);
+                    }
+                }
+            }
+        }
+
+        // Finalize marquee if active
+        if sel.marquee.is_some() {
+            let base = sel
+                .marquee
+                .as_ref()
+                .map(|m| m.base_selection.clone())
+                .unwrap_or_default();
+
+            self.selection.update(|mut s| {
+                s.marquee = None;
+                s
+            });
+
+            // Fire selection change with final diff
+            let final_sel = self.selection.get();
+            if let Some(ref cb) = self.on_selection_change_cb {
+                let added = final_sel.selected.difference(&base).cloned().collect();
+                let removed = base.difference(&final_sel.selected).cloned().collect();
+                cb(&SelectionChangeEvent {
+                    selected: final_sel.selected.clone(),
+                    added,
+                    removed,
+                });
+            }
+        }
+
+        // Clear interaction state
+        self.interaction.set(InteractionState {
+            hovered: ia.hovered,
+            active: None,
+            drag_start: None,
+            did_drag: false,
+        });
+    }
+
+    fn handle_drag(&self, evt: &EventContext, screen_pt: Point) {
+        let ia = self.interaction.get();
+        let sel = self.selection.get();
+
+        if ia.active.is_some() {
+            // Element drag — move all selected elements
+            let vp = self.viewport.get();
+            let content_pt = vp.screen_to_content(screen_pt);
+            let delta = if let Some(start) = ia.drag_start {
+                Point::new(content_pt.x - start.x, content_pt.y - start.y)
+            } else {
+                Point::new(0.0, 0.0)
+            };
+
+            if let Some(ref cb) = self.on_drag_cb {
+                // Fire callback for each selected element with the same delta
+                for selected_id in &sel.selected {
+                    cb(&CanvasDragEvent {
+                        content_point: content_pt,
+                        content_delta: delta,
+                        screen_point: screen_pt,
+                        region_id: selected_id.clone(),
+                    });
+                }
+                // If the active element isn't in the selection (edge case),
+                // fire for it anyway
+                if let Some(ref active_id) = ia.active {
+                    if !sel.selected.contains(active_id) {
+                        cb(&CanvasDragEvent {
+                            content_point: content_pt,
+                            content_delta: delta,
+                            screen_point: screen_pt,
+                            region_id: active_id.clone(),
+                        });
+                    }
+                }
+            }
+
+            // Update drag_start for incremental deltas
+            self.interaction.set(InteractionState {
+                hovered: ia.hovered,
+                active: ia.active,
+                drag_start: Some(content_pt),
+                did_drag: true,
+            });
+        } else if sel.marquee.is_some() {
+            // Marquee drag — update current point + live preview
+            let vp = self.viewport.get();
+            let content_pt = vp.screen_to_content(screen_pt);
+
+            // Query spatial index for regions in marquee rect
+            let marquee_anchor = sel.marquee.as_ref().map(|m| m.anchor).unwrap_or(content_pt);
+            let marquee_rect = Rect::from_points(marquee_anchor, content_pt);
+            let hits = self.query_rect(marquee_rect);
+
+            self.selection.update(|mut s| {
+                if let Some(ref mut m) = s.marquee {
+                    m.current = content_pt;
+                    if m.additive {
+                        s.selected = m.base_selection.clone();
+                        s.selected.extend(hits);
+                    } else {
+                        s.selected = hits;
+                    }
+                }
+                s
+            });
+        } else {
+            // Background drag in Pan mode — pan viewport
+            let dx = evt.drag_delta_x;
+            let dy = evt.drag_delta_y;
+            let mut vp = self.viewport.get();
+            let mut pan = self.pan.get();
+            pan.on_drag(&mut vp, dx, dy);
+            self.pan.set(pan);
+            self.viewport.set(vp);
+        }
+    }
+
+    fn handle_drag_end(&self, evt: &EventContext, screen_pt: Point) {
+        let ia = self.interaction.get();
+        if ia.active.is_some() {
+            // Element drag end
+            if let Some(ref cb) = self.on_drag_end_cb {
+                let vp = self.viewport.get();
+                let content_pt = vp.screen_to_content(screen_pt);
+                cb(&CanvasEvent {
+                    content_point: content_pt,
+                    screen_point: screen_pt,
+                    region_id: ia.active.clone(),
+                });
+            }
+            self.interaction.set(InteractionState {
+                hovered: ia.hovered,
+                active: None,
+                drag_start: None,
+                did_drag: false,
+            });
+        } else {
+            // Background drag end — momentum (only if not marquee)
+            let sel = self.selection.get();
+            if sel.marquee.is_none() {
                 self.pan.update(|mut pan| {
                     pan.on_drag_end();
                     pan
                 });
             }
-            event_types::SCROLL => {
-                let delta_y = evt.scroll_delta_y;
-                let cursor = Point::new(evt.local_x, evt.local_y);
-                let zc = self.zoom_controller.clone();
-                self.viewport.update(|mut vp| {
-                    zc.on_scroll(&mut vp, delta_y, cursor);
-                    vp
-                });
-            }
-            event_types::PINCH => {
-                let scale = evt.pinch_scale;
-                let center = Point::new(evt.pinch_center_x, evt.pinch_center_y);
-                let zc = self.zoom_controller.clone();
-                self.viewport.update(|mut vp| {
-                    zc.on_pinch(&mut vp, scale, center);
-                    vp
-                });
-            }
-            _ => {}
+            // Note: marquee finalization happens in POINTER_UP
+            let _ = evt;
         }
     }
 
     /// Returns a handler closure suitable for attaching to any element.
     ///
-    /// The returned closure handles DRAG, DRAG_END, SCROLL, and PINCH events.
-    ///
-    /// ```ignore
-    /// let kit = CanvasKit::new("my_canvas");
-    /// let h = kit.handler();
-    /// div().on_drag(h.clone()).on_scroll(h.clone()).on_drag_end(h.clone())
-    /// ```
+    /// Handles POINTER_DOWN/UP/MOVE, DRAG, DRAG_END, SCROLL, and PINCH.
     pub fn handler(&self) -> Arc<dyn Fn(&EventContext) + Send + Sync + 'static> {
         let kit = self.clone();
         Arc::new(move |evt: &EventContext| {
@@ -163,9 +652,8 @@ impl CanvasKit {
     ///
     /// The render callback receives `DrawContext` with the viewport transform
     /// already applied — draw in content-space coordinates directly.
-    ///
-    /// The returned Div is `w_full().h_full()`. Chain additional builder
-    /// methods to customize sizing.
+    /// Call `kit.hit_rect(id, rect)` inside the callback to register
+    /// interactive regions.
     pub fn element<F>(&self, render_fn: F) -> Div
     where
         F: Fn(&mut dyn blinc_core::DrawContext, CanvasBounds) + 'static,
@@ -173,23 +661,61 @@ impl CanvasKit {
         let kit_render = self.clone();
         let render = Rc::new(render_fn);
 
-        let h_drag = self.handler();
-        let h_drag_end = self.handler();
-        let h_scroll = self.handler();
-        let h_pinch = self.handler();
+        let h = self.handler();
+        let h_drag = h.clone();
+        let h_drag_end = h.clone();
+        let h_scroll = h.clone();
+        let h_pinch = h.clone();
+        let h_ptr_down = h.clone();
+        let h_ptr_up = h.clone();
+        let h_ptr_move = h;
 
         div()
             .w_full()
             .h_full()
+            .on_event(event_types::POINTER_DOWN, move |evt| h_ptr_down(evt))
+            .on_event(event_types::POINTER_UP, move |evt| h_ptr_up(evt))
+            .on_event(event_types::POINTER_MOVE, move |evt| h_ptr_move(evt))
             .on_drag(move |evt| h_drag(evt))
             .on_drag_end(move |evt| h_drag_end(evt))
             .on_scroll(move |evt| h_scroll(evt))
             .on_event(event_types::PINCH, move |evt| h_pinch(evt))
             .child(
                 canvas(move |ctx, bounds| {
-                    let transform = kit_render.transform();
+                    // Store screen bounds for viewport culling helper
+                    kit_render.screen_bounds.set((bounds.width, bounds.height));
+
+                    kit_render.begin_frame();
+                    let vp = kit_render.viewport();
+                    let transform = vp.transform();
                     ctx.push_transform(transform.into());
+
+                    // Draw background pattern (behind user content)
+                    kit_render
+                        .background
+                        .draw(ctx, &vp, bounds.width, bounds.height);
+
                     render(ctx, bounds);
+
+                    // Draw marquee overlay (above user content)
+                    let sel = kit_render.selection.get();
+                    if let Some(ref marquee) = sel.marquee {
+                        let rect = marquee.rect();
+                        let stroke = Stroke::new(1.0 / vp.zoom)
+                            .with_dash(vec![4.0 / vp.zoom, 3.0 / vp.zoom], 0.0);
+                        ctx.stroke_rect(
+                            rect,
+                            CornerRadius::uniform(0.0),
+                            &stroke,
+                            Brush::Solid(Color::rgba(0.2, 0.5, 1.0, 0.8)),
+                        );
+                        ctx.fill_rect(
+                            rect,
+                            CornerRadius::uniform(0.0),
+                            Brush::Solid(Color::rgba(0.2, 0.5, 1.0, 0.15)),
+                        );
+                    }
+
                     ctx.pop_transform();
                 })
                 .w_full()
@@ -230,5 +756,15 @@ impl CanvasKit {
     /// Convert content-space point to screen-space.
     pub fn content_to_screen(&self, content: Point) -> Point {
         self.viewport.get().content_to_screen(content)
+    }
+
+    /// Current interaction state (hovered/active regions).
+    pub fn interaction(&self) -> InteractionState {
+        self.interaction.get()
+    }
+
+    /// Signal ID for the interaction state (for reactive deps).
+    pub fn interaction_signal(&self) -> SignalId {
+        self.interaction.signal_id()
     }
 }

--- a/crates/blinc_canvas_kit/src/pan.rs
+++ b/crates/blinc_canvas_kit/src/pan.rs
@@ -1,0 +1,195 @@
+use crate::viewport::CanvasViewport;
+
+/// Pan controller that processes drag events and tracks velocity for momentum.
+///
+/// Velocity is tracked via exponential moving average (EMA) matching
+/// the scroll physics in `blinc_layout::ScrollPhysics`.
+#[derive(Clone, Debug)]
+pub struct PanController {
+    /// Momentum velocity in content-space px/s (X axis)
+    velocity_x: f32,
+    /// Momentum velocity in content-space px/s (Y axis)
+    velocity_y: f32,
+    /// EMA smoothing factor for velocity tracking (0.0-1.0)
+    smoothing: f32,
+    /// Deceleration rate in px/s²
+    deceleration: f32,
+    /// Whether momentum animation is active
+    pub is_animating: bool,
+    /// Last drag delta for velocity estimation
+    last_dx: f32,
+    last_dy: f32,
+}
+
+impl Default for PanController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PanController {
+    pub fn new() -> Self {
+        Self {
+            velocity_x: 0.0,
+            velocity_y: 0.0,
+            smoothing: 0.3,
+            deceleration: 1500.0,
+            is_animating: false,
+            last_dx: 0.0,
+            last_dy: 0.0,
+        }
+    }
+
+    /// Configure the EMA smoothing factor (default 0.3).
+    pub fn with_smoothing(mut self, smoothing: f32) -> Self {
+        self.smoothing = smoothing.clamp(0.01, 1.0);
+        self
+    }
+
+    /// Configure the deceleration rate in px/s² (default 1500.0).
+    pub fn with_deceleration(mut self, deceleration: f32) -> Self {
+        self.deceleration = deceleration.max(0.0);
+        self
+    }
+
+    /// Handle a DRAG event — apply delta to viewport, track velocity.
+    ///
+    /// `dx`, `dy`: drag delta in screen pixels from the EventContext.
+    pub fn on_drag(&mut self, viewport: &mut CanvasViewport, dx: f32, dy: f32) {
+        // Apply pan (pan_by divides by zoom internally)
+        viewport.pan_by(dx - self.last_dx, dy - self.last_dy);
+
+        // Track velocity via EMA (estimate px/frame → px/s at ~60fps)
+        let instant_vx = (dx - self.last_dx) * 60.0;
+        let instant_vy = (dy - self.last_dy) * 60.0;
+        self.velocity_x = self.velocity_x * (1.0 - self.smoothing) + instant_vx * self.smoothing;
+        self.velocity_y = self.velocity_y * (1.0 - self.smoothing) + instant_vy * self.smoothing;
+
+        self.last_dx = dx;
+        self.last_dy = dy;
+        self.is_animating = false;
+    }
+
+    /// Handle DRAG_END — start momentum if velocity is sufficient.
+    pub fn on_drag_end(&mut self) {
+        self.last_dx = 0.0;
+        self.last_dy = 0.0;
+
+        let speed = (self.velocity_x * self.velocity_x + self.velocity_y * self.velocity_y).sqrt();
+        // Only start momentum if speed exceeds threshold (50 px/s)
+        self.is_animating = speed > 50.0;
+
+        if !self.is_animating {
+            self.velocity_x = 0.0;
+            self.velocity_y = 0.0;
+        }
+    }
+
+    /// Tick momentum deceleration. Call each frame while `is_animating`.
+    ///
+    /// `dt`: time delta in seconds (e.g. 1.0/60.0 for 60fps).
+    ///
+    /// Returns `true` if still animating.
+    pub fn tick(&mut self, viewport: &mut CanvasViewport, dt: f32) -> bool {
+        if !self.is_animating {
+            return false;
+        }
+
+        // Apply velocity to viewport
+        viewport.pan_by(self.velocity_x * dt, self.velocity_y * dt);
+
+        // Decelerate
+        let speed = (self.velocity_x * self.velocity_x + self.velocity_y * self.velocity_y).sqrt();
+        if speed < 1.0 {
+            self.stop();
+            return false;
+        }
+
+        let decel = self.deceleration * dt;
+        let factor = ((speed - decel) / speed).max(0.0);
+        self.velocity_x *= factor;
+        self.velocity_y *= factor;
+
+        true
+    }
+
+    /// Stop momentum immediately.
+    pub fn stop(&mut self) {
+        self.velocity_x = 0.0;
+        self.velocity_y = 0.0;
+        self.is_animating = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pan_controller_default() {
+        let pc = PanController::new();
+        assert_eq!(pc.velocity_x, 0.0);
+        assert_eq!(pc.velocity_y, 0.0);
+        assert!(!pc.is_animating);
+    }
+
+    #[test]
+    fn test_on_drag_applies_delta() {
+        let mut pc = PanController::new();
+        let mut vp = CanvasViewport::new();
+
+        pc.on_drag(&mut vp, 10.0, 20.0);
+        assert!((vp.pan_x - 10.0).abs() < 1e-3);
+        assert!((vp.pan_y - 20.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_drag_end_starts_momentum() {
+        let mut pc = PanController::new();
+        let mut vp = CanvasViewport::new();
+
+        // Simulate fast drag
+        pc.on_drag(&mut vp, 5.0, 0.0);
+        pc.on_drag(&mut vp, 15.0, 0.0);
+        pc.on_drag(&mut vp, 30.0, 0.0);
+        pc.on_drag_end();
+
+        assert!(pc.is_animating);
+        assert!(pc.velocity_x.abs() > 0.0);
+    }
+
+    #[test]
+    fn test_momentum_decelerates_to_zero() {
+        let mut pc = PanController::new();
+        let mut vp = CanvasViewport::new();
+
+        // Simulate drag and release
+        pc.on_drag(&mut vp, 10.0, 0.0);
+        pc.on_drag(&mut vp, 25.0, 0.0);
+        pc.on_drag_end();
+
+        // Tick until stopped
+        let dt = 1.0 / 60.0;
+        let mut frames = 0;
+        while pc.tick(&mut vp, dt) {
+            frames += 1;
+            if frames > 600 {
+                // 10 seconds max
+                break;
+            }
+        }
+
+        assert!(!pc.is_animating);
+        assert!(frames < 600, "momentum should settle within 10 seconds");
+    }
+
+    #[test]
+    fn test_stop() {
+        let mut pc = PanController::new();
+        pc.velocity_x = 500.0;
+        pc.is_animating = true;
+        pc.stop();
+        assert!(!pc.is_animating);
+        assert_eq!(pc.velocity_x, 0.0);
+    }
+}

--- a/crates/blinc_canvas_kit/src/selection.rs
+++ b/crates/blinc_canvas_kit/src/selection.rs
@@ -1,0 +1,187 @@
+//! Multi-select and marquee selection for canvas elements.
+//!
+//! Provides `SelectionState` for tracking selected region IDs,
+//! `MarqueeState` for active box-select drags, and `CanvasTool`
+//! for switching between pan and selection modes.
+
+use std::collections::HashSet;
+
+use blinc_core::layer::{Point, Rect};
+
+/// Tool mode for canvas interaction.
+///
+/// In `Pan` mode, background drag pans the viewport.
+/// In `Select` mode, background drag draws a marquee selection rectangle.
+/// Element drag always moves selected elements regardless of tool mode.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum CanvasTool {
+    /// Background drag pans viewport. Shift+drag for marquee.
+    #[default]
+    Pan,
+    /// Background drag draws marquee. Element drag moves selection.
+    Select,
+}
+
+/// Selection state for multi-select.
+#[derive(Clone, Debug, Default)]
+pub struct SelectionState {
+    /// Currently selected region IDs.
+    pub selected: HashSet<String>,
+    /// Active marquee rectangle, if a marquee drag is in progress.
+    pub marquee: Option<MarqueeState>,
+}
+
+/// Active marquee (box-select) drag state.
+#[derive(Clone, Debug)]
+pub struct MarqueeState {
+    /// Content-space anchor point (where drag started).
+    pub anchor: Point,
+    /// Content-space current point (where pointer is now).
+    pub current: Point,
+    /// Whether shift was held at marquee start (additive mode).
+    pub additive: bool,
+    /// Snapshot of selected IDs when marquee started (for additive mode).
+    pub base_selection: HashSet<String>,
+}
+
+impl MarqueeState {
+    /// The marquee rectangle (normalized: positive width/height).
+    pub fn rect(&self) -> Rect {
+        Rect::from_points(self.anchor, self.current)
+    }
+}
+
+/// Event emitted when the selection changes.
+#[derive(Clone, Debug)]
+pub struct SelectionChangeEvent {
+    /// The new complete set of selected region IDs.
+    pub selected: HashSet<String>,
+    /// IDs that were added in this change.
+    pub added: HashSet<String>,
+    /// IDs that were removed in this change.
+    pub removed: HashSet<String>,
+}
+
+impl SelectionState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Check if a region is selected.
+    pub fn is_selected(&self, id: &str) -> bool {
+        self.selected.contains(id)
+    }
+
+    /// Clear the entire selection.
+    pub fn clear(&mut self) {
+        self.selected.clear();
+    }
+
+    /// Replace selection with a single item.
+    pub fn select_single(&mut self, id: String) {
+        self.selected.clear();
+        self.selected.insert(id);
+    }
+
+    /// Toggle a region in/out of the selection.
+    pub fn toggle(&mut self, id: &str) {
+        if self.selected.contains(id) {
+            self.selected.remove(id);
+        } else {
+            self.selected.insert(id.to_string());
+        }
+    }
+
+    /// Add a region to the selection.
+    pub fn add(&mut self, id: String) {
+        self.selected.insert(id);
+    }
+
+    /// Replace the entire selection set.
+    pub fn replace(&mut self, ids: HashSet<String>) {
+        self.selected = ids;
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_empty() {
+        let sel = SelectionState::new();
+        assert!(sel.selected.is_empty());
+        assert!(sel.marquee.is_none());
+    }
+
+    #[test]
+    fn test_select_single() {
+        let mut sel = SelectionState::new();
+        sel.select_single("a".into());
+        assert!(sel.is_selected("a"));
+        assert_eq!(sel.selected.len(), 1);
+
+        sel.select_single("b".into());
+        assert!(!sel.is_selected("a"));
+        assert!(sel.is_selected("b"));
+        assert_eq!(sel.selected.len(), 1);
+    }
+
+    #[test]
+    fn test_toggle() {
+        let mut sel = SelectionState::new();
+        sel.toggle("a");
+        assert!(sel.is_selected("a"));
+        sel.toggle("a");
+        assert!(!sel.is_selected("a"));
+    }
+
+    #[test]
+    fn test_add_and_clear() {
+        let mut sel = SelectionState::new();
+        sel.add("a".into());
+        sel.add("b".into());
+        sel.add("c".into());
+        assert_eq!(sel.selected.len(), 3);
+
+        sel.clear();
+        assert!(sel.selected.is_empty());
+    }
+
+    #[test]
+    fn test_replace() {
+        let mut sel = SelectionState::new();
+        sel.add("old".into());
+
+        let mut new_set = HashSet::new();
+        new_set.insert("x".into());
+        new_set.insert("y".into());
+        sel.replace(new_set);
+
+        assert!(!sel.is_selected("old"));
+        assert!(sel.is_selected("x"));
+        assert!(sel.is_selected("y"));
+    }
+
+    #[test]
+    fn test_marquee_rect() {
+        let marquee = MarqueeState {
+            anchor: Point::new(100.0, 200.0),
+            current: Point::new(50.0, 300.0),
+            additive: false,
+            base_selection: HashSet::new(),
+        };
+        let r = marquee.rect();
+        assert!((r.x() - 50.0).abs() < 1e-6);
+        assert!((r.y() - 200.0).abs() < 1e-6);
+        assert!((r.width() - 50.0).abs() < 1e-6);
+        assert!((r.height() - 100.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_tool_default() {
+        assert_eq!(CanvasTool::default(), CanvasTool::Pan);
+    }
+}

--- a/crates/blinc_canvas_kit/src/snap.rs
+++ b/crates/blinc_canvas_kit/src/snap.rs
@@ -1,0 +1,118 @@
+//! Snap-to-grid controller for content-space coordinates.
+//!
+//! Rounds points to the nearest grid intersection when enabled.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! let kit = CanvasKit::new("editor").with_snap(25.0);
+//!
+//! kit.on_element_drag(|evt| {
+//!     let new_pos = base_pos + evt.content_delta;
+//!     element.set_pos(kit.snap_point(new_pos));
+//! });
+//! ```
+
+use blinc_core::layer::Point;
+
+/// Snap-to-grid controller.
+///
+/// Apply to target positions (not deltas) for clean grid alignment.
+#[derive(Clone, Debug)]
+pub struct SnapController {
+    /// Whether snapping is enabled.
+    pub enabled: bool,
+    /// Grid spacing in content-space units.
+    pub spacing: f32,
+}
+
+impl Default for SnapController {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+impl SnapController {
+    /// Create a disabled snap controller (default spacing 10.0).
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            spacing: 10.0,
+        }
+    }
+
+    /// Create an enabled snap controller with the given spacing.
+    pub fn new(spacing: f32) -> Self {
+        Self {
+            enabled: true,
+            spacing: spacing.max(1.0),
+        }
+    }
+
+    /// Snap a content-space point to the nearest grid intersection.
+    ///
+    /// Returns the point unchanged if snapping is disabled.
+    pub fn snap_point(&self, pt: Point) -> Point {
+        if !self.enabled || self.spacing <= 0.0 {
+            return pt;
+        }
+        Point::new(
+            (pt.x / self.spacing).round() * self.spacing,
+            (pt.y / self.spacing).round() * self.spacing,
+        )
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_snap_disabled() {
+        let snap = SnapController::disabled();
+        let pt = Point::new(17.3, 42.8);
+        let result = snap.snap_point(pt);
+        assert_eq!(result.x, 17.3);
+        assert_eq!(result.y, 42.8);
+    }
+
+    #[test]
+    fn test_snap_enabled() {
+        let snap = SnapController::new(10.0);
+        assert_eq!(
+            snap.snap_point(Point::new(13.0, 27.0)),
+            Point::new(10.0, 30.0)
+        );
+        assert_eq!(
+            snap.snap_point(Point::new(15.0, 25.0)),
+            Point::new(20.0, 30.0)
+        );
+    }
+
+    #[test]
+    fn test_snap_exact() {
+        let snap = SnapController::new(25.0);
+        assert_eq!(
+            snap.snap_point(Point::new(50.0, 75.0)),
+            Point::new(50.0, 75.0)
+        );
+    }
+
+    #[test]
+    fn test_snap_negative() {
+        let snap = SnapController::new(10.0);
+        assert_eq!(
+            snap.snap_point(Point::new(-13.0, -27.0)),
+            Point::new(-10.0, -30.0)
+        );
+    }
+
+    #[test]
+    fn test_snap_minimum_spacing() {
+        let snap = SnapController::new(0.5);
+        // Clamped to 1.0
+        assert_eq!(snap.spacing, 1.0);
+    }
+}

--- a/crates/blinc_canvas_kit/src/spatial.rs
+++ b/crates/blinc_canvas_kit/src/spatial.rs
@@ -1,0 +1,239 @@
+//! Uniform-grid spatial hash for fast AABB queries.
+//!
+//! Used internally by `CanvasKit` for O(1) point hit testing and
+//! O(cells) range queries (marquee selection). Replaces the previous
+//! linear scan over `Vec<HitRegion>`.
+
+use std::collections::{HashMap, HashSet};
+
+use blinc_core::layer::{Point, Rect};
+
+use crate::hit::HitRegion;
+
+/// Uniform-grid spatial hash for canvas hit regions.
+///
+/// Elements are inserted by bounding box and hashed into fixed-size cells.
+/// Point queries check only the relevant cell; range queries check all
+/// overlapping cells with deduplication.
+#[derive(Clone, Debug)]
+pub struct SpatialIndex {
+    cell_size: f32,
+    cells: HashMap<(i32, i32), Vec<usize>>,
+    regions: Vec<HitRegion>,
+}
+
+impl Default for SpatialIndex {
+    fn default() -> Self {
+        Self::new(100.0)
+    }
+}
+
+impl SpatialIndex {
+    /// Create a new spatial index with the given cell size.
+    ///
+    /// Cell size should be roughly the average element size in content-space.
+    /// Default: 100.0.
+    pub fn new(cell_size: f32) -> Self {
+        Self {
+            cell_size: cell_size.max(1.0),
+            cells: HashMap::new(),
+            regions: Vec::new(),
+        }
+    }
+
+    /// Clear all entries. Called at `begin_frame()`.
+    pub fn clear(&mut self) {
+        self.cells.clear();
+        self.regions.clear();
+    }
+
+    /// Insert a hit region into the spatial index.
+    pub fn insert(&mut self, region: HitRegion) {
+        let idx = self.regions.len();
+        let (col_min, row_min, col_max, row_max) = self.cell_range(&region.rect);
+        for col in col_min..=col_max {
+            for row in row_min..=row_max {
+                self.cells.entry((col, row)).or_default().push(idx);
+            }
+        }
+        self.regions.push(region);
+    }
+
+    /// Point query: find the topmost region containing the point.
+    ///
+    /// Returns regions in reverse insertion order (last inserted = topmost),
+    /// matching the existing `hit_test` convention.
+    pub fn hit_test(&self, point: Point) -> Option<String> {
+        let col = (point.x / self.cell_size).floor() as i32;
+        let row = (point.y / self.cell_size).floor() as i32;
+
+        if let Some(indices) = self.cells.get(&(col, row)) {
+            // Reverse iteration: topmost (last inserted) wins
+            for &idx in indices.iter().rev() {
+                if self.regions[idx].rect.contains(point) {
+                    return Some(self.regions[idx].id.clone());
+                }
+            }
+        }
+        None
+    }
+
+    /// Range query: find all region IDs whose bounding box intersects the query rect.
+    ///
+    /// Used for marquee selection.
+    pub fn query_rect(&self, query: &Rect) -> HashSet<String> {
+        let (col_min, row_min, col_max, row_max) = self.cell_range(query);
+        let mut result = HashSet::new();
+        let mut seen = HashSet::new();
+
+        for col in col_min..=col_max {
+            for row in row_min..=row_max {
+                if let Some(indices) = self.cells.get(&(col, row)) {
+                    for &idx in indices {
+                        if seen.insert(idx) && self.regions[idx].rect.intersects(query) {
+                            result.insert(self.regions[idx].id.clone());
+                        }
+                    }
+                }
+            }
+        }
+        result
+    }
+
+    /// Number of registered regions.
+    pub fn len(&self) -> usize {
+        self.regions.len()
+    }
+
+    /// Whether the index is empty.
+    pub fn is_empty(&self) -> bool {
+        self.regions.is_empty()
+    }
+
+    /// Compute the cell range (col_min, row_min, col_max, row_max) for a rect.
+    fn cell_range(&self, rect: &Rect) -> (i32, i32, i32, i32) {
+        let x_min = rect.x();
+        let y_min = rect.y();
+        let x_max = rect.x() + rect.width();
+        let y_max = rect.y() + rect.height();
+        (
+            (x_min / self.cell_size).floor() as i32,
+            (y_min / self.cell_size).floor() as i32,
+            (x_max / self.cell_size).floor() as i32,
+            (y_max / self.cell_size).floor() as i32,
+        )
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_region(id: &str, x: f32, y: f32, w: f32, h: f32) -> HitRegion {
+        HitRegion::new(id, Rect::new(x, y, w, h))
+    }
+
+    #[test]
+    fn test_empty_index() {
+        let idx = SpatialIndex::new(100.0);
+        assert!(idx.is_empty());
+        assert!(idx.hit_test(Point::new(50.0, 50.0)).is_none());
+        assert!(idx
+            .query_rect(&Rect::new(0.0, 0.0, 100.0, 100.0))
+            .is_empty());
+    }
+
+    #[test]
+    fn test_single_insert_and_hit() {
+        let mut idx = SpatialIndex::new(100.0);
+        idx.insert(make_region("a", 10.0, 10.0, 50.0, 50.0));
+        assert_eq!(idx.len(), 1);
+        assert_eq!(idx.hit_test(Point::new(20.0, 20.0)), Some("a".into()));
+        assert!(idx.hit_test(Point::new(100.0, 100.0)).is_none());
+    }
+
+    #[test]
+    fn test_topmost_wins() {
+        let mut idx = SpatialIndex::new(100.0);
+        idx.insert(make_region("bottom", 0.0, 0.0, 100.0, 100.0));
+        idx.insert(make_region("top", 20.0, 20.0, 60.0, 60.0));
+        // Point inside both — "top" (last inserted) wins
+        assert_eq!(idx.hit_test(Point::new(30.0, 30.0)), Some("top".into()));
+        // Point only in bottom
+        assert_eq!(idx.hit_test(Point::new(5.0, 5.0)), Some("bottom".into()));
+    }
+
+    #[test]
+    fn test_negative_coordinates() {
+        let mut idx = SpatialIndex::new(100.0);
+        idx.insert(make_region("neg", -150.0, -150.0, 100.0, 100.0));
+        assert_eq!(idx.hit_test(Point::new(-100.0, -100.0)), Some("neg".into()));
+        assert!(idx.hit_test(Point::new(0.0, 0.0)).is_none());
+    }
+
+    #[test]
+    fn test_large_region_spans_cells() {
+        let mut idx = SpatialIndex::new(50.0);
+        // Region spans 4 cells (200x200 with cell_size 50)
+        idx.insert(make_region("big", 0.0, 0.0, 200.0, 200.0));
+        assert_eq!(idx.hit_test(Point::new(10.0, 10.0)), Some("big".into()));
+        assert_eq!(idx.hit_test(Point::new(150.0, 150.0)), Some("big".into()));
+    }
+
+    #[test]
+    fn test_query_rect_basic() {
+        let mut idx = SpatialIndex::new(100.0);
+        idx.insert(make_region("a", 10.0, 10.0, 30.0, 30.0));
+        idx.insert(make_region("b", 200.0, 200.0, 30.0, 30.0));
+        idx.insert(make_region("c", 50.0, 50.0, 30.0, 30.0));
+
+        let hits = idx.query_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+        assert!(hits.contains("a"));
+        assert!(hits.contains("c"));
+        assert!(!hits.contains("b"));
+    }
+
+    #[test]
+    fn test_query_rect_no_duplicates() {
+        let mut idx = SpatialIndex::new(50.0);
+        // Region spans multiple cells
+        idx.insert(make_region("wide", 0.0, 0.0, 200.0, 200.0));
+
+        let hits = idx.query_rect(&Rect::new(10.0, 10.0, 180.0, 180.0));
+        assert_eq!(hits.len(), 1);
+        assert!(hits.contains("wide"));
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut idx = SpatialIndex::new(100.0);
+        idx.insert(make_region("a", 10.0, 10.0, 30.0, 30.0));
+        assert_eq!(idx.len(), 1);
+        idx.clear();
+        assert!(idx.is_empty());
+        assert!(idx.hit_test(Point::new(20.0, 20.0)).is_none());
+    }
+
+    #[test]
+    fn test_many_regions() {
+        let mut idx = SpatialIndex::new(100.0);
+        for i in 0..100 {
+            let x = (i % 10) as f32 * 50.0;
+            let y = (i / 10) as f32 * 50.0;
+            idx.insert(make_region(&format!("r{i}"), x, y, 40.0, 40.0));
+        }
+        assert_eq!(idx.len(), 100);
+
+        // Hit test specific region
+        assert_eq!(idx.hit_test(Point::new(10.0, 10.0)), Some("r0".into()));
+        // Miss
+        assert!(idx.hit_test(Point::new(1000.0, 1000.0)).is_none());
+
+        // Range query
+        let hits = idx.query_rect(&Rect::new(0.0, 0.0, 100.0, 100.0));
+        assert!(hits.contains("r0"));
+        assert!(hits.contains("r1"));
+    }
+}

--- a/crates/blinc_canvas_kit/src/viewport.rs
+++ b/crates/blinc_canvas_kit/src/viewport.rs
@@ -1,0 +1,260 @@
+use blinc_core::layer::{Affine2D, Point};
+
+/// Canvas viewport state: pan offset + zoom level.
+///
+/// The viewport defines a content-space → screen-space mapping:
+///   screen = scale(zoom) * translate(pan) * content
+///
+/// `screen_to_content()` inverts this for hit testing.
+#[derive(Clone, Debug)]
+pub struct CanvasViewport {
+    /// Pan offset in content-space pixels
+    pub pan_x: f32,
+    pub pan_y: f32,
+    /// Zoom level (1.0 = 100%, 2.0 = 200%)
+    pub zoom: f32,
+    /// Minimum zoom level
+    pub min_zoom: f32,
+    /// Maximum zoom level
+    pub max_zoom: f32,
+}
+
+impl Default for CanvasViewport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CanvasViewport {
+    pub fn new() -> Self {
+        Self {
+            pan_x: 0.0,
+            pan_y: 0.0,
+            zoom: 1.0,
+            min_zoom: 0.1,
+            max_zoom: 10.0,
+        }
+    }
+
+    /// The combined affine transform: content-space → screen-space.
+    ///
+    /// Applies pan translation then zoom scaling.
+    pub fn transform(&self) -> Affine2D {
+        // scale(zoom) * translate(pan)
+        let translate = Affine2D::translation(self.pan_x, self.pan_y);
+        let scale = Affine2D::scale(self.zoom, self.zoom);
+        scale.then(&translate)
+    }
+
+    /// Inverse transform: screen-space → content-space.
+    ///
+    /// Returns identity if the transform is singular (zoom ≈ 0).
+    pub fn inverse_transform(&self) -> Affine2D {
+        affine_inverse(&self.transform()).unwrap_or(Affine2D::IDENTITY)
+    }
+
+    /// Convert a screen-space point to content-space.
+    pub fn screen_to_content(&self, screen: Point) -> Point {
+        self.inverse_transform().transform_point(screen)
+    }
+
+    /// Convert a content-space point to screen-space.
+    pub fn content_to_screen(&self, content: Point) -> Point {
+        self.transform().transform_point(content)
+    }
+
+    /// Pan by a delta in screen pixels.
+    ///
+    /// The delta is divided by zoom so panning feels consistent at all zoom levels.
+    pub fn pan_by(&mut self, dx: f32, dy: f32) {
+        self.pan_x += dx / self.zoom;
+        self.pan_y += dy / self.zoom;
+    }
+
+    /// Zoom centered on a screen-space point.
+    ///
+    /// Adjusts pan so the point under the cursor stays fixed in content-space.
+    pub fn zoom_at(&mut self, screen_point: Point, factor: f32) {
+        // Content point under cursor before zoom
+        let content_before = self.screen_to_content(screen_point);
+
+        // Apply zoom
+        self.zoom = (self.zoom * factor).clamp(self.min_zoom, self.max_zoom);
+
+        // Content point under cursor after zoom (with old pan)
+        let content_after = self.screen_to_content(screen_point);
+
+        // Adjust pan to keep content_before at the same screen position
+        self.pan_x += content_after.x - content_before.x;
+        self.pan_y += content_after.y - content_before.y;
+    }
+
+    /// Set zoom level, clamped to [min_zoom, max_zoom].
+    pub fn set_zoom(&mut self, zoom: f32) {
+        self.zoom = zoom.clamp(self.min_zoom, self.max_zoom);
+    }
+
+    /// Reset to identity (pan=0, zoom=1).
+    pub fn reset(&mut self) {
+        self.pan_x = 0.0;
+        self.pan_y = 0.0;
+        self.zoom = 1.0;
+    }
+
+    /// Check if a content-space rectangle is visible within the screen bounds.
+    pub fn is_visible(
+        &self,
+        content_x: f32,
+        content_y: f32,
+        content_w: f32,
+        content_h: f32,
+        screen_w: f32,
+        screen_h: f32,
+    ) -> bool {
+        let tl = self.content_to_screen(Point::new(content_x, content_y));
+        let br = self.content_to_screen(Point::new(content_x + content_w, content_y + content_h));
+        // AABB overlap test
+        br.x > 0.0 && tl.x < screen_w && br.y > 0.0 && tl.y < screen_h
+    }
+}
+
+/// Compute the inverse of an affine transform.
+///
+/// Returns `None` if the matrix is singular (determinant ≈ 0).
+pub fn affine_inverse(affine: &Affine2D) -> Option<Affine2D> {
+    let [a, b, c, d, tx, ty] = affine.elements;
+    let det = a * d - c * b;
+    if det.abs() < 1e-10 {
+        return None;
+    }
+    let inv_det = 1.0 / det;
+    Some(Affine2D {
+        elements: [
+            d * inv_det,
+            -b * inv_det,
+            -c * inv_det,
+            a * inv_det,
+            (c * ty - d * tx) * inv_det,
+            (b * tx - a * ty) * inv_det,
+        ],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_affine_inverse_identity() {
+        let inv = affine_inverse(&Affine2D::IDENTITY).unwrap();
+        assert!((inv.elements[0] - 1.0).abs() < 1e-6);
+        assert!((inv.elements[3] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_affine_inverse_roundtrip() {
+        let t = Affine2D::translation(50.0, -30.0);
+        let s = Affine2D::scale(2.0, 0.5);
+        let combined = s.then(&t);
+        let inv = affine_inverse(&combined).unwrap();
+        let result = combined.then(&inv);
+        for i in 0..6 {
+            let expected = Affine2D::IDENTITY.elements[i];
+            assert!(
+                (result.elements[i] - expected).abs() < 1e-4,
+                "element {i}: {} != {}",
+                result.elements[i],
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_affine_inverse_singular() {
+        let singular = Affine2D {
+            elements: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        };
+        assert!(affine_inverse(&singular).is_none());
+    }
+
+    #[test]
+    fn test_viewport_default() {
+        let vp = CanvasViewport::new();
+        assert_eq!(vp.pan_x, 0.0);
+        assert_eq!(vp.pan_y, 0.0);
+        assert_eq!(vp.zoom, 1.0);
+    }
+
+    #[test]
+    fn test_coordinate_roundtrip() {
+        let mut vp = CanvasViewport::new();
+        vp.pan_x = 100.0;
+        vp.pan_y = -50.0;
+        vp.zoom = 2.0;
+
+        let original = Point::new(42.0, 73.0);
+        let screen = vp.content_to_screen(original);
+        let back = vp.screen_to_content(screen);
+
+        assert!((back.x - original.x).abs() < 1e-3);
+        assert!((back.y - original.y).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_zoom_at_keeps_point_fixed() {
+        let mut vp = CanvasViewport::new();
+        vp.pan_x = 50.0;
+        vp.pan_y = 30.0;
+        vp.zoom = 1.5;
+
+        let cursor = Point::new(200.0, 150.0);
+        let content_before = vp.screen_to_content(cursor);
+
+        vp.zoom_at(cursor, 1.5);
+
+        let content_after = vp.screen_to_content(cursor);
+        assert!((content_after.x - content_before.x).abs() < 1e-2);
+        assert!((content_after.y - content_before.y).abs() < 1e-2);
+    }
+
+    #[test]
+    fn test_zoom_clamp() {
+        let mut vp = CanvasViewport::new();
+        vp.set_zoom(100.0);
+        assert_eq!(vp.zoom, vp.max_zoom);
+
+        vp.set_zoom(0.001);
+        assert_eq!(vp.zoom, vp.min_zoom);
+    }
+
+    #[test]
+    fn test_pan_by() {
+        let mut vp = CanvasViewport::new();
+        vp.zoom = 2.0;
+        vp.pan_by(10.0, 20.0);
+        // dx/zoom = 10/2 = 5, dy/zoom = 20/2 = 10
+        assert!((vp.pan_x - 5.0).abs() < 1e-6);
+        assert!((vp.pan_y - 10.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_reset() {
+        let mut vp = CanvasViewport::new();
+        vp.pan_x = 100.0;
+        vp.pan_y = -50.0;
+        vp.zoom = 3.0;
+        vp.reset();
+        assert_eq!(vp.pan_x, 0.0);
+        assert_eq!(vp.pan_y, 0.0);
+        assert_eq!(vp.zoom, 1.0);
+    }
+
+    #[test]
+    fn test_is_visible() {
+        let vp = CanvasViewport::new();
+        // Content rect at (100,100) 200x200, screen 800x600
+        assert!(vp.is_visible(100.0, 100.0, 200.0, 200.0, 800.0, 600.0));
+        // Content rect far off-screen
+        assert!(!vp.is_visible(1000.0, 1000.0, 50.0, 50.0, 800.0, 600.0));
+    }
+}

--- a/crates/blinc_canvas_kit/src/zoom.rs
+++ b/crates/blinc_canvas_kit/src/zoom.rs
@@ -52,12 +52,7 @@ impl ZoomController {
     ///
     /// `pinch_scale`: scale ratio delta (>1 = zoom in, <1 = zoom out).
     /// `pinch_center`: screen-space center of the pinch gesture.
-    pub fn on_pinch(
-        &self,
-        viewport: &mut CanvasViewport,
-        pinch_scale: f32,
-        pinch_center: Point,
-    ) {
+    pub fn on_pinch(&self, viewport: &mut CanvasViewport, pinch_scale: f32, pinch_center: Point) {
         let factor = 1.0 + (pinch_scale - 1.0) * self.pinch_sensitivity;
         viewport.zoom_at(pinch_center, factor);
     }

--- a/crates/blinc_canvas_kit/src/zoom.rs
+++ b/crates/blinc_canvas_kit/src/zoom.rs
@@ -1,0 +1,132 @@
+use blinc_core::layer::Point;
+
+use crate::viewport::CanvasViewport;
+
+/// Zoom controller that processes scroll and pinch events.
+#[derive(Clone, Debug)]
+pub struct ZoomController {
+    /// Zoom speed multiplier for scroll wheel
+    pub scroll_sensitivity: f32,
+    /// Zoom speed multiplier for pinch gestures
+    pub pinch_sensitivity: f32,
+}
+
+impl Default for ZoomController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ZoomController {
+    pub fn new() -> Self {
+        Self {
+            scroll_sensitivity: 0.001,
+            pinch_sensitivity: 1.0,
+        }
+    }
+
+    /// Configure scroll sensitivity (default 0.001).
+    pub fn with_scroll_sensitivity(mut self, sensitivity: f32) -> Self {
+        self.scroll_sensitivity = sensitivity;
+        self
+    }
+
+    /// Configure pinch sensitivity (default 1.0).
+    pub fn with_pinch_sensitivity(mut self, sensitivity: f32) -> Self {
+        self.pinch_sensitivity = sensitivity;
+        self
+    }
+
+    /// Handle SCROLL event — zoom in/out centered on cursor.
+    ///
+    /// `scroll_delta_y`: raw scroll delta (positive = scroll down = zoom out by convention).
+    /// `cursor`: screen-space cursor position to zoom toward.
+    pub fn on_scroll(&self, viewport: &mut CanvasViewport, scroll_delta_y: f32, cursor: Point) {
+        // Negate so scroll-up zooms in
+        let factor = 1.0 - scroll_delta_y * self.scroll_sensitivity;
+        let factor = factor.clamp(0.5, 2.0); // Prevent extreme jumps from large deltas
+        viewport.zoom_at(cursor, factor);
+    }
+
+    /// Handle PINCH event — zoom centered on pinch midpoint.
+    ///
+    /// `pinch_scale`: scale ratio delta (>1 = zoom in, <1 = zoom out).
+    /// `pinch_center`: screen-space center of the pinch gesture.
+    pub fn on_pinch(
+        &self,
+        viewport: &mut CanvasViewport,
+        pinch_scale: f32,
+        pinch_center: Point,
+    ) {
+        let factor = 1.0 + (pinch_scale - 1.0) * self.pinch_sensitivity;
+        viewport.zoom_at(pinch_center, factor);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zoom_controller_default() {
+        let zc = ZoomController::new();
+        assert!((zc.scroll_sensitivity - 0.001).abs() < 1e-6);
+        assert!((zc.pinch_sensitivity - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_scroll_zoom_in() {
+        let zc = ZoomController::new();
+        let mut vp = CanvasViewport::new();
+        let cursor = Point::new(400.0, 300.0);
+
+        let zoom_before = vp.zoom;
+        // Negative scroll_delta_y = scroll up = zoom in
+        zc.on_scroll(&mut vp, -100.0, cursor);
+        assert!(vp.zoom > zoom_before);
+    }
+
+    #[test]
+    fn test_scroll_zoom_out() {
+        let zc = ZoomController::new();
+        let mut vp = CanvasViewport::new();
+        let cursor = Point::new(400.0, 300.0);
+
+        let zoom_before = vp.zoom;
+        // Positive scroll_delta_y = scroll down = zoom out
+        zc.on_scroll(&mut vp, 100.0, cursor);
+        assert!(vp.zoom < zoom_before);
+    }
+
+    #[test]
+    fn test_pinch_zoom_in() {
+        let zc = ZoomController::new();
+        let mut vp = CanvasViewport::new();
+        let center = Point::new(400.0, 300.0);
+
+        let zoom_before = vp.zoom;
+        zc.on_pinch(&mut vp, 1.5, center);
+        assert!(vp.zoom > zoom_before);
+    }
+
+    #[test]
+    fn test_zoom_respects_bounds() {
+        let zc = ZoomController::new();
+        let mut vp = CanvasViewport::new();
+        vp.min_zoom = 0.5;
+        vp.max_zoom = 3.0;
+        let cursor = Point::new(0.0, 0.0);
+
+        // Zoom way in
+        for _ in 0..100 {
+            zc.on_scroll(&mut vp, -200.0, cursor);
+        }
+        assert!(vp.zoom <= vp.max_zoom);
+
+        // Zoom way out
+        for _ in 0..100 {
+            zc.on_scroll(&mut vp, 200.0, cursor);
+        }
+        assert!(vp.zoom >= vp.min_zoom);
+    }
+}

--- a/crates/blinc_cli/Cargo.toml
+++ b/crates/blinc_cli/Cargo.toml
@@ -13,8 +13,8 @@ name = "blinc"
 path = "src/main.rs"
 
 [dependencies]
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
-blinc_animation = { path = "../blinc_animation", version = "0.1.13" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
+blinc_animation = { path = "../blinc_animation", version = "0.1.14" }
 
 # CLI
 clap.workspace = true

--- a/crates/blinc_cn/Cargo.toml
+++ b/crates/blinc_cn/Cargo.toml
@@ -16,12 +16,12 @@ default = []
 
 [dependencies]
 # Primitives layer
-blinc_layout = { path = "../blinc_layout", version = "0.1.13" }
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
-blinc_animation = { path = "../blinc_animation", version = "0.1.13" }
-blinc_theme = { path = "../blinc_theme", version = "0.1.13" }
-blinc_macros = { path = "../blinc_macros", version = "0.1.13" }
-blinc_icons = { path = "../blinc_icons", version = "0.1.13" }
+blinc_layout = { path = "../blinc_layout", version = "0.1.14" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
+blinc_animation = { path = "../blinc_animation", version = "0.1.14" }
+blinc_theme = { path = "../blinc_theme", version = "0.1.14" }
+blinc_macros = { path = "../blinc_macros", version = "0.1.14" }
+blinc_icons = { path = "../blinc_icons", version = "0.1.14" }
 
 # Layout
 taffy.workspace = true

--- a/crates/blinc_cn/Cargo.toml
+++ b/crates/blinc_cn/Cargo.toml
@@ -20,6 +20,7 @@ blinc_layout = { path = "../blinc_layout", version = "0.1.14" }
 blinc_core = { path = "../blinc_core", version = "0.1.14" }
 blinc_animation = { path = "../blinc_animation", version = "0.1.14" }
 blinc_theme = { path = "../blinc_theme", version = "0.1.14" }
+blinc_i18n = { path = "../blinc_i18n", version = "0.1.14" }
 blinc_macros = { path = "../blinc_macros", version = "0.1.14" }
 blinc_icons = { path = "../blinc_icons", version = "0.1.14" }
 

--- a/crates/blinc_debugger/Cargo.toml
+++ b/crates/blinc_debugger/Cargo.toml
@@ -15,14 +15,14 @@ path = "src/main.rs"
 
 [dependencies]
 # Blinc crates
-blinc_app = { path = "../blinc_app", version = "0.1.13" }
-blinc_layout = { path = "../blinc_layout", version = "0.1.13" }
-blinc_theme = { path = "../blinc_theme", version = "0.1.13" }
-blinc_cn = { path = "../blinc_cn", version = "0.1.13" }
-blinc_icons = { path = "../blinc_icons", version = "0.1.13" }
-blinc_recorder = { path = "../blinc_recorder", version = "0.1.13" }
-blinc_animation = { path = "../blinc_animation", version = "0.1.13" }
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
+blinc_app = { path = "../blinc_app", version = "0.1.14" }
+blinc_layout = { path = "../blinc_layout", version = "0.1.14" }
+blinc_theme = { path = "../blinc_theme", version = "0.1.14" }
+blinc_cn = { path = "../blinc_cn", version = "0.1.14" }
+blinc_icons = { path = "../blinc_icons", version = "0.1.14" }
+blinc_recorder = { path = "../blinc_recorder", version = "0.1.14" }
+blinc_animation = { path = "../blinc_animation", version = "0.1.14" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/blinc_gpu/Cargo.toml
+++ b/crates/blinc_gpu/Cargo.toml
@@ -26,9 +26,9 @@ fuchsia = ["vulkan"]                    # Fuchsia uses Vulkan via Scenic (native
 harmony = ["vulkan"]                    # HarmonyOS prefers Vulkan (native windowing)
 
 [dependencies]
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
-blinc_paint = { path = "../blinc_paint", version = "0.1.13" }
-blinc_text = { path = "../blinc_text", version = "0.1.13" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
+blinc_paint = { path = "../blinc_paint", version = "0.1.14" }
+blinc_text = { path = "../blinc_text", version = "0.1.14" }
 
 # GPU
 wgpu.workspace = true

--- a/crates/blinc_image/Cargo.toml
+++ b/crates/blinc_image/Cargo.toml
@@ -28,10 +28,10 @@ thiserror = "2"
 tracing = "0.1"
 
 # Platform asset loading (optional)
-blinc_platform = { path = "../blinc_platform", version = "0.1.13", optional = true }
+blinc_platform = { path = "../blinc_platform", version = "0.1.14", optional = true }
 
 # Text rendering for emoji (optional)
-blinc_text = { path = "../blinc_text", version = "0.1.13", optional = true }
+blinc_text = { path = "../blinc_text", version = "0.1.14", optional = true }
 
 [features]
 default = ["platform", "emoji"]

--- a/crates/blinc_layout/CHANGELOG.md
+++ b/crates/blinc_layout/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `blinc_layout` will be documented in this file.
 
+## [0.1.14] - 2026-02-24
+
+### Added
+
+- `set_auto_id()` and `children_builders_mut()` methods on `ElementBuilder` trait for stable child ID assignment within stateful containers
+- `assign_inner_ids_recursive()` in stateful callback wrapper: auto-assigns deterministic inner IDs to children via `derive_child_key()` (e.g. `"button_0:div:0"`) so event handlers and CSS selectors persist across rebuilds
+
+### Fixed
+
+- CSS `color` property now inherits into text elements inside stateful container rebuilds (added text_color propagation to `apply_stylesheet_base_styles_for_subtree()` post-pass)
+- Event handlers on inner children are now re-registered during visual-only subtree rebuilds (`update_subtree_props_from_builder`), ensuring closures capturing new state are properly propagated
+- CSS text property inheritance (text_color, text_decoration, white_space, text_overflow) added to the full-tree post-pass at initial render time
+
 ## [0.1.13] - 2026-02-18
 
 ### Added

--- a/crates/blinc_layout/Cargo.toml
+++ b/crates/blinc_layout/Cargo.toml
@@ -17,9 +17,9 @@ default = []
 recorder = []
 
 [dependencies]
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
-blinc_animation = { path = "../blinc_animation", version = "0.1.13" }
-blinc_theme = { path = "../blinc_theme", version = "0.1.13" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
+blinc_animation = { path = "../blinc_animation", version = "0.1.14" }
+blinc_theme = { path = "../blinc_theme", version = "0.1.14" }
 
 # Layout
 taffy.workspace = true

--- a/crates/blinc_layout/Cargo.toml
+++ b/crates/blinc_layout/Cargo.toml
@@ -14,12 +14,14 @@ crate-type = ["lib"]
 [features]
 default = []
 # Enable recorder integration for debugging/testing. Disable for production builds.
-recorder = []
+recorder = ["dep:blinc_recorder"]
 
 [dependencies]
 blinc_core = { path = "../blinc_core", version = "0.1.14" }
 blinc_animation = { path = "../blinc_animation", version = "0.1.14" }
 blinc_theme = { path = "../blinc_theme", version = "0.1.14" }
+blinc_i18n = { path = "../blinc_i18n", version = "0.1.14" }
+blinc_recorder = { path = "../blinc_recorder", version = "0.1.14", optional = true }
 
 # Layout
 taffy.workspace = true

--- a/crates/blinc_layout/src/div.rs
+++ b/crates/blinc_layout/src/div.rs
@@ -3845,6 +3845,19 @@ pub trait ElementBuilder {
         None
     }
 
+    /// Set an auto-generated element ID (used by stateful containers for stable child IDs).
+    ///
+    /// Only sets the ID if one hasn't been explicitly assigned by the user.
+    /// Returns true if the ID was set, false if an explicit ID already existed.
+    fn set_auto_id(&mut self, _id: String) -> bool {
+        false
+    }
+
+    /// Get mutable access to children for auto-ID assignment
+    fn children_builders_mut(&mut self) -> &mut [Box<dyn ElementBuilder>] {
+        &mut []
+    }
+
     /// Get the element's CSS class list for selector matching
     fn element_classes(&self) -> &[String] {
         &[]
@@ -3972,6 +3985,19 @@ impl ElementBuilder for Div {
 
     fn element_id(&self) -> Option<&str> {
         self.element_id.as_deref()
+    }
+
+    fn set_auto_id(&mut self, id: String) -> bool {
+        if self.element_id.is_none() {
+            self.element_id = Some(id);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn children_builders_mut(&mut self) -> &mut [Box<dyn ElementBuilder>] {
+        &mut self.children
     }
 
     fn element_classes(&self) -> &[String] {

--- a/crates/blinc_layout/src/renderer.rs
+++ b/crates/blinc_layout/src/renderer.rs
@@ -4453,6 +4453,12 @@ impl RenderTree {
                 props.text_overflow = Some(to);
             }
         }
+        // color (CSS spec: inherited)
+        if props.text_color.is_none() {
+            if let Some(c) = parent_props.text_color {
+                props.text_color = Some(c);
+            }
+        }
     }
 
     /// Build TextData from TextRenderInfo, applying CSS overrides from RenderProps
@@ -7782,9 +7788,10 @@ impl RenderTree {
                     n.props.text_decoration_thickness,
                     n.props.white_space,
                     n.props.text_overflow,
+                    n.props.text_color,
                 )
             });
-            if let Some((td, td_color, td_thick, ws, to)) = parent_text_props {
+            if let Some((td, td_color, td_thick, ws, to, tc)) = parent_text_props {
                 if let Some(node) = self.render_nodes.get_mut(&node_id) {
                     if node.props.text_decoration.is_none() {
                         node.props.text_decoration = td;
@@ -7800,6 +7807,9 @@ impl RenderTree {
                     }
                     if node.props.text_overflow.is_none() {
                         node.props.text_overflow = to;
+                    }
+                    if node.props.text_color.is_none() {
+                        node.props.text_color = tc;
                     }
                 }
             }

--- a/crates/blinc_layout/src/renderer.rs
+++ b/crates/blinc_layout/src/renderer.rs
@@ -7874,6 +7874,47 @@ impl RenderTree {
                 }
             }
         }
+
+        // Propagate inherited text properties (color, text-decoration, etc.)
+        // from parent to child nodes within the rebuilt subtree.
+        for &node_id in &subtree_nodes {
+            let parent_id = match self.element_registry.get_parent(node_id) {
+                Some(id) => id,
+                None => continue,
+            };
+            let parent_text_props = self.render_nodes.get(&parent_id).map(|n| {
+                (
+                    n.props.text_decoration,
+                    n.props.text_decoration_color,
+                    n.props.text_decoration_thickness,
+                    n.props.white_space,
+                    n.props.text_overflow,
+                    n.props.text_color,
+                )
+            });
+            if let Some((td, td_color, td_thick, ws, to, tc)) = parent_text_props {
+                if let Some(node) = self.render_nodes.get_mut(&node_id) {
+                    if node.props.text_decoration.is_none() {
+                        node.props.text_decoration = td;
+                    }
+                    if node.props.text_decoration_color.is_none() {
+                        node.props.text_decoration_color = td_color;
+                    }
+                    if node.props.text_decoration_thickness.is_none() {
+                        node.props.text_decoration_thickness = td_thick;
+                    }
+                    if node.props.white_space.is_none() {
+                        node.props.white_space = ws;
+                    }
+                    if node.props.text_overflow.is_none() {
+                        node.props.text_overflow = to;
+                    }
+                    if node.props.text_color.is_none() {
+                        node.props.text_color = tc;
+                    }
+                }
+            }
+        }
     }
 
     /// Collect all node IDs in a subtree (the node itself + all descendants).
@@ -8484,6 +8525,13 @@ impl RenderTree {
                     new_props.node_id = render_node.props.node_id;
                     new_props.motion = render_node.props.motion.clone();
                     render_node.props = new_props;
+                }
+
+                // Re-register event handlers from the new element builder.
+                // During visual-only rebuilds the tree structure doesn't change,
+                // but callbacks may capture new closure state that needs updating.
+                if let Some(handlers) = new_child.event_handlers() {
+                    self.handler_registry.register(*child_id, handlers.clone());
                 }
 
                 // Recursively update grandchildren

--- a/crates/blinc_layout/src/stateful.rs
+++ b/crates/blinc_layout/src/stateful.rs
@@ -1952,6 +1952,43 @@ impl<S: StateTransitions> StateContext<S> {
 }
 
 // =========================================================================
+// Auto-ID assignment for stateful children
+// =========================================================================
+
+/// Recursively assign stable auto-generated IDs to children within a stateful
+/// container's returned Div.
+///
+/// Uses `StateContext::derive_child_key()` to generate deterministic IDs like
+/// `"{stateful_key}:div:0"`, `"{stateful_key}:div:1"`, etc.
+/// Children that already have an explicit ID (set by the user) are skipped.
+/// This ensures event handlers and CSS selectors persist across stateful rebuilds.
+fn assign_inner_ids_recursive<S: StateTransitions>(
+    ctx: &StateContext<S>,
+    element: &mut dyn crate::div::ElementBuilder,
+) {
+    let children = element.children_builders_mut();
+    for child in children.iter_mut() {
+        // Determine element type name for key generation
+        let type_name = match child.element_type_id() {
+            crate::div::ElementTypeId::Text => "text",
+            crate::div::ElementTypeId::StyledText => "styled_text",
+            crate::div::ElementTypeId::Image => "img",
+            crate::div::ElementTypeId::Svg => "svg",
+            crate::div::ElementTypeId::Canvas => "canvas",
+            crate::div::ElementTypeId::Motion => "motion",
+            _ => "div",
+        };
+
+        // Assign auto ID if child doesn't have an explicit one
+        let auto_id = ctx.derive_child_key(type_name);
+        child.set_auto_id(auto_id);
+
+        // Recurse into grandchildren
+        assign_inner_ids_recursive(ctx, child.as_mut());
+    }
+}
+
+// =========================================================================
 // StatefulBuilder - New API Entry Point
 // =========================================================================
 
@@ -2073,7 +2110,14 @@ impl<S: StateTransitions + Default> StatefulBuilder<S> {
                 ctx.reset_counter();
 
                 // Call user callback and get the returned Div
-                let user_div = callback_clone(&ctx);
+                let mut user_div = callback_clone(&ctx);
+
+                // Auto-assign stable inner IDs to children that don't have explicit IDs.
+                // This uses derive_child_key() to generate deterministic keys like
+                // "{stateful_key}:div:0", "{stateful_key}:div:1", etc.
+                // Stable IDs ensure event handlers persist across stateful rebuilds
+                // because children can be matched by ID rather than by position alone.
+                assign_inner_ids_recursive(&ctx, &mut user_div);
 
                 // Set the stateful context key on the returned Div for auto-keying
                 let user_div = user_div.with_stateful_context(ctx.full_key());

--- a/crates/blinc_paint/Cargo.toml
+++ b/crates/blinc_paint/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 
 [dependencies]
 # Core types (unified with blinc_core)
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
 
 # GPU types (shared with blinc_gpu)
 bytemuck.workspace = true

--- a/crates/blinc_recorder/Cargo.toml
+++ b/crates/blinc_recorder/Cargo.toml
@@ -15,7 +15,7 @@ png = ["dep:png"]
 
 [dependencies]
 png = { version = "0.17", optional = true }
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 tracing.workspace = true

--- a/crates/blinc_runtime/Cargo.toml
+++ b/crates/blinc_runtime/Cargo.toml
@@ -14,12 +14,12 @@ default = ["full"]
 full = ["blinc_core", "blinc_animation", "blinc_layout", "blinc_gpu", "blinc_paint"]
 
 [dependencies]
-blinc_core = { path = "../blinc_core", version = "0.1.13", optional = true }
-blinc_animation = { path = "../blinc_animation", version = "0.1.13", optional = true }
-blinc_layout = { path = "../blinc_layout", version = "0.1.13", optional = true }
-blinc_gpu = { path = "../blinc_gpu", version = "0.1.13", optional = true }
-blinc_paint = { path = "../blinc_paint", version = "0.1.13", optional = true }
-# blinc_cn = { path = "../blinc_cn", version = "0.1.13", optional = true }
+blinc_core = { path = "../blinc_core", version = "0.1.14", optional = true }
+blinc_animation = { path = "../blinc_animation", version = "0.1.14", optional = true }
+blinc_layout = { path = "../blinc_layout", version = "0.1.14", optional = true }
+blinc_gpu = { path = "../blinc_gpu", version = "0.1.14", optional = true }
+blinc_paint = { path = "../blinc_paint", version = "0.1.14", optional = true }
+# blinc_cn = { path = "../blinc_cn", version = "0.1.14", optional = true }
 
 # Errors
 anyhow.workspace = true

--- a/crates/blinc_svg/Cargo.toml
+++ b/crates/blinc_svg/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["ui", "gui", "svg", "blinc"]
 categories = ["gui", "graphics"]
 
 [dependencies]
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
 usvg = "0.44"
 resvg = "0.44"
 tiny-skia = "0.11"

--- a/crates/blinc_test_suite/Cargo.toml
+++ b/crates/blinc_test_suite/Cargo.toml
@@ -23,12 +23,12 @@ interactive = []
 
 [dependencies]
 # Core Blinc crates
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
-blinc_gpu = { path = "../blinc_gpu", version = "0.1.13" }
-blinc_layout = { path = "../blinc_layout", version = "0.1.13" }
-blinc_paint = { path = "../blinc_paint", version = "0.1.13" }
-blinc_text = { path = "../blinc_text", version = "0.1.13" }
-blinc_svg = { path = "../blinc_svg", version = "0.1.13" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
+blinc_gpu = { path = "../blinc_gpu", version = "0.1.14" }
+blinc_layout = { path = "../blinc_layout", version = "0.1.14" }
+blinc_paint = { path = "../blinc_paint", version = "0.1.14" }
+blinc_text = { path = "../blinc_text", version = "0.1.14" }
+blinc_svg = { path = "../blinc_svg", version = "0.1.14" }
 
 # GPU and windowing
 wgpu.workspace = true

--- a/crates/blinc_text/Cargo.toml
+++ b/crates/blinc_text/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["ui", "gui", "text", "font", "blinc"]
 categories = ["gui", "text-processing"]
 
 [dependencies]
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
 
 # Font parsing
 ttf-parser = { workspace = true }

--- a/crates/blinc_theme/Cargo.toml
+++ b/crates/blinc_theme/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["ui", "gui", "theme", "design", "blinc"]
 categories = ["gui"]
 
 [dependencies]
-blinc_core = { path = "../blinc_core", version = "0.1.13" }
-blinc_animation = { path = "../blinc_animation", version = "0.1.13" }
+blinc_core = { path = "../blinc_core", version = "0.1.14" }
+blinc_animation = { path = "../blinc_animation", version = "0.1.14" }
 
 # Utilities
 tracing = { workspace = true }

--- a/docs/book/src/advanced/performance.md
+++ b/docs/book/src/advanced/performance.md
@@ -4,25 +4,23 @@ Blinc is designed for high performance, but following these guidelines ensures y
 
 ## Use Stateful for Visual States
 
-**Do:** Use `stateful(handle)` for hover, press, and focus effects:
+**Do:** Use `stateful::<S>()` for hover, press, and focus effects:
 
 ```rust
 use blinc_layout::stateful::stateful;
 
-fn hover_button(ctx: &WindowedContext) -> impl ElementBuilder {
-    let handle = ctx.use_state(ButtonState::Idle);
-
-    stateful(handle)
+fn hover_button() -> impl ElementBuilder {
+    stateful::<ButtonState>()
         .px(16.0)
         .py(8.0)
         .rounded(8.0)
-        .on_state(|state, div| {
-            let bg = match state {
+        .on_state(|ctx| {
+            let bg = match ctx.state() {
                 ButtonState::Idle => Color::RED,
                 ButtonState::Hovered => Color::BLUE,
                 _ => Color::RED,
             };
-            div.set_bg(bg);
+            div().bg(bg)
         })
         .child(text("Hover me").color(Color::WHITE))
 }
@@ -43,7 +41,7 @@ div()
     })
 ```
 
-The `stateful(handle)` pattern only updates the affected element, while signals with if-else rebuild the entire UI tree.
+The `stateful::<S>()` pattern only updates the affected element, while signals with if-else rebuild the entire UI tree.
 
 ## Minimize Signal Updates
 

--- a/docs/book/src/animation/motion.md
+++ b/docs/book/src/animation/motion.md
@@ -163,41 +163,31 @@ fn pull_to_refresh(ctx: &WindowedContext) -> impl ElementBuilder {
 Use a stateful element with `.deps()` to react to visibility state changes:
 
 ```rust
-fn animated_card_list(ctx: &WindowedContext) -> impl ElementBuilder {
-    let show_cards = ctx.use_state_keyed("show_cards", || true);
-    let button_handle = ctx.use_state(ButtonState::Idle);
-
-    stateful(button_handle)
+fn animated_card_list(show_cards: State<bool>) -> impl ElementBuilder {
+    stateful::<ButtonState>()
         .flex_col()
         .gap(16.0)
-        .deps(&[show_cards.signal_id()])
-        .on_state(move |state, container| {
+        .deps([show_cards.signal_id()])
+        .on_state(move |ctx| {
             let visible = show_cards.get();
             let label = if visible { "Hide Cards" } else { "Show Cards" };
 
-            let bg = match state {
+            let bg = match ctx.state() {
                 ButtonState::Idle => Color::rgba(0.3, 0.5, 0.9, 1.0),
                 ButtonState::Hovered => Color::rgba(0.4, 0.6, 1.0, 1.0),
                 _ => Color::rgba(0.3, 0.5, 0.9, 1.0),
             };
 
-            // Build content based on visibility
-            let mut content = div()
-                .bg(bg)
-                .px(16.0)
-                .py(8.0)
-                .rounded(8.0)
-                .child(text(label).color(Color::WHITE));
-
-            container.merge(content);
+            div().bg(bg).px(16.0).py(8.0).rounded(8.0)
+                .child(text(label).color(Color::WHITE))
         })
         .on_click(move |_| {
             show_cards.update(|v| !v);
         })
-        .child(card_list(ctx))
+        .child(card_list())
 }
 
-fn card_list(ctx: &WindowedContext) -> impl ElementBuilder {
+fn card_list() -> impl ElementBuilder {
     // Cards with staggered animation
     motion()
         .stagger(StaggerConfig::new(80, AnimationPreset::fade_in(300)))
@@ -221,10 +211,11 @@ fn card_list(ctx: &WindowedContext) -> impl ElementBuilder {
 Use a custom state type for page navigation:
 
 ```rust
-use blinc_layout::stateful::{stateful, StateTransitions};
+use blinc_layout::stateful::{stateful, StateTransitions, use_shared_state};
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
 enum Page {
+    #[default]
     Home,
     Settings,
     Profile,
@@ -237,51 +228,44 @@ impl StateTransitions for Page {
     }
 }
 
-fn page_transition(ctx: &WindowedContext) -> impl ElementBuilder {
-    let page_handle = ctx.use_state(Page::Home);
-
-    stateful(page_handle.clone())
+fn page_transition(current_page: State<u8>) -> impl ElementBuilder {
+    stateful::<NoState>()
         .w_full()
         .h_full()
-        .on_state(move |page, container| {
-            // Render different content based on current page
-            let content = match page {
-                Page::Home => div().child(text("Home Page").color(Color::WHITE)),
-                Page::Settings => div().child(text("Settings Page").color(Color::WHITE)),
-                Page::Profile => div().child(text("Profile Page").color(Color::WHITE)),
+        .deps([current_page.signal_id()])
+        .on_state(move |_ctx| {
+            // Render different content based on current page signal
+            let content = match current_page.get() {
+                0 => div().child(text("Home Page").color(Color::WHITE)),
+                1 => div().child(text("Settings Page").color(Color::WHITE)),
+                _ => div().child(text("Profile Page").color(Color::WHITE)),
             };
 
-            container.merge(
-                div()
-                    .child(
-                        motion()
-                            .fade_in(200)
-                            .slide_in(SlideDirection::Right, 200)
-                            .child(content)
-                    )
-            );
+            div().child(
+                motion()
+                    .fade_in(200)
+                    .slide_in(SlideDirection::Right, 200)
+                    .child(content)
+            )
         })
 }
 
-// Navigate programmatically
-fn nav_button(ctx: &WindowedContext, target: Page, label: &str) -> impl ElementBuilder {
-    let page_handle = ctx.use_state(Page::Home);  // Same handle
-    let handle = ctx.use_state_for(label, ButtonState::Idle);
-
-    stateful(handle)
+// Navigate programmatically using a shared signal
+fn nav_button(current_page: State<u8>, target: u8, label: &str) -> impl ElementBuilder {
+    stateful::<ButtonState>()
         .px(16.0)
         .py(8.0)
         .rounded(8.0)
-        .on_state(|state, div| {
-            let bg = match state {
+        .on_state(|ctx| {
+            let bg = match ctx.state() {
                 ButtonState::Idle => Color::rgba(0.3, 0.5, 0.9, 1.0),
                 ButtonState::Hovered => Color::rgba(0.4, 0.6, 1.0, 1.0),
                 _ => Color::rgba(0.3, 0.5, 0.9, 1.0),
             };
-            div.set_bg(bg);
+            div().bg(bg)
         })
         .on_click(move |_| {
-            page_handle.set(target);
+            current_page.set(target);
         })
         .child(text(label).color(Color::WHITE))
 }

--- a/docs/book/src/animation/springs.md
+++ b/docs/book/src/animation/springs.md
@@ -113,7 +113,7 @@ fn hover_scale_card(ctx: &WindowedContext) -> impl ElementBuilder {
 }
 ```
 
-**Note:** For simple hover state changes without spring physics (e.g., just color changes), prefer `stateful(handle)` which is more efficient. Use `motion()` when you specifically need spring-animated values.
+**Note:** For simple hover state changes without spring physics (e.g., just color changes), prefer `stateful::<S>()` which is more efficient. Use `motion()` when you specifically need spring-animated values.
 
 ### Example: Drag Position
 

--- a/docs/book/src/architecture/reactive-state.md
+++ b/docs/book/src/architecture/reactive-state.md
@@ -35,12 +35,12 @@ When code accesses a signal's value, the dependency is automatically recorded:
 
 ```rust
 // Stateful element with signal dependency
-stateful(handle)
-    .deps(&[count.signal_id()])  // Declare dependency
-    .on_state(move |state, div| {
+stateful::<ButtonState>()
+    .deps([count.signal_id()])  // Declare dependency
+    .on_state(move |ctx| {
         // Reading count.get() here is tracked
         let value = count.get();
-        div.set_bg(color_for_value(value));
+        div().bg(color_for_value(value))
     })
 ```
 
@@ -149,18 +149,14 @@ ctx.batch(|g| {
 The reactive system integrates with stateful elements via `.deps()`:
 
 ```rust
-fn counter_display(ctx: &WindowedContext, count: State<i32>) -> impl ElementBuilder {
-    let handle = ctx.use_state(ButtonState::Idle);
-
-    stateful(handle)
+fn counter_display(count: State<i32>) -> impl ElementBuilder {
+    stateful::<NoState>()
         // Declare signal dependencies
-        .deps(&[count.signal_id()])
-        .on_state(move |_state, container| {
+        .deps([count.signal_id()])
+        .on_state(move |_ctx| {
             // This callback re-runs when count changes
             let current = count.get();
-            container.merge(
-                div().child(text(&format!("{}", current)).color(Color::WHITE))
-            );
+            div().child(text(&format!("{}", current)).color(Color::WHITE))
         })
 }
 ```

--- a/docs/book/src/components/blinc-component.md
+++ b/docs/book/src/components/blinc-component.md
@@ -47,62 +47,55 @@ fn counter_demo(ctx: &WindowedContext) -> impl ElementBuilder {
     let count = Counter::use_count(ctx, 0);
     let step = Counter::use_step(ctx, 1);
 
-    // Create persistent button state handle
-    let button_handle = ctx.use_state(ButtonState::Idle);
-
-    // Use stateful(handle) with .deps() to react to state changes
-    stateful(button_handle)
+    // Use stateful::<S>() with .deps() to react to state changes
+    stateful::<ButtonState>()
         .flex_col()
         .gap(16.0)
         .p(16.0)
-        .deps(&[count.signal_id(), step.signal_id()])
-        .on_state(move |state, container| {
+        .deps([count.signal_id(), step.signal_id()])
+        .on_state(move |ctx| {
             // Read current values inside on_state
             let current_count = count.get();
             let current_step = step.get();
 
-            let bg = match state {
+            let bg = match ctx.state() {
                 ButtonState::Idle => Color::rgba(0.15, 0.15, 0.2, 1.0),
                 ButtonState::Hovered => Color::rgba(0.18, 0.18, 0.25, 1.0),
                 _ => Color::rgba(0.15, 0.15, 0.2, 1.0),
             };
 
-            // Update container with dynamic content
-            container.merge(
-                div()
-                    .bg(bg)
-                    .child(text(&format!("Count: {}", current_count)).color(Color::WHITE))
-                    .child(text(&format!("Step: {}", current_step)).color(Color::WHITE))
-            );
+            // Return a Div with dynamic content
+            div()
+                .bg(bg)
+                .child(text(&format!("Count: {}", current_count)).color(Color::WHITE))
+                .child(text(&format!("Step: {}", current_step)).color(Color::WHITE))
         })
         .on_click(move |_| {
             let current_step = step.get();
             count.update(|v| v + current_step);
         })
-        .child(increment_button(ctx))
+        .child(increment_button())
 }
 
-fn increment_button(ctx: &WindowedContext) -> impl ElementBuilder {
-    let handle = ctx.use_state(ButtonState::Idle);
-
-    stateful(handle)
+fn increment_button() -> impl ElementBuilder {
+    stateful::<ButtonState>()
         .px(16.0)
         .py(8.0)
         .rounded(8.0)
-        .on_state(|state, div| {
-            let bg = match state {
+        .on_state(|ctx| {
+            let bg = match ctx.state() {
                 ButtonState::Idle => Color::rgba(0.3, 0.5, 0.9, 1.0),
                 ButtonState::Hovered => Color::rgba(0.4, 0.6, 1.0, 1.0),
                 ButtonState::Pressed => Color::rgba(0.2, 0.4, 0.8, 1.0),
                 _ => Color::rgba(0.3, 0.5, 0.9, 1.0),
             };
-            div.set_bg(bg);
+            div().bg(bg)
         })
         .child(text("Increment").color(Color::WHITE))
 }
 ```
 
-**Key point:** When UI content depends on state values that can change, use `stateful(handle)` with `.deps()` to declare the dependency. The `on_state` callback re-runs whenever those signals change, and you update the display via `container.merge()` or `div.set_*()` methods.
+**Key point:** When UI content depends on state values that can change, use `stateful::<S>()` with `.deps()` to declare the dependency. The `on_state` callback re-runs whenever those signals change, and you return a `Div` with the updated content.
 
 ### Common State Patterns
 

--- a/docs/book/src/components/reusable.md
+++ b/docs/book/src/components/reusable.md
@@ -57,48 +57,40 @@ card_with_content("Settings",
 )
 ```
 
-### Components with Context
+### Stateful Components
 
-For components needing state or animations:
+For components needing interactive state or reactive updates:
 
 ```rust
 use blinc_layout::stateful::stateful;
 
-fn counter_card(ctx: &WindowedContext) -> impl ElementBuilder {
-    let count = ctx.use_state_keyed("counter_card_count", || 0i32);
-    let card_handle = ctx.use_state(ButtonState::Idle);
-
-    stateful(card_handle)
+fn counter_card(count: State<i32>) -> impl ElementBuilder {
+    stateful::<ButtonState>()
         .p(16.0)
         .rounded(12.0)
         .bg(Color::rgba(0.15, 0.15, 0.2, 1.0))
         .flex_col()
         .gap(12.0)
-        .deps(&[count.signal_id()])
-        .on_state(move |_state, container| {
+        .deps([count.signal_id()])
+        .on_state(move |_ctx| {
             let current = count.get();
-            container.merge(
-                div()
-                    .child(text(&format!("Count: {}", current)).color(Color::WHITE))
-            );
+            div().child(text(&format!("Count: {}", current)).color(Color::WHITE))
         })
-        .child(increment_btn(ctx, count))
+        .child(increment_btn(count))
 }
 
-fn increment_btn(ctx: &WindowedContext, count: State<i32>) -> impl ElementBuilder {
-    let handle = ctx.use_state(ButtonState::Idle);
-
-    stateful(handle)
+fn increment_btn(count: State<i32>) -> impl ElementBuilder {
+    stateful::<ButtonState>()
         .px(16.0)
         .py(8.0)
         .rounded(8.0)
-        .on_state(|state, div| {
-            let bg = match state {
+        .on_state(|ctx| {
+            let bg = match ctx.state() {
                 ButtonState::Idle => Color::rgba(0.3, 0.5, 0.9, 1.0),
                 ButtonState::Hovered => Color::rgba(0.4, 0.6, 1.0, 1.0),
                 _ => Color::rgba(0.3, 0.5, 0.9, 1.0),
             };
-            div.set_bg(bg);
+            div().bg(bg)
         })
         .on_click(move |_| {
             count.update(|v| v + 1);
@@ -151,32 +143,29 @@ fn animated_card(ctx: &WindowedContext, title: &str) -> impl ElementBuilder {
 }
 ```
 
-**Note:** For hover-only visual effects without animations, prefer `Stateful` instead - it's more efficient as it doesn't require continuous redraws.
+**Note:** For hover-only visual effects without animations, prefer `stateful::<S>()` instead - it's more efficient as it doesn't require continuous redraws.
 
 ---
 
 ## Stateful Components
 
-Use `stateful(handle)` for components with visual states:
+Use `stateful::<S>()` for components with visual states:
 
 ```rust
 use blinc_layout::stateful::stateful;
 
-fn interactive_card(ctx: &WindowedContext, title: &str) -> impl ElementBuilder {
-    // Use use_state_for with title as key for reusable component
-    let handle = ctx.use_state_for(title, ButtonState::Idle);
-
-    stateful(handle)
+fn interactive_card(title: &str) -> impl ElementBuilder {
+    stateful::<ButtonState>()
         .p(16.0)
         .rounded(12.0)
-        .on_state(|state, div| {
-            let bg = match state {
+        .on_state(|ctx| {
+            let bg = match ctx.state() {
                 ButtonState::Idle => Color::rgba(0.15, 0.15, 0.2, 1.0),
                 ButtonState::Hovered => Color::rgba(0.18, 0.18, 0.25, 1.0),
                 ButtonState::Pressed => Color::rgba(0.12, 0.12, 0.16, 1.0),
                 _ => Color::rgba(0.15, 0.15, 0.2, 1.0),
             };
-            div.set_bg(bg);
+            div().bg(bg)
         })
         .child(text(title).color(Color::WHITE))
 }
@@ -363,6 +352,6 @@ pub fn notification(props: NotificationProps) -> Div {
 
 7. **Use BlincComponent for state and animations** - Type-safe hooks for both `State<T>` and `SharedAnimatedValue` prevent key collisions.
 
-8. **Use Stateful for visual states** - Hover, press, focus effects should use `Stateful` rather than signals.
+8. **Use `stateful::<S>()` for visual states** - Hover, press, focus effects should use stateful containers rather than signals.
 
 9. **Use motion() for animated values** - Wrap animated content in `motion()` for proper redraws.

--- a/docs/book/src/core/events.md
+++ b/docs/book/src/core/events.md
@@ -149,20 +149,18 @@ Use `ToggleState` for toggle buttons - it handles click transitions automaticall
 ```rust
 use blinc_layout::stateful::stateful;
 
-fn toggle_button(ctx: &WindowedContext) -> impl ElementBuilder {
-    let handle = ctx.use_state(ToggleState::Off);
-
-    stateful(handle)
+fn toggle_button() -> impl ElementBuilder {
+    stateful::<ToggleState>()
         .w(100.0)
         .h(40.0)
         .rounded(8.0)
         .flex_center()
-        .on_state(|state, div| {
-            let bg = match state {
+        .on_state(|ctx| {
+            let bg = match ctx.state() {
                 ToggleState::Off => Color::rgba(0.3, 0.3, 0.35, 1.0),
                 ToggleState::On => Color::rgba(0.2, 0.8, 0.4, 1.0),
             };
-            div.set_bg(bg);
+            div().bg(bg)
         })
         .on_click(|_| {
             println!("Toggled!");
@@ -226,20 +224,17 @@ fn keyboard_handler(ctx: &WindowedContext) -> impl ElementBuilder {
 ```rust
 use blinc_layout::stateful::stateful;
 
-fn hover_card(ctx: &WindowedContext) -> impl ElementBuilder {
-    let handle = ctx.use_state(ButtonState::Idle);
-
-    stateful(handle)
+fn hover_card() -> impl ElementBuilder {
+    stateful::<ButtonState>()
         .w(200.0)
         .h(120.0)
         .rounded(12.0)
-        .on_state(|state, div| {
-            let (bg, scale) = match state {
+        .on_state(|ctx| {
+            let (bg, scale) = match ctx.state() {
                 ButtonState::Hovered => (Color::rgba(0.2, 0.2, 0.3, 1.0), 1.02),
                 _ => (Color::rgba(0.15, 0.15, 0.2, 1.0), 1.0),
             };
-            div.set_bg(bg);
-            div.set_transform(Transform::scale(scale, scale));
+            div().bg(bg).transform(Transform::scale(scale, scale))
         })
         .child(text("Hover me!").color(Color::WHITE))
 }
@@ -321,7 +316,7 @@ fn shared_state_example() -> impl ElementBuilder {
 
 1. **Keep handlers lightweight** - Do minimal work in event handlers. For heavy operations, queue work or update state.
 
-2. **Use stateful(handle) for hover/press** - Instead of manually tracking hover state, use `ctx.use_state()` with `stateful(handle)` which handles state transitions automatically.
+2. **Use `stateful::<S>()` for hover/press** - Instead of manually tracking hover state, use `stateful::<ButtonState>()` which handles state transitions automatically.
 
 3. **Clone before closures** - Clone `Arc`, signals, or context references before moving them into closures.
 

--- a/docs/book/src/core/styling-materials.md
+++ b/docs/book/src/core/styling-materials.md
@@ -303,25 +303,23 @@ fn ghost_button() -> Div {
 
 ### Hover Effects with State
 
-Use `stateful(handle)` to create elements with automatic hover/press state transitions:
+Use `stateful::<S>()` to create elements with automatic hover/press state transitions:
 
 ```rust
 use blinc_layout::stateful::stateful;
 
-fn hoverable_card(ctx: &WindowedContext) -> impl ElementBuilder {
-    let handle = ctx.use_state(ButtonState::Idle);
-
-    stateful(handle)
+fn hoverable_card() -> impl ElementBuilder {
+    stateful::<ButtonState>()
         .p(16.0)
         .rounded(12.0)
-        .on_state(|state, div| {
-            let bg = match state {
+        .on_state(|ctx| {
+            let bg = match ctx.state() {
                 ButtonState::Idle => Color::rgba(0.15, 0.15, 0.2, 1.0),
                 ButtonState::Hovered => Color::rgba(0.18, 0.18, 0.24, 1.0),
                 ButtonState::Pressed => Color::rgba(0.12, 0.12, 0.16, 1.0),
                 _ => Color::rgba(0.15, 0.15, 0.2, 1.0),
             };
-            div.set_bg(bg);
+            div().bg(bg)
         })
         .child(text("Hover me").color(Color::WHITE))
 }

--- a/docs/book/src/core/theming.md
+++ b/docs/book/src/core/theming.md
@@ -254,21 +254,20 @@ fn my_component() -> impl ElementBuilder {
 For interactive elements that need to respond to theme changes within event handlers, fetch colors inside the callback:
 
 ```rust
-fn themed_button(ctx: &WindowedContext) -> impl ElementBuilder {
-    let handle = ctx.use_state_for("btn", ButtonState::Idle);
-
-    stateful(handle)
-        .on_state(|state, div| {
+fn themed_button() -> impl ElementBuilder {
+    stateful::<ButtonState>()
+        .on_state(|ctx| {
             // Fetch colors inside callback for theme reactivity
             let theme = ThemeState::get();
             let primary = theme.color(ColorToken::Primary);
             let primary_hover = theme.color(ColorToken::PrimaryHover);
 
-            match state {
-                ButtonState::Idle => div.set_bg(primary),
-                ButtonState::Hovered => div.set_bg(primary_hover),
-                // ...
-            }
+            let bg = match ctx.state() {
+                ButtonState::Idle => primary,
+                ButtonState::Hovered => primary_hover,
+                _ => primary,
+            };
+            div().bg(bg)
         })
         .child(text("Click me"))
 }
@@ -537,34 +536,28 @@ use blinc_app::prelude::*;
 use blinc_theme::{ThemeState, ColorToken};
 
 fn notification_toast(
-    ctx: &WindowedContext,
     message: &str,
     variant: ColorToken,
 ) -> impl ElementBuilder {
     let theme = ThemeState::get();
-    let handle = ctx.use_state_for("toast", ButtonState::Idle);
-
     let bg_color = theme.color(variant);
 
-    stateful(handle)
+    stateful::<ButtonState>()
         .w(320.0)
         .p(theme.spacing().space_4)
         .rounded(theme.radii().radius_lg)
         .bg(bg_color.with_alpha(0.15))
         .border(1.0, bg_color.with_alpha(0.3))
         .shadow_md()
-        .on_state(move |state, div| {
+        .on_state(move |ctx| {
             let theme = ThemeState::get();
             let base = theme.color(variant);
 
-            match state {
-                ButtonState::Hovered => {
-                    div.set_bg(base.with_alpha(0.2));
-                }
-                _ => {
-                    div.set_bg(base.with_alpha(0.15));
-                }
-            }
+            let bg = match ctx.state() {
+                ButtonState::Hovered => base.with_alpha(0.2),
+                _ => base.with_alpha(0.15),
+            };
+            div().bg(bg)
         })
         .flex_row()
         .items_center()
@@ -585,7 +578,7 @@ fn notification_toast(
 }
 
 // Usage
-notification_toast(ctx, "File saved successfully", ColorToken::Success)
-notification_toast(ctx, "Network error occurred", ColorToken::Error)
-notification_toast(ctx, "New update available", ColorToken::Info)
+notification_toast("File saved successfully", ColorToken::Success)
+notification_toast("Network error occurred", ColorToken::Error)
+notification_toast("New update available", ColorToken::Info)
 ```

--- a/docs/book/src/getting-started/first-app.md
+++ b/docs/book/src/getting-started/first-app.md
@@ -70,14 +70,13 @@ fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
 
 ### Step 3: Building the Layout with Stateful Elements
 
-The key insight in Blinc is that UI doesn't rebuild on every state change. Instead, we use `stateful(handle)` with `.deps()` to react to state changes:
+The key insight in Blinc is that UI doesn't rebuild on every state change. Instead, we use `stateful::<S>()` with `.deps()` to react to state changes:
 
 ```rust
 use blinc_layout::stateful::stateful;
 
 fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
     let count = ctx.use_state_keyed("counter", || 0i32);
-    let container_handle = ctx.use_state(ButtonState::Idle);
 
     div()
         .w(ctx.width)
@@ -95,71 +94,62 @@ fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
                 .color(Color::WHITE)
         )
         // Count display - uses stateful with deps to update when count changes
-        .child(count_display(ctx, count.clone()))
+        .child(count_display(count.clone()))
         // Buttons row
         .child(
             div()
                 .flex_row()
                 .gap(16.0)
-                .child(counter_button(ctx, count.clone(), "-", -1))
-                .child(counter_button(ctx, count.clone(), "+", 1))
+                .child(counter_button(count.clone(), "-", -1))
+                .child(counter_button(count.clone(), "+", 1))
         )
 }
 ```
 
 ### Step 4: Creating the Count Display
 
-The count display needs to update when the count changes. We use `stateful(handle)` with `.deps()`:
+The count display needs to update when the count changes. We use `stateful::<NoState>()` with `.deps()`:
 
 ```rust
-fn count_display(ctx: &WindowedContext, count: State<i32>) -> impl ElementBuilder {
-    let handle = ctx.use_state(ButtonState::Idle);
-
-    stateful(handle)
-        .deps(&[count.signal_id()])
-        .on_state(move |_state, container| {
+fn count_display(count: State<i32>) -> impl ElementBuilder {
+    stateful::<NoState>()
+        .deps([count.signal_id()])
+        .on_state(move |_ctx| {
             let current = count.get();
-            container.merge(
-                div()
-                    .child(
-                        text(&format!("{}", current))
-                            .size(64.0)
-                            .weight(FontWeight::Bold)
-                            .color(Color::rgba(0.4, 0.6, 1.0, 1.0))
-                    )
-            );
+            div().child(
+                text(&format!("{}", current))
+                    .size(64.0)
+                    .weight(FontWeight::Bold)
+                    .color(Color::rgba(0.4, 0.6, 1.0, 1.0))
+            )
         })
 }
 ```
 
 ### Step 5: Creating Interactive Buttons
 
-For interactive buttons with hover and press states, use `stateful(handle)`:
+For interactive buttons with hover and press states, use `stateful::<ButtonState>()`:
 
 ```rust
 fn counter_button(
-    ctx: &WindowedContext,
     count: State<i32>,
     label: &'static str,
     delta: i32,
 ) -> impl ElementBuilder {
-    // Use use_state_for for reusable components with a unique key
-    let handle = ctx.use_state_for(label, ButtonState::Idle);
-
-    stateful(handle)
+    stateful::<ButtonState>()
         .w(60.0)
         .h(60.0)
         .rounded(12.0)
         .flex_center()
-        .on_state(|state, div| {
+        .on_state(|ctx| {
             // Apply different styles based on current state
-            let bg = match state {
+            let bg = match ctx.state() {
                 ButtonState::Idle => Color::rgba(0.2, 0.2, 0.25, 1.0),
                 ButtonState::Hovered => Color::rgba(0.3, 0.3, 0.35, 1.0),
                 ButtonState::Pressed => Color::rgba(0.15, 0.15, 0.2, 1.0),
                 ButtonState::Disabled => Color::rgba(0.1, 0.1, 0.12, 0.5),
             };
-            div.set_bg(bg);
+            div().bg(bg)
         })
         .on_click(move |_| {
             count.update(|v| v + delta);
@@ -215,56 +205,48 @@ fn build_ui(ctx: &WindowedContext) -> impl ElementBuilder {
                 .weight(FontWeight::Bold)
                 .color(Color::WHITE)
         )
-        .child(count_display(ctx, count.clone()))
+        .child(count_display(count.clone()))
         .child(
             div()
                 .flex_row()
                 .gap(16.0)
-                .child(counter_button(ctx, count.clone(), "-", -1))
-                .child(counter_button(ctx, count.clone(), "+", 1))
+                .child(counter_button(count.clone(), "-", -1))
+                .child(counter_button(count.clone(), "+", 1))
         )
 }
 
-fn count_display(ctx: &WindowedContext, count: State<i32>) -> impl ElementBuilder {
-    let handle = ctx.use_state(ButtonState::Idle);
-
-    stateful(handle)
-        .deps(&[count.signal_id()])
-        .on_state(move |_state, container| {
+fn count_display(count: State<i32>) -> impl ElementBuilder {
+    stateful::<NoState>()
+        .deps([count.signal_id()])
+        .on_state(move |_ctx| {
             let current = count.get();
-            container.merge(
-                div()
-                    .child(
-                        text(&format!("{}", current))
-                            .size(64.0)
-                            .weight(FontWeight::Bold)
-                            .color(Color::rgba(0.4, 0.6, 1.0, 1.0))
-                    )
-            );
+            div().child(
+                text(&format!("{}", current))
+                    .size(64.0)
+                    .weight(FontWeight::Bold)
+                    .color(Color::rgba(0.4, 0.6, 1.0, 1.0))
+            )
         })
 }
 
 fn counter_button(
-    ctx: &WindowedContext,
     count: State<i32>,
     label: &'static str,
     delta: i32,
 ) -> impl ElementBuilder {
-    let handle = ctx.use_state_for(label, ButtonState::Idle);
-
-    stateful(handle)
+    stateful::<ButtonState>()
         .w(60.0)
         .h(60.0)
         .rounded(12.0)
         .flex_center()
-        .on_state(|state, div| {
-            let bg = match state {
+        .on_state(|ctx| {
+            let bg = match ctx.state() {
                 ButtonState::Idle => Color::rgba(0.2, 0.2, 0.25, 1.0),
                 ButtonState::Hovered => Color::rgba(0.3, 0.3, 0.35, 1.0),
                 ButtonState::Pressed => Color::rgba(0.15, 0.15, 0.2, 1.0),
                 ButtonState::Disabled => Color::rgba(0.1, 0.1, 0.12, 0.5),
             };
-            div.set_bg(bg);
+            div().bg(bg)
         })
         .on_click(move |_| {
             count.update(|v| v + delta);
@@ -286,7 +268,7 @@ fn counter_button(
 1. **WindowedApp::run** - Entry point for desktop applications
 2. **WindowedContext** - Provides window dimensions and state hooks
 3. **use_state_keyed** - Creates reactive state with a string key
-4. **stateful(handle)** - Creates elements that react to state changes
+4. **stateful::\<S\>()** - Creates elements that react to state changes
 5. **deps()** - Declares signal dependencies for reactive updates
 6. **on_state** - Callback that runs when state or dependencies change
 7. **Fluent Builder API** - Chain methods like `.w()`, `.h()`, `.child()`

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -109,6 +109,10 @@ fn main() -> Result<()> {
 }
 ```
 
+## For AI Agents
+
+If you're an AI coding agent working with Blinc, see [Skills.md](https://github.com/project-blinc/Blinc/blob/main/Skills.md) in the repository root — a concise, example-driven reference with verified APIs, CSS-first styling patterns, and common pitfalls.
+
 ## Next Steps
 
 - [Installation](./getting-started/installation.md) - Set up your development environment

--- a/docs/book/src/widgets/media.md
+++ b/docs/book/src/widgets/media.md
@@ -252,23 +252,20 @@ fn avatar(url: &str, size: f32) -> impl ElementBuilder {
 ```rust
 use blinc_layout::stateful::stateful;
 
-fn icon_button(ctx: &WindowedContext, icon_path: &str) -> impl ElementBuilder {
-    // Use use_state_for with icon_path as key for reusable component
-    let handle = ctx.use_state_for(icon_path, ButtonState::Idle);
-
-    stateful(handle)
+fn icon_button(icon_path: &str) -> impl ElementBuilder {
+    stateful::<ButtonState>()
         .w(40.0)
         .h(40.0)
         .rounded(8.0)
         .flex_center()
-        .on_state(|state, div| {
-            let bg = match state {
+        .on_state(|ctx| {
+            let bg = match ctx.state() {
                 ButtonState::Idle => Color::TRANSPARENT,
                 ButtonState::Hovered => Color::rgba(0.2, 0.2, 0.25, 1.0),
                 ButtonState::Pressed => Color::rgba(0.15, 0.15, 0.2, 1.0),
                 _ => Color::TRANSPARENT,
             };
-            div.set_bg(bg);
+            div().bg(bg)
         })
         .child(
             svg(icon_path)

--- a/extensions/blinc_platform_android/Cargo.toml
+++ b/extensions/blinc_platform_android/Cargo.toml
@@ -20,9 +20,9 @@ default-activity = []
 
 [dependencies]
 # Core dependencies (always available)
-blinc_core = { path = "../../crates/blinc_core", version = "0.1.13" }
-blinc_animation = { path = "../../crates/blinc_animation", version = "0.1.13" }
-blinc_platform = { path = "../../crates/blinc_platform", version = "0.1.13" }
+blinc_core = { path = "../../crates/blinc_core", version = "0.1.14" }
+blinc_animation = { path = "../../crates/blinc_animation", version = "0.1.14" }
+blinc_platform = { path = "../../crates/blinc_platform", version = "0.1.14" }
 
 # Logging (platform-independent)
 tracing.workspace = true
@@ -31,7 +31,7 @@ log = "0.4"
 
 # Android-specific dependencies (only when targeting Android)
 [target.'cfg(target_os = "android")'.dependencies]
-blinc_gpu = { path = "../../crates/blinc_gpu", version = "0.1.13", default-features = false, features = ["vulkan"], optional = true }
+blinc_gpu = { path = "../../crates/blinc_gpu", version = "0.1.14", default-features = false, features = ["vulkan"], optional = true }
 
 # Android NDK
 ndk.workspace = true

--- a/extensions/blinc_platform_desktop/Cargo.toml
+++ b/extensions/blinc_platform_desktop/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 
 [dependencies]
 # Platform abstraction
-blinc_platform = { path = "../../crates/blinc_platform", version = "0.1.13" }
+blinc_platform = { path = "../../crates/blinc_platform", version = "0.1.14" }
 
 # Windowing
 winit.workspace = true

--- a/extensions/blinc_platform_ios/Cargo.toml
+++ b/extensions/blinc_platform_ios/Cargo.toml
@@ -17,9 +17,9 @@ zrtl-plugin = []
 
 [dependencies]
 # Core dependencies (always available)
-blinc_core = { path = "../../crates/blinc_core", version = "0.1.13" }
-blinc_animation = { path = "../../crates/blinc_animation", version = "0.1.13" }
-blinc_platform = { path = "../../crates/blinc_platform", version = "0.1.13" }
+blinc_core = { path = "../../crates/blinc_core", version = "0.1.14" }
+blinc_animation = { path = "../../crates/blinc_animation", version = "0.1.14" }
+blinc_platform = { path = "../../crates/blinc_platform", version = "0.1.14" }
 
 # Logging
 tracing.workspace = true
@@ -30,7 +30,7 @@ libc = "0.2"
 
 # iOS-specific dependencies (only when targeting iOS)
 [target.'cfg(target_os = "ios")'.dependencies]
-blinc_gpu = { path = "../../crates/blinc_gpu", version = "0.1.13", default-features = false, features = ["metal"] }
+blinc_gpu = { path = "../../crates/blinc_gpu", version = "0.1.14", default-features = false, features = ["metal"] }
 
 # iOS/macOS Objective-C bindings
 objc2.workspace = true


### PR DESCRIPTION
## Summary
- Merge latest `upstream/main` changes into fork branch
- Includes upstream commits up to `43db407` (2026-03-03 fetch)
- Resolved merge conflicts in:
  - `crates/blinc_app/Cargo.toml`
  - `crates/blinc_cn/Cargo.toml`
  - `crates/blinc_layout/Cargo.toml`
- Conflict resolution favored upstream (`main`) definitions to align dependency/version updates

## Validation
- `cargo fmt --all`
- `cargo fmt --all -- --check`

## Upstream commits included
- 43db407 chore(canvas_kit): prepare crate for publishing
- 7e3c7ff feat(canvas_kit): add selection, spatial index, snap-to-grid, and background patterns
- 9b68f0d feat: add blinc_canvas_kit crate for interactive canvas pan/zoom
- 9281d35 style: cargo fmt css_debug example
- 63b4da1 chore: bump version to 0.1.14
- 00df844 fix: persist child event handlers and auto-assign inner IDs in stateful containers
- 01ec1d9 test: add css_debug example for var(), percentage, and color inheritance
- b3adfa2 fix: inherit CSS color property from parent to child text elements
- 5ffd901 docs: add no-web-search directive to Skills.md
- 9ba1ba0 docs: add .when() conditional rendering to Skills.md
- 55520db docs: clarify CSS transform FLIP support in Skills.md
- c958453 docs: add text .class() pitfall to Skills.md
- be58f4f docs: add Skills.md agent reference for Blinc framework
- 1a3fb06 docs: update stateful container API from legacy to current pattern
