### PR TITLE
chore: sync upstream/main into fork (2026-03-04)

### DIFF
--- a/crates/blinc_app/src/context.rs
+++ b/crates/blinc_app/src/context.rs
@@ -22,6 +22,7 @@ use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 
 use crate::error::Result;
+use crate::svg_atlas::SvgAtlas;
 
 /// Maximum number of images to keep in cache (prevents unbounded memory growth)
 const IMAGE_CACHE_CAPACITY: usize = 32;
@@ -55,9 +56,7 @@ fn effective_single_clip(primary: Option<[f32; 4]>, scroll: Option<[f32; 4]>) ->
     }
 }
 
-/// Maximum number of rasterized SVG textures to cache
-/// Key is (svg_hash, width, height, tint_hash) - separate textures for different sizes/tints
-const RASTERIZED_SVG_CACHE_CAPACITY: usize = 256;
+// Rasterized SVG textures are now packed into SvgAtlas (single shared GPU texture)
 
 /// Internal render context that manages GPU resources and rendering
 pub struct RenderContext {
@@ -75,8 +74,8 @@ pub struct RenderContext {
     image_cache: LruCache<String, GpuImage>,
     // LRU cache for parsed SVG documents (avoids re-parsing)
     svg_cache: LruCache<u64, SvgDocument>,
-    // LRU cache for rasterized SVG textures (CPU-rasterized with proper AA)
-    rasterized_svg_cache: LruCache<u64, GpuImage>,
+    // Texture atlas for rasterized SVGs (single shared GPU texture, shelf-packed)
+    svg_atlas: SvgAtlas,
     // Scratch buffers for per-frame allocations (reused to avoid allocations)
     scratch_glyphs: Vec<GpuGlyph>,
     scratch_texts: Vec<TextElement>,
@@ -294,6 +293,7 @@ impl RenderContext {
         sample_count: u32,
     ) -> Self {
         let image_ctx = ImageRenderingContext::new(device.clone(), queue.clone());
+        let svg_atlas = SvgAtlas::new(&device);
         Self {
             renderer,
             text_ctx,
@@ -305,9 +305,7 @@ impl RenderContext {
             msaa_texture: None,
             image_cache: LruCache::new(NonZeroUsize::new(IMAGE_CACHE_CAPACITY).unwrap()),
             svg_cache: LruCache::new(NonZeroUsize::new(SVG_CACHE_CAPACITY).unwrap()),
-            rasterized_svg_cache: LruCache::new(
-                NonZeroUsize::new(RASTERIZED_SVG_CACHE_CAPACITY).unwrap(),
-            ),
+            svg_atlas,
             scratch_glyphs: Vec::with_capacity(1024), // Pre-allocate for typical text
             scratch_texts: Vec::with_capacity(64),    // Pre-allocate for text elements
             scratch_svgs: Vec::with_capacity(32),     // Pre-allocate for SVG elements
@@ -777,14 +775,16 @@ impl RenderContext {
         let color_cap = self.text_ctx.color_glyph_cache_capacity();
         let img_cache = self.image_cache.len();
         let svg_cache = self.svg_cache.len();
-        let rast_svg = self.rasterized_svg_cache.len();
+        let svg_atlas_entries = self.svg_atlas.entry_count();
+        let svg_atlas_util = self.svg_atlas.utilization();
+        let (svg_aw, svg_ah) = (self.svg_atlas.width(), self.svg_atlas.height());
 
         tracing::info!(
             "Cache stats [frame {}]: \
              atlas={}x{} ({} glyphs, {:.1}% used), \
              color_atlas={}x{} ({} glyphs, {:.1}% used), \
              glyph_lru={}/{}, color_glyph_lru={}/{}, \
-             image={}/{}, svg_doc={}/{}, rasterized_svg={}/{}",
+             image={}/{}, svg_doc={}/{}, svg_atlas={}x{} ({} entries, {:.1}% used)",
             self.frame_count,
             aw,
             ah,
@@ -802,8 +802,10 @@ impl RenderContext {
             IMAGE_CACHE_CAPACITY,
             svg_cache,
             SVG_CACHE_CAPACITY,
-            rast_svg,
-            RASTERIZED_SVG_CACHE_CAPACITY,
+            svg_aw,
+            svg_ah,
+            svg_atlas_entries,
+            svg_atlas_util * 100.0,
         );
     }
 
@@ -1688,6 +1690,9 @@ impl RenderContext {
         svgs: &[SvgElement],
         scale_factor: f32,
     ) {
+        // Collect all instances for a single batched draw call
+        let mut instances: Vec<GpuImageInstance> = Vec::with_capacity(svgs.len());
+
         for svg in svgs {
             // Skip completely transparent SVGs
             if svg.motion_opacity <= 0.001 {
@@ -1807,8 +1812,8 @@ impl RenderContext {
                 hasher.finish()
             };
 
-            // Check cache first — skip string manipulation entirely on cache hit
-            if self.rasterized_svg_cache.get(&cache_key).is_none() {
+            // Check atlas first — skip string manipulation entirely on cache hit
+            if self.svg_atlas.get(cache_key).is_none() {
                 // Cache miss: build SVG source with inline attribute overrides
                 let has_overrides = svg.tint.is_some()
                     || svg.fill.is_some()
@@ -2095,23 +2100,28 @@ impl RenderContext {
                     }
                 };
 
-                // Upload to GPU
-                let gpu_image = GpuImage::from_rgba(
-                    &self.device,
-                    &self.queue,
-                    rasterized.data(),
-                    rasterized.width,
-                    rasterized.height,
-                    Some("Rasterized SVG"),
-                );
-
-                self.rasterized_svg_cache.put(cache_key, gpu_image);
+                // Insert into atlas (handles grow/clear internally)
+                if self
+                    .svg_atlas
+                    .insert(
+                        cache_key,
+                        rasterized.width,
+                        rasterized.height,
+                        rasterized.data(),
+                        &self.device,
+                    )
+                    .is_none()
+                {
+                    tracing::warn!("SVG atlas full, could not allocate {}x{}", raster_width, raster_height);
+                    continue;
+                }
             }
 
-            // Get the cached GPU image
-            let Some(gpu_image) = self.rasterized_svg_cache.get(&cache_key) else {
+            // Get the atlas region for this SVG
+            let Some(region) = self.svg_atlas.get(cache_key) else {
                 continue;
             };
+            let src_uv = region.uv_bounds(self.svg_atlas.width(), self.svg_atlas.height());
 
             // Apply CSS affine transform to SVG bounds if present.
             // Pass full 2x2 affine to shader for rotation, scale, and skew support.
@@ -2142,8 +2152,9 @@ impl RenderContext {
                     (svg.x, svg.y, svg.width, svg.height, 1.0, 0.0, 0.0, 1.0)
                 };
 
-            // Create instance at (possibly transformed) SVG position
+            // Create instance with atlas UV coordinates
             let mut instance = GpuImageInstance::new(draw_x, draw_y, draw_w, draw_h)
+                .with_src_uv(src_uv[0], src_uv[1], src_uv[2], src_uv[3])
                 .with_opacity(svg.motion_opacity)
                 .with_transform(ta, tb, tc, td);
 
@@ -2160,9 +2171,14 @@ impl RenderContext {
                 instance = instance.with_clip_rect(clip_x, clip_y, clip_w, clip_h);
             }
 
-            // Render the rasterized SVG as an image
+            instances.push(instance);
+        }
+
+        // Upload atlas to GPU if dirty, then batch-render all SVG instances
+        if !instances.is_empty() {
+            self.svg_atlas.upload(&self.queue);
             self.renderer
-                .render_images(target, gpu_image.view(), &[instance]);
+                .render_images(target, self.svg_atlas.view(), &instances);
         }
     }
 

--- a/crates/blinc_app/src/context.rs
+++ b/crates/blinc_app/src/context.rs
@@ -2112,7 +2112,11 @@ impl RenderContext {
                     )
                     .is_none()
                 {
-                    tracing::warn!("SVG atlas full, could not allocate {}x{}", raster_width, raster_height);
+                    tracing::warn!(
+                        "SVG atlas full, could not allocate {}x{}",
+                        raster_width,
+                        raster_height
+                    );
                     continue;
                 }
             }

--- a/crates/blinc_app/src/context.rs
+++ b/crates/blinc_app/src/context.rs
@@ -27,7 +27,7 @@ use crate::error::Result;
 const IMAGE_CACHE_CAPACITY: usize = 32;
 
 /// Maximum number of parsed SVG documents to cache
-const SVG_CACHE_CAPACITY: usize = 32;
+const SVG_CACHE_CAPACITY: usize = 128;
 
 /// Intersect two axis-aligned clip rects [x, y, w, h], returning their overlap.
 fn intersect_clip_rects(a: [f32; 4], b: [f32; 4]) -> [f32; 4] {
@@ -57,7 +57,7 @@ fn effective_single_clip(primary: Option<[f32; 4]>, scroll: Option<[f32; 4]>) ->
 
 /// Maximum number of rasterized SVG textures to cache
 /// Key is (svg_hash, width, height, tint_hash) - separate textures for different sizes/tints
-const RASTERIZED_SVG_CACHE_CAPACITY: usize = 32;
+const RASTERIZED_SVG_CACHE_CAPACITY: usize = 256;
 
 /// Internal render context that manages GPU resources and rendering
 pub struct RenderContext {
@@ -221,7 +221,7 @@ struct ImageElement {
 /// SVG element data for rendering
 #[derive(Clone)]
 struct SvgElement {
-    source: String,
+    source: Arc<str>,
     x: f32,
     y: f32,
     width: f32,
@@ -1887,7 +1887,7 @@ impl RenderContext {
                         }
                     }
 
-                    let mut modified = svg.source.clone();
+                    let mut modified = String::from(&*svg.source);
 
                     // Strip existing attributes from the <svg> tag
                     if let Some(svg_close) = modified.find('>') {
@@ -2064,7 +2064,7 @@ impl RenderContext {
 
                     std::borrow::Cow::Owned(modified)
                 } else {
-                    std::borrow::Cow::Borrowed(&svg.source)
+                    std::borrow::Cow::Borrowed(&*svg.source)
                 };
 
                 // Resolve currentColor references in SVG source.

--- a/crates/blinc_app/src/lib.rs
+++ b/crates/blinc_app/src/lib.rs
@@ -125,6 +125,7 @@ pub fn system_font_paths() -> &'static [&'static str] {
 mod app;
 mod context;
 mod error;
+mod svg_atlas;
 mod text_measurer;
 
 // Windowed module is compiled for desktop (windowed feature), Android, iOS, Fuchsia, and HarmonyOS

--- a/crates/blinc_app/src/svg_atlas.rs
+++ b/crates/blinc_app/src/svg_atlas.rs
@@ -214,9 +214,7 @@ impl SvgAtlas {
             let src_offset = y as usize * row_bytes;
             let dst_offset =
                 ((region.y + y) as usize * self.width as usize + region.x as usize) * 4;
-            if src_offset + row_bytes <= rgba.len()
-                && dst_offset + row_bytes <= self.pixels.len()
-            {
+            if src_offset + row_bytes <= rgba.len() && dst_offset + row_bytes <= self.pixels.len() {
                 self.pixels[dst_offset..dst_offset + row_bytes]
                     .copy_from_slice(&rgba[src_offset..src_offset + row_bytes]);
             }

--- a/crates/blinc_app/src/svg_atlas.rs
+++ b/crates/blinc_app/src/svg_atlas.rs
@@ -1,0 +1,286 @@
+//! SVG texture atlas for batched GPU rendering
+//!
+//! Packs all rasterized SVG icons into a single shared RGBA texture using
+//! shelf-packing (skyline algorithm). Eliminates per-icon GPU textures and
+//! enables single-draw-call rendering for all SVG instances in a frame.
+
+use std::collections::HashMap;
+
+/// Region allocated in the SVG atlas
+#[derive(Debug, Clone, Copy)]
+pub struct SvgAtlasRegion {
+    pub x: u32,
+    pub y: u32,
+    pub width: u32,
+    pub height: u32,
+}
+
+impl SvgAtlasRegion {
+    /// Returns [u_min, v_min, u_max, v_max] matching GpuImageInstance.src_uv format
+    pub fn uv_bounds(&self, atlas_w: u32, atlas_h: u32) -> [f32; 4] {
+        let u_min = self.x as f32 / atlas_w as f32;
+        let v_min = self.y as f32 / atlas_h as f32;
+        let u_max = (self.x + self.width) as f32 / atlas_w as f32;
+        let v_max = (self.y + self.height) as f32 / atlas_h as f32;
+        [u_min, v_min, u_max, v_max]
+    }
+}
+
+/// A shelf in the skyline packing algorithm
+#[derive(Debug)]
+struct Shelf {
+    y: u32,
+    height: u32,
+    x: u32,
+}
+
+const INITIAL_SIZE: u32 = 1024;
+const MAX_SIZE: u32 = 4096;
+const PADDING: u32 = 2;
+
+/// SVG texture atlas — packs rasterized SVGs into a single GPU texture
+pub struct SvgAtlas {
+    width: u32,
+    height: u32,
+    pixels: Vec<u8>,
+    shelves: Vec<Shelf>,
+    entries: HashMap<u64, SvgAtlasRegion>,
+    texture: wgpu::Texture,
+    view: wgpu::TextureView,
+    dirty: bool,
+}
+
+impl SvgAtlas {
+    pub fn new(device: &wgpu::Device) -> Self {
+        let (texture, view) = create_atlas_texture(device, INITIAL_SIZE, INITIAL_SIZE);
+        Self {
+            width: INITIAL_SIZE,
+            height: INITIAL_SIZE,
+            pixels: vec![0u8; (INITIAL_SIZE * INITIAL_SIZE * 4) as usize],
+            shelves: Vec::new(),
+            entries: HashMap::new(),
+            texture,
+            view,
+            dirty: false,
+        }
+    }
+
+    pub fn view(&self) -> &wgpu::TextureView {
+        &self.view
+    }
+
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    pub fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Look up an existing entry by cache key
+    pub fn get(&self, cache_key: u64) -> Option<&SvgAtlasRegion> {
+        self.entries.get(&cache_key)
+    }
+
+    /// Allocate space, write pixels, and insert a cache entry. Returns the region.
+    /// Returns None if the atlas is completely full (even after growing).
+    pub fn insert(
+        &mut self,
+        cache_key: u64,
+        width: u32,
+        height: u32,
+        rgba_pixels: &[u8],
+        device: &wgpu::Device,
+    ) -> Option<SvgAtlasRegion> {
+        // Try to allocate
+        let region = match self.allocate(width, height) {
+            Some(r) => r,
+            None => {
+                // Try growing
+                if self.grow(device) {
+                    self.allocate(width, height)?
+                } else {
+                    // At max size, clear and retry
+                    self.clear();
+                    self.allocate(width, height)?
+                }
+            }
+        };
+
+        self.write_pixels(&region, rgba_pixels);
+        self.entries.insert(cache_key, region);
+        Some(region)
+    }
+
+    /// Upload dirty pixels to the GPU texture
+    pub fn upload(&mut self, queue: &wgpu::Queue) {
+        if !self.dirty {
+            return;
+        }
+        queue.write_texture(
+            wgpu::ImageCopyTexture {
+                texture: &self.texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &self.pixels,
+            wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(self.width * 4),
+                rows_per_image: Some(self.height),
+            },
+            wgpu::Extent3d {
+                width: self.width,
+                height: self.height,
+                depth_or_array_layers: 1,
+            },
+        );
+        self.dirty = false;
+    }
+
+    /// Clear all entries and shelves (full eviction)
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.shelves.clear();
+        self.pixels.fill(0);
+        self.dirty = true;
+    }
+
+    /// Calculate atlas utilization (0.0 to 1.0)
+    pub fn utilization(&self) -> f32 {
+        let used_height = self.shelves.last().map(|s| s.y + s.height).unwrap_or(0);
+        used_height as f32 / self.height as f32
+    }
+
+    /// Allocate a region using shelf packing
+    fn allocate(&mut self, width: u32, height: u32) -> Option<SvgAtlasRegion> {
+        let padded_w = width + PADDING;
+        let padded_h = height + PADDING;
+
+        // Find best shelf (smallest height that fits, lowest Y)
+        let mut best_shelf: Option<usize> = None;
+        let mut best_y = u32::MAX;
+
+        for (i, shelf) in self.shelves.iter().enumerate() {
+            if shelf.height >= padded_h && shelf.x + padded_w <= self.width && shelf.y < best_y {
+                best_y = shelf.y;
+                best_shelf = Some(i);
+            }
+        }
+
+        if let Some(idx) = best_shelf {
+            let shelf = &mut self.shelves[idx];
+            let region = SvgAtlasRegion {
+                x: shelf.x,
+                y: shelf.y,
+                width,
+                height,
+            };
+            shelf.x += padded_w;
+            return Some(region);
+        }
+
+        // Create new shelf
+        let new_y = self.shelves.last().map(|s| s.y + s.height).unwrap_or(0);
+        if new_y + padded_h > self.height {
+            return None;
+        }
+
+        let region = SvgAtlasRegion {
+            x: 0,
+            y: new_y,
+            width,
+            height,
+        };
+
+        self.shelves.push(Shelf {
+            y: new_y,
+            height: padded_h,
+            x: padded_w,
+        });
+
+        Some(region)
+    }
+
+    /// Blit RGBA pixel data into the atlas at the given region
+    fn write_pixels(&mut self, region: &SvgAtlasRegion, rgba: &[u8]) {
+        let row_bytes = region.width as usize * 4;
+        for y in 0..region.height {
+            let src_offset = y as usize * row_bytes;
+            let dst_offset =
+                ((region.y + y) as usize * self.width as usize + region.x as usize) * 4;
+            if src_offset + row_bytes <= rgba.len()
+                && dst_offset + row_bytes <= self.pixels.len()
+            {
+                self.pixels[dst_offset..dst_offset + row_bytes]
+                    .copy_from_slice(&rgba[src_offset..src_offset + row_bytes]);
+            }
+        }
+        self.dirty = true;
+    }
+
+    /// Double atlas dimensions, copy old pixels into top-left quadrant.
+    /// Creates a new GPU texture. Returns false if already at max size.
+    fn grow(&mut self, device: &wgpu::Device) -> bool {
+        let new_w = (self.width * 2).min(MAX_SIZE);
+        let new_h = (self.height * 2).min(MAX_SIZE);
+
+        if new_w == self.width && new_h == self.height {
+            return false;
+        }
+
+        let mut new_pixels = vec![0u8; (new_w * new_h * 4) as usize];
+        for y in 0..self.height {
+            let src_start = (y * self.width * 4) as usize;
+            let src_end = src_start + (self.width * 4) as usize;
+            let dst_start = (y * new_w * 4) as usize;
+            let dst_end = dst_start + (self.width * 4) as usize;
+            new_pixels[dst_start..dst_end].copy_from_slice(&self.pixels[src_start..src_end]);
+        }
+
+        self.pixels = new_pixels;
+        self.width = new_w;
+        self.height = new_h;
+
+        let (texture, view) = create_atlas_texture(device, new_w, new_h);
+        self.texture = texture;
+        self.view = view;
+        self.dirty = true;
+
+        tracing::info!(
+            "SVG atlas grew to {}x{} ({:.1} MB)",
+            new_w,
+            new_h,
+            (new_w as f64 * new_h as f64 * 4.0) / (1024.0 * 1024.0)
+        );
+        true
+    }
+}
+
+fn create_atlas_texture(
+    device: &wgpu::Device,
+    width: u32,
+    height: u32,
+) -> (wgpu::Texture, wgpu::TextureView) {
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("SVG Atlas"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    (texture, view)
+}

--- a/crates/blinc_cn/src/components/button.rs
+++ b/crates/blinc_cn/src/components/button.rs
@@ -300,7 +300,7 @@ struct ButtonConfig {
 }
 
 /// The built button element — wraps `blinc_layout::widgets::button::Button`
-/// which provides Stateful<ButtonState> FSM for hover/press behavior.
+/// which provides `Stateful<ButtonState>`` FSM for hover/press behavior.
 pub struct Button {
     inner: layout_button::Button,
 }

--- a/crates/blinc_cn/src/components/button.rs
+++ b/crates/blinc_cn/src/components/button.rs
@@ -300,7 +300,7 @@ struct ButtonConfig {
 }
 
 /// The built button element — wraps `blinc_layout::widgets::button::Button`
-/// which provides `Stateful<ButtonState>`` FSM for hover/press behavior.
+/// which provides `Stateful<ButtonState>` FSM for hover/press behavior.
 pub struct Button {
     inner: layout_button::Button,
 }

--- a/crates/blinc_layout/src/div.rs
+++ b/crates/blinc_layout/src/div.rs
@@ -3649,7 +3649,7 @@ pub struct StyledTextRenderInfo {
 /// SVG render data extracted from element
 #[derive(Clone)]
 pub struct SvgRenderInfo {
-    pub source: String,
+    pub source: Arc<str>,
     pub tint: Option<blinc_core::Color>,
     pub fill: Option<blinc_core::Color>,
     pub stroke: Option<blinc_core::Color>,

--- a/crates/blinc_layout/src/renderer.rs
+++ b/crates/blinc_layout/src/renderer.rs
@@ -202,7 +202,7 @@ pub struct StyledTextData {
 /// SVG data for rendering
 #[derive(Clone)]
 pub struct SvgData {
-    pub source: String,
+    pub source: Arc<str>,
     pub tint: Option<Color>,
     pub fill: Option<Color>,
     pub stroke: Option<Color>,

--- a/crates/blinc_layout/src/svg.rs
+++ b/crates/blinc_layout/src/svg.rs
@@ -10,6 +10,12 @@
 //!     .color(Color::WHITE);
 //! ```
 
+use std::cell::RefCell;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
 use blinc_core::{Color, Shadow, Transform};
 use taffy::prelude::*;
 
@@ -17,10 +23,48 @@ use crate::div::{ElementBuilder, ElementTypeId, SvgRenderInfo};
 use crate::element::{RenderLayer, RenderProps};
 use crate::tree::{LayoutNodeId, LayoutTree};
 
+// ---------------------------------------------------------------------------
+// SVG string interning
+// ---------------------------------------------------------------------------
+
+/// Maximum number of interned SVG source strings.
+/// When exceeded, entries only held by the cache (strong_count == 1) are evicted.
+const SVG_INTERN_CAP: usize = 512;
+
+thread_local! {
+    static SVG_INTERN: RefCell<HashMap<u64, Arc<str>>> =
+        RefCell::new(HashMap::with_capacity(64));
+}
+
+/// Intern an SVG source string: if the same content was seen before, return the
+/// cached `Arc<str>` and drop the input.  Otherwise store and return a new Arc.
+fn intern_svg_source(s: String) -> Arc<str> {
+    let mut hasher = DefaultHasher::new();
+    s.hash(&mut hasher);
+    let hash = hasher.finish();
+
+    SVG_INTERN.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(cached) = cache.get(&hash) {
+            return Arc::clone(cached);
+        }
+        // Evict dead entries when full (strong_count == 1 ⇒ only cache holds it)
+        if cache.len() >= SVG_INTERN_CAP {
+            cache.retain(|_, v| Arc::strong_count(v) > 1);
+            if cache.len() >= SVG_INTERN_CAP {
+                cache.clear();
+            }
+        }
+        let arc: Arc<str> = Arc::from(s.as_str());
+        cache.insert(hash, Arc::clone(&arc));
+        arc
+    })
+}
+
 /// An SVG element builder
 pub struct Svg {
-    /// The SVG source string
-    source: String,
+    /// The SVG source string (Arc for O(1) cloning through the render pipeline)
+    source: Arc<str>,
     /// Width in pixels
     width: f32,
     /// Height in pixels
@@ -53,7 +97,7 @@ impl Svg {
     /// Create a new SVG element from source string
     pub fn new(source: impl Into<String>) -> Self {
         Self {
-            source: source.into(),
+            source: intern_svg_source(source.into()),
             width: 24.0,
             height: 24.0,
             tint: None,
@@ -359,7 +403,7 @@ pub fn svg(source: impl Into<String>) -> Svg {
 #[derive(Clone)]
 pub struct SvgRenderData {
     /// The SVG source string
-    pub source: String,
+    pub source: Arc<str>,
     /// Width in pixels
     pub width: f32,
     /// Height in pixels

--- a/crates/blinc_test_suite/src/harness.rs
+++ b/crates/blinc_test_suite/src/harness.rs
@@ -309,7 +309,7 @@ impl<'a> TestContext<'a> {
                 }
                 ElementType::Svg(svg_data) => {
                     svgs.push((
-                        svg_data.source.clone(),
+                        svg_data.source.to_string(),
                         abs_x,
                         abs_y,
                         bounds.width,


### PR DESCRIPTION
## Summary
- Merge latest upstream/main into fork sync branch
- Resolve merge conflict in crates/blinc_app/src/lib.rs by keeping both module declarations (runloop and svg_atlas)
- Bring upstream updates (SVG atlas perf, Arc<str> interning/LRU cache, doc/style fixes) into fork PR

## Verification
- cargo fmt --all
- cargo fmt --all -- --check

## Base/Head
- Base: mrchypark/Blinc:main
- Head: mrchypark/Blinc:feature/sync-upstream-20260304
