### PR TITLE
docs: add desktop platform implementation plans

### DIFF
--- a/docs/plans/2026-03-06-desktop-accessibility-ime-impl-plan.md
+++ b/docs/plans/2026-03-06-desktop-accessibility-ime-impl-plan.md
@@ -1,0 +1,162 @@
+# Desktop Accessibility And IME Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add composition-aware text input and accessibility semantics groundwork so desktop Blinc apps can support multilingual text entry now and unlock a later full assistive-technology bridge.
+
+**Architecture:** Add shared IME and accessibility contracts in `blinc_platform`, surface IME events through desktop event conversion, and teach `blinc_layout` widgets to consume composition events and export semantic metadata. This plan stops at a desktop accessibility backend boundary and semantic snapshot path; full OS assistive-technology adapters remain a follow-up once the semantics contract is stable.
+
+**Tech Stack:** Rust 2021, `winit`, crate tests, layout widget tests.
+
+---
+
+### Task 1: Add Red Tests For IME And Accessibility Contracts
+
+**Files:**
+- Create: `crates/blinc_platform/tests/accessibility_api.rs`
+- Modify: `crates/blinc_platform/src/input.rs`
+- Modify: `crates/blinc_platform/src/lib.rs`
+
+**Step 1: Write the failing tests**
+
+- Add a test for composition lifecycle events: `CompositionStarted`, `CompositionUpdated`, `CompositionCommitted`, `CompositionCancelled`.
+- Add a test for accessibility node roles, names, descriptions, bounds, and focusability.
+- Add a test for focus traversal intents being represented without desktop-only types leaking into the shared layer.
+
+**Step 2: Run targeted tests to verify failure**
+
+Run:
+- `cargo test -p blinc_platform --test accessibility_api -- --nocapture`
+
+Expected: compile failures because neither IME nor accessibility modules exist.
+
+**Step 3: Commit the red tests**
+
+```bash
+git add crates/blinc_platform/tests/accessibility_api.rs crates/blinc_platform/src/input.rs crates/blinc_platform/src/lib.rs
+git commit -m "test: add desktop ime and accessibility contracts"
+```
+
+### Task 2: Add Shared IME And Accessibility Primitives
+
+**Files:**
+- Create: `crates/blinc_platform/src/accessibility.rs`
+- Modify: `crates/blinc_platform/src/input.rs`
+- Modify: `crates/blinc_platform/src/event.rs`
+- Modify: `crates/blinc_platform/src/lib.rs`
+
+**Step 1: Implement shared IME value types**
+
+- Add composition event payloads carrying selection range and preview text.
+- Keep committed text delivery separate from raw key events.
+
+**Step 2: Implement accessibility value types**
+
+- Add `AccessibilityNode`, `AccessibilityRole`, `AccessibilityAction`, and `AccessibilityTreeSnapshot`.
+- Add an event channel for accessibility actions invoked by the platform.
+
+**Step 3: Re-run shared API tests**
+
+Run:
+- `cargo test -p blinc_platform --test accessibility_api -- --nocapture`
+
+Expected: PASS.
+
+**Step 4: Commit the shared contracts**
+
+```bash
+git add crates/blinc_platform/src/accessibility.rs crates/blinc_platform/src/input.rs crates/blinc_platform/src/event.rs crates/blinc_platform/src/lib.rs crates/blinc_platform/tests/accessibility_api.rs
+git commit -m "feat: add shared ime and accessibility primitives"
+```
+
+### Task 3: Implement Desktop IME Handling And Accessibility Backend Boundary
+
+**Files:**
+- Create: `extensions/blinc_platform_desktop/src/accessibility.rs`
+- Modify: `extensions/blinc_platform_desktop/src/input.rs`
+- Modify: `extensions/blinc_platform_desktop/src/event_loop.rs`
+- Modify: `extensions/blinc_platform_desktop/src/lib.rs`
+- Create: `extensions/blinc_platform_desktop/tests/ime_runtime.rs`
+- Modify: `extensions/blinc_platform_desktop/tests/support.rs`
+
+**Step 1: Write the failing desktop IME tests**
+
+- Add a test for translating IME preedit/commit notifications into the shared composition events.
+- Add a test ensuring plain keypress handling still works when composition is inactive.
+
+**Step 2: Run targeted backend tests to verify failure**
+
+Run:
+- Linux/CI: `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop --test ime_runtime -- --nocapture`
+- macOS/Windows/local GUI session: `cargo test -p blinc_platform_desktop --test ime_runtime -- --nocapture`
+
+Expected: failures because the desktop backend only emits keyboard/mouse/touch/scroll/pinch events today.
+
+**Step 3: Implement the minimal backend boundary**
+
+- Translate `winit` IME callbacks into the shared input model.
+- Add an accessibility backend boundary that can ingest semantic snapshots, but keep real OS bridge work explicitly out of scope for this plan.
+
+**Step 4: Re-run backend tests**
+
+Run:
+- Linux/CI: `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop --test ime_runtime -- --nocapture`
+- macOS/Windows/local GUI session: `cargo test -p blinc_platform_desktop --test ime_runtime -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit the desktop IME implementation**
+
+```bash
+git add extensions/blinc_platform_desktop/src/accessibility.rs extensions/blinc_platform_desktop/src/input.rs extensions/blinc_platform_desktop/src/event_loop.rs extensions/blinc_platform_desktop/src/lib.rs extensions/blinc_platform_desktop/tests/support.rs extensions/blinc_platform_desktop/tests/ime_runtime.rs
+git commit -m "feat: add desktop ime event handling"
+```
+
+### Task 4: Teach Layout Widgets About Composition And Semantics
+
+**Files:**
+- Create: `crates/blinc_layout/src/accessibility.rs`
+- Modify: `crates/blinc_layout/src/tests/mod.rs`
+- Modify: `crates/blinc_layout/src/widgets/text_input.rs`
+- Modify: `crates/blinc_layout/src/widgets/text_area.rs`
+- Modify: `crates/blinc_layout/src/widgets/button.rs`
+- Modify: `crates/blinc_layout/src/widgets/checkbox.rs`
+- Modify: `crates/blinc_layout/src/tree.rs`
+- Modify: `crates/blinc_layout/src/lib.rs`
+- Create: `crates/blinc_layout/src/tests/accessibility_semantics.rs`
+
+**Step 1: Write the failing layout tests**
+
+- Execute this task only after Task 4 of `2026-03-06-desktop-file-flows-impl-plan.md` has landed, because that task creates the shared `blinc_layout` test harness.
+- Reuse the `#[cfg(test)] mod tests;` hook introduced by the file-flows plan.
+- Extend the existing `crates/blinc_layout/src/tests/mod.rs` aggregator introduced by the file-flows plan to wire in `accessibility_semantics`.
+- Add a test named `accessibility_semantics_preserve_preedit_text`.
+- Add a test named `accessibility_semantics_export_roles`.
+- Add a test named `accessibility_semantics_focus_order`.
+
+**Step 2: Run targeted tests to verify failure**
+
+Run:
+- `cargo test -p blinc_layout accessibility_semantics_export_roles -- --nocapture`
+
+Expected: failures because layout widgets do not currently track composition or emit semantic snapshots.
+
+**Step 3: Implement the minimal widget integration**
+
+- Store composition state in text input and text area widgets.
+- Add semantic metadata hooks to common interactive widgets.
+- Add a layout-side snapshot exporter that can be consumed by the desktop accessibility backend.
+
+**Step 4: Re-run targeted layout tests**
+
+Run:
+- `cargo test -p blinc_layout accessibility_semantics_export_roles -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit the widget integration**
+
+```bash
+git add crates/blinc_layout/src/accessibility.rs crates/blinc_layout/src/widgets/text_input.rs crates/blinc_layout/src/widgets/text_area.rs crates/blinc_layout/src/widgets/button.rs crates/blinc_layout/src/widgets/checkbox.rs crates/blinc_layout/src/tree.rs crates/blinc_layout/src/lib.rs crates/blinc_layout/src/tests/mod.rs crates/blinc_layout/src/tests/accessibility_semantics.rs
+git commit -m "feat: add layout accessibility and ime support"
+```

--- a/docs/plans/2026-03-06-desktop-file-flows-impl-plan.md
+++ b/docs/plans/2026-03-06-desktop-file-flows-impl-plan.md
@@ -1,0 +1,172 @@
+# Desktop File Flows Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add desktop-native file dialogs, drag-and-drop file intake, and richer clipboard support so Blinc apps can participate in ordinary desktop workflows.
+
+**Architecture:** Define shared dialog and data-transfer contracts in `blinc_platform`, first refactor clipboard access so public APIs can dispatch to a desktop backend instead of only `native_bridge`, then extend the input/event surface for drag-and-drop, and finally implement desktop-native behavior in `blinc_platform_desktop` using backend-specific helpers. This plan owns creation of the shared `blinc_layout` test harness (`#[cfg(test)] mod tests;` plus `src/tests/mod.rs`) that later desktop plans will extend.
+
+**Tech Stack:** Rust 2021, `winit`, native dialog crate (`rfd` or equivalent), desktop integration tests.
+
+---
+
+### Task 1: Add Red Tests For Dialog And Drag-Drop APIs
+
+**Files:**
+- Create: `crates/blinc_platform/tests/file_flows_api.rs`
+- Modify: `crates/blinc_platform/src/input.rs`
+- Modify: `crates/blinc_platform/src/lib.rs`
+
+**Step 1: Write the failing tests**
+
+- Add a test for a `FileDialogOptions` builder producing open/save/directory selection requests.
+- Add a test for `InputEvent` carrying `DragEntered`, `DragMoved`, `DragLeft`, and `DropFiles` payloads.
+- Add a test for clipboard payload types supporting plain text plus file URI lists.
+
+**Step 2: Run targeted tests to verify failure**
+
+Run:
+- `cargo test -p blinc_platform --test file_flows_api -- --nocapture`
+
+Expected: missing modules and enum variants cause compile failures.
+
+**Step 3: Commit the red tests**
+
+```bash
+git add crates/blinc_platform/tests/file_flows_api.rs crates/blinc_platform/src/input.rs crates/blinc_platform/src/lib.rs
+git commit -m "test: add desktop file flow contracts"
+```
+
+### Task 2: Add Shared Dialog And Clipboard Contracts
+
+**Files:**
+- Create: `crates/blinc_platform/src/dialogs.rs`
+- Modify: `crates/blinc_platform/src/clipboard.rs`
+- Create: `crates/blinc_platform/src/clipboard_backend.rs`
+- Modify: `crates/blinc_platform/src/input.rs`
+- Modify: `crates/blinc_platform/src/lib.rs`
+
+**Step 1: Add a dialog abstraction**
+
+- Introduce `FileDialogKind`, `FileDialogOptions`, and `FileDialogResult`.
+- Keep the API synchronous at first to minimize blast radius.
+
+**Step 2: Introduce clipboard backend dispatch**
+
+- Add a `ClipboardBackend` trait plus process-local registry in `crates/blinc_platform/src/clipboard_backend.rs`.
+- Keep the current `native_bridge` path as the default backend so mobile/service tests continue to pass.
+- Refactor `crates/blinc_platform/src/clipboard.rs` to dispatch through the registry before falling back to `native_bridge`.
+
+**Step 3: Extend clipboard types**
+
+- Add typed clipboard payloads for `Text`, `Html`, `FileList`, and an `Unsupported` fallback.
+- Preserve current text helper functions as a convenience layer on top of the typed API.
+
+**Step 4: Extend drag-and-drop input events**
+
+- Add file hover and drop events to `InputEvent`.
+- Ensure events carry absolute paths and cursor position.
+
+**Step 5: Re-run shared API tests**
+
+Run:
+- `cargo test -p blinc_platform --test file_flows_api -- --nocapture`
+
+Expected: shared contracts compile and tests pass.
+
+**Step 6: Commit the shared file-flow layer**
+
+```bash
+git add crates/blinc_platform/src/dialogs.rs crates/blinc_platform/src/clipboard.rs crates/blinc_platform/src/clipboard_backend.rs crates/blinc_platform/src/input.rs crates/blinc_platform/src/lib.rs crates/blinc_platform/tests/file_flows_api.rs
+git commit -m "feat: add shared desktop file flow abstractions"
+```
+
+### Task 3: Implement Desktop Dialogs, Clipboard Payloads, And Drag-Drop
+
+**Files:**
+- Create: `extensions/blinc_platform_desktop/src/dialogs.rs`
+- Create: `extensions/blinc_platform_desktop/src/clipboard.rs`
+- Modify: `extensions/blinc_platform_desktop/src/event_loop.rs`
+- Modify: `extensions/blinc_platform_desktop/src/input.rs`
+- Modify: `extensions/blinc_platform_desktop/src/lib.rs`
+- Modify: `extensions/blinc_platform_desktop/Cargo.toml`
+- Create: `extensions/blinc_platform_desktop/tests/file_flows_runtime.rs`
+- Modify: `extensions/blinc_platform_desktop/tests/support.rs`
+
+**Step 1: Write the failing backend tests**
+
+- Add a test for translating `winit` dropped-file callbacks into the new `InputEvent` variants.
+- Add a test double for dialog execution returning deterministic file paths.
+- Add a test proving `DesktopPlatform::new()` or `create_event_loop_with_config()` registers the clipboard backend before the first public clipboard call.
+- Add a test for typed clipboard read/write on platforms that expose it in CI, with a skip guard if the environment lacks a display server.
+
+**Step 2: Run targeted backend tests to verify failure**
+
+Run:
+- Linux/CI: `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop --test file_flows_runtime -- --nocapture`
+- macOS/Windows/local GUI session: `cargo test -p blinc_platform_desktop --test file_flows_runtime -- --nocapture`
+
+Expected: failures because the backend has no dialog module and no file-drop event mapping.
+
+**Step 3: Implement desktop integrations**
+
+- Wire native open/save/select-folder dialogs behind `FileDialogOptions`.
+- Add `ensure_desktop_clipboard_backend_registered()` in `extensions/blinc_platform_desktop/src/clipboard.rs`.
+- Call that registration helper from `DesktopPlatform::new()` and `create_event_loop_with_config()` in `extensions/blinc_platform_desktop/src/lib.rs` so public `blinc_platform::clipboard` functions can reach the new backend before any windowed app code touches the clipboard.
+- Convert `HoveredFile`, `DroppedFile`, and cancellation events from `winit`.
+- Provide typed clipboard translation, falling back to text-only where richer payloads are unavailable.
+
+**Step 4: Re-run backend and shared tests**
+
+Run:
+- Linux/CI: `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop --test file_flows_runtime -- --nocapture`
+- macOS/Windows/local GUI session: `cargo test -p blinc_platform_desktop --test file_flows_runtime -- --nocapture`
+- `cargo test -p blinc_platform --test file_flows_api -- --nocapture`
+
+Expected: both pass.
+
+**Step 5: Commit the desktop file-flow implementation**
+
+```bash
+git add extensions/blinc_platform_desktop/src/dialogs.rs extensions/blinc_platform_desktop/src/clipboard.rs extensions/blinc_platform_desktop/src/event_loop.rs extensions/blinc_platform_desktop/src/input.rs extensions/blinc_platform_desktop/src/lib.rs extensions/blinc_platform_desktop/tests/support.rs extensions/blinc_platform_desktop/tests/file_flows_runtime.rs extensions/blinc_platform_desktop/Cargo.toml
+git commit -m "feat: add desktop dialogs and drag-drop flows"
+```
+
+### Task 4: Add A Consumer Smoke Test In Layout
+
+**Files:**
+- Modify: `crates/blinc_layout/src/event_router.rs`
+- Create: `crates/blinc_layout/src/tests/mod.rs`
+- Create: `crates/blinc_layout/src/tests/desktop_file_flows.rs`
+- Modify: `crates/blinc_layout/src/lib.rs`
+
+**Step 1: Write the failing smoke test**
+
+- Add `#[cfg(test)] mod tests;` to `crates/blinc_layout/src/lib.rs`.
+- Create `crates/blinc_layout/src/tests/mod.rs` and wire in `desktop_file_flows`.
+- Add a test named `desktop_file_flows_routes_events` proving the layout event router does not discard the new drag-and-drop events.
+
+**Step 2: Run the targeted smoke test to verify failure**
+
+Run:
+- `cargo test -p blinc_layout desktop_file_flows_routes_events -- --nocapture`
+
+Expected: the event router ignores the new variants or the test module is missing.
+
+**Step 3: Make the minimal integration change**
+
+- Update routing matches to accept and forward the new file flow events without introducing widget behavior yet.
+
+**Step 4: Re-run the smoke test**
+
+Run:
+- `cargo test -p blinc_layout desktop_file_flows_routes_events -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit the consumer integration**
+
+```bash
+git add crates/blinc_layout/src/event_router.rs crates/blinc_layout/src/lib.rs crates/blinc_layout/src/tests/mod.rs crates/blinc_layout/src/tests/desktop_file_flows.rs
+git commit -m "feat: route desktop file flow events through layout"
+```

--- a/docs/plans/2026-03-06-desktop-platform-master-plan.md
+++ b/docs/plans/2026-03-06-desktop-platform-master-plan.md
@@ -1,0 +1,110 @@
+# Desktop Platform Master Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Deliver the full desktop-platform expansion as a sequence of smaller executable plans with stable verification gates between phases.
+
+**Architecture:** Keep cross-platform API contracts in `crates/blinc_platform`, put concrete desktop behavior in `extensions/blinc_platform_desktop`, and only touch `blinc_layout` / `blinc_app` where desktop features must surface into widgets or app runtime. Any shared trait widening must land with compile-safe no-op or default-preserving follow-ups for Android, iOS, and Harmony in the same task. Execute plans in dependency order so later shell/accessibility work builds on a stable windowing core.
+
+**Tech Stack:** Rust 2021, `winit`, crate integration tests, desktop backend tests, `cargo fmt`, targeted `cargo test`.
+
+---
+
+### Task 1: Establish Baseline Before Any Desktop Expansion
+
+**Files:**
+- Modify: none
+- Test: `crates/blinc_platform/tests/services_api.rs`
+
+**Step 1: Run the current platform test baseline**
+
+Run:
+- `cargo test -p blinc_platform --test services_api -- --nocapture`
+- `cargo test -p blinc_platform --test sensors_api -- --nocapture`
+
+Expected: both test targets pass so later failures are attributable to desktop-platform changes.
+
+**Step 2: Run the current desktop backend baseline**
+
+Run:
+- `cargo test -p blinc_platform_desktop -- --nocapture`
+
+Expected: either zero tests or an all-pass run with no failing desktop backend assertions.
+
+**Step 3: Record the display-less GUI test strategy up front**
+
+- On Linux CI, wrap all `blinc_platform_desktop` test invocations with `xvfb-run --auto-servernum` for consistency.
+- For platform-specific runtime tests that still require a real GUI session, reuse a shared `extensions/blinc_platform_desktop/tests/support.rs` `requires_display()` helper created in the first desktop runtime-test plan and skip cleanly when the environment is headless.
+- Prefer mock-backed adapter tests for clipboard, tray, notifications, updater, and capture integrations unless the code path strictly requires a real native window.
+
+**Step 4: Commit the verified baseline note**
+
+```bash
+git add .omx/context/desktop-platform-2026-03-06-205853.md .omx/interviews/desktop-platform-2026-03-06-205853.md .omx/specs/deep-interview-desktop-platform.md docs/plans/2026-03-06-desktop-platform-master-plan.md
+git commit -m "docs: add desktop platform planning baseline"
+```
+
+### Task 2: Execute The Dependency Chain In Order
+
+**Files:**
+- Modify: `docs/plans/2026-03-06-desktop-windowing-foundation-impl-plan.md`
+- Modify: `docs/plans/2026-03-06-desktop-file-flows-impl-plan.md`
+- Modify: `docs/plans/2026-03-06-desktop-shell-integration-impl-plan.md`
+- Modify: `docs/plans/2026-03-06-desktop-accessibility-ime-impl-plan.md`
+- Modify: `docs/plans/2026-03-06-desktop-productization-impl-plan.md`
+
+**Step 1: Execute the foundation plan first**
+
+Run the tasks in:
+- `docs/plans/2026-03-06-desktop-windowing-foundation-impl-plan.md`
+
+Expected: shared window contracts and desktop implementation land with tests before higher-level integrations start.
+
+**Step 2: Execute feature plans in this order**
+
+Run next:
+1. `docs/plans/2026-03-06-desktop-file-flows-impl-plan.md`
+2. `docs/plans/2026-03-06-desktop-shell-integration-impl-plan.md`
+3. `docs/plans/2026-03-06-desktop-accessibility-ime-impl-plan.md`
+4. `docs/plans/2026-03-06-desktop-productization-impl-plan.md`
+
+Expected: each plan rebases on already-tested abstractions instead of inventing parallel APIs.
+
+### Task 3: Run End-To-End Verification After The Last Plan
+
+**Files:**
+- Modify only if verification exposes issues.
+
+**Step 1: Run formatting**
+
+Run:
+- `cargo fmt --all`
+- `cargo fmt --all -- --check`
+
+Expected: formatting passes cleanly.
+
+**Step 2: Run shared and desktop tests**
+
+Run:
+- `cargo test -p blinc_platform -- --nocapture`
+- `cargo check -p blinc_platform_android`
+- `cargo check -p blinc_platform_ios`
+- `cargo check -p blinc_platform_harmony`
+- `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop -- --nocapture`
+
+Expected: shared API tests, non-desktop compile checks, and desktop backend tests pass together.
+
+**Step 3: Run representative integration tests for consumers**
+
+Run:
+- `cargo test -p blinc_layout --lib -- --nocapture`
+- `cargo test -p blinc_app --features windowed --lib -- --nocapture`
+
+Expected: widget/runtime consumers still compile and pass after desktop API expansion.
+
+**Step 4: Commit the integrated desktop platform upgrade**
+
+```bash
+git add crates/blinc_platform crates/blinc_layout crates/blinc_app extensions/blinc_platform_desktop docs/plans
+git commit -m "feat: expand desktop platform capabilities"
+```

--- a/docs/plans/2026-03-06-desktop-productization-impl-plan.md
+++ b/docs/plans/2026-03-06-desktop-productization-impl-plan.md
@@ -1,0 +1,162 @@
+# Desktop Productization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Finish the desktop platform with productization hooks for capture utilities, updater plumbing, best-effort runtime observability notes, and developer-facing documentation/examples.
+
+**Architecture:** Reuse the now-expanded shared platform contracts, add only narrow productization abstractions, and validate with backend tests plus documentation smoke checks instead of building a large opinionated app-management layer. Sleep/wake and display-topology handling are not treated as immediate `winit` features here; this plan records best-effort hooks and a follow-up OS-specific backlog item instead of promising a uniform implementation.
+
+**Tech Stack:** Rust 2021, `winit`, desktop helper crates, docs and example updates.
+
+---
+
+### Task 1: Add Red Tests For Productization Hooks
+
+**Files:**
+- Create: `crates/blinc_platform/tests/productization_api.rs`
+- Modify: `crates/blinc_platform/src/event.rs`
+- Modify: `crates/blinc_platform/src/lib.rs`
+
+**Step 1: Write the failing tests**
+
+- Add a test for capture request value objects for screen, window, and region capture.
+- Add a test for updater status objects (`Idle`, `Checking`, `UpdateAvailable`, `Downloading`, `ReadyToInstall`, `Error`).
+- Add a test for a best-effort desktop observability note type that can record unsupported lifecycle capabilities without pretending they are implemented uniformly.
+
+**Step 2: Run targeted tests to verify failure**
+
+Run:
+- `cargo test -p blinc_platform --test productization_api -- --nocapture`
+
+Expected: compile failures because none of these productization hooks exist.
+
+**Step 3: Commit the red tests**
+
+```bash
+git add crates/blinc_platform/tests/productization_api.rs crates/blinc_platform/src/event.rs crates/blinc_platform/src/lib.rs
+git commit -m "test: add desktop productization contracts"
+```
+
+### Task 2: Add Shared Productization Modules
+
+**Files:**
+- Create: `crates/blinc_platform/src/capture.rs`
+- Create: `crates/blinc_platform/src/updater.rs`
+- Create: `crates/blinc_platform/src/desktop_runtime_notes.rs`
+- Modify: `crates/blinc_platform/src/lib.rs`
+
+**Step 1: Add shared capture types**
+
+- Introduce `CaptureTarget`, `CaptureRequest`, and `CaptureResult`.
+- Keep the API request/response based so desktop backends can opt into platform-specific capture permissions later.
+
+**Step 2: Add updater status types**
+
+- Introduce `UpdateChannel`, `UpdateStatus`, and `UpdateCommand`.
+- Keep download/install orchestration outside the shared layer.
+
+**Step 3: Add best-effort runtime observability notes**
+
+- Add a small shared note or capability type that can report unsupported or platform-specific lifecycle hooks without turning them into guaranteed cross-platform events.
+
+**Step 4: Re-run shared API tests**
+
+Run:
+- `cargo test -p blinc_platform --test productization_api -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit the shared productization types**
+
+```bash
+git add crates/blinc_platform/src/capture.rs crates/blinc_platform/src/updater.rs crates/blinc_platform/src/desktop_runtime_notes.rs crates/blinc_platform/src/lib.rs crates/blinc_platform/tests/productization_api.rs
+git commit -m "feat: add desktop productization abstractions"
+```
+
+### Task 3: Implement Desktop Capture, Updater Hooks, And Runtime Notes
+
+**Files:**
+- Create: `extensions/blinc_platform_desktop/src/capture.rs`
+- Create: `extensions/blinc_platform_desktop/src/updater.rs`
+- Modify: `extensions/blinc_platform_desktop/src/event_loop.rs`
+- Create: `extensions/blinc_platform_desktop/src/runtime_notes.rs`
+- Modify: `extensions/blinc_platform_desktop/src/lib.rs`
+- Modify: `extensions/blinc_platform_desktop/Cargo.toml`
+- Create: `extensions/blinc_platform_desktop/tests/productization_runtime.rs`
+- Modify: `extensions/blinc_platform_desktop/tests/support.rs`
+
+**Step 1: Write the failing backend tests**
+
+- Add a test for a capture backend stub returning deterministic metadata.
+- Add a test for updater state-machine transitions without calling a real update service.
+- Add a test for runtime notes reporting that sleep/wake and display-topology support are unsupported or OS-specific on the current backend.
+
+**Step 2: Run targeted backend tests to verify failure**
+
+Run:
+- Linux/CI: `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop --test productization_runtime -- --nocapture`
+- macOS/Windows/local GUI session: `cargo test -p blinc_platform_desktop --test productization_runtime -- --nocapture`
+
+Expected: failures because the backend has no capture or updater modules yet.
+
+**Step 3: Implement minimal backend adapters**
+
+- Add a capture trait adapter and a backend stub implementation behind a concrete `desktop-capture-stub` feature declared in `extensions/blinc_platform_desktop/Cargo.toml`.
+- Add updater polling hooks with a mockable backend.
+- Add runtime notes that mark sleep/wake and display-topology as OS-specific follow-up work rather than claiming uniform support.
+
+**Step 4: Re-run targeted backend tests**
+
+Run:
+- Linux/CI: `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop --test productization_runtime -- --nocapture`
+- macOS/Windows/local GUI session: `cargo test -p blinc_platform_desktop --test productization_runtime -- --nocapture`
+- `cargo test -p blinc_platform --test productization_api -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit the backend productization hooks**
+
+```bash
+git add extensions/blinc_platform_desktop/src/capture.rs extensions/blinc_platform_desktop/src/updater.rs extensions/blinc_platform_desktop/src/event_loop.rs extensions/blinc_platform_desktop/src/runtime_notes.rs extensions/blinc_platform_desktop/src/lib.rs extensions/blinc_platform_desktop/tests/support.rs extensions/blinc_platform_desktop/tests/productization_runtime.rs extensions/blinc_platform_desktop/Cargo.toml
+git commit -m "feat: add desktop productization hooks"
+```
+
+### Task 4: Update Docs, Scaffolds, And Examples
+
+**Files:**
+- Modify: `extensions/blinc_platform_desktop/README.md`
+- Modify: `README.md`
+- Modify: `crates/blinc_cli/src/project.rs`
+- Create: `examples/desktop_platform_showcase/README.md`
+
+**Step 1: Write the failing documentation checklist**
+
+- Add a short checklist in the commit description or task notes covering new APIs that must be documented: window controls, dialogs, drag-drop, shortcuts, accessibility, capture, updater.
+
+**Step 2: Update desktop docs and scaffolds**
+
+- Document the new desktop capability surface and any new optional dependencies/features.
+- Update project scaffolding notes if desktop apps now need extra config for updater setup, capture permissions, or Linux `xvfb-run` based verification.
+- Add an explicit note that sleep/wake and display-topology remain OS-specific follow-up work.
+
+**Step 3: Add a showcase example README**
+
+- Document how to manually verify window controls, file drop, menu commands, IME, and notifications in one sample app directory.
+
+**Step 4: Run final verification**
+
+Run:
+- `cargo fmt --all`
+- `cargo fmt --all -- --check`
+- `cargo test -p blinc_platform -- --nocapture`
+- Linux/CI: `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop -- --nocapture`
+- macOS/Windows/local GUI session: `cargo test -p blinc_platform_desktop -- --nocapture`
+
+Expected: docs are updated and the final verification pass is green.
+
+**Step 5: Commit the docs and scaffolding updates**
+
+```bash
+git add extensions/blinc_platform_desktop/README.md README.md crates/blinc_cli/src/project.rs examples/desktop_platform_showcase/README.md
+git commit -m "docs: describe desktop platform capabilities"
+```

--- a/docs/plans/2026-03-06-desktop-shell-integration-impl-plan.md
+++ b/docs/plans/2026-03-06-desktop-shell-integration-impl-plan.md
@@ -1,0 +1,167 @@
+# Desktop Shell Integration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add desktop-native app shell integrations including local/global shortcuts, menu models, tray support, notifications, and deep-link entrypoints.
+
+**Architecture:** Start with shared shell contracts in `blinc_platform`, add an application-scope event sink in `blinc_platform_desktop` that queues `blinc_platform::Event` values so tray/global shortcut/deep-link events survive without a live window, implement desktop-native adapters on top of that sink, and then surface only the minimum runtime hooks needed by `blinc_app`.
+
+**Tech Stack:** Rust 2021, `winit`, menu/tray/shortcut helper crates, integration tests.
+
+---
+
+### Task 1: Add Red Tests For Shortcut And Menu Contracts
+
+**Files:**
+- Create: `crates/blinc_platform/tests/shell_api.rs`
+- Modify: `crates/blinc_platform/src/lib.rs`
+
+**Step 1: Write the failing tests**
+
+- Add a test for `Shortcut` parsing plus normalized modifier matching.
+- Add a test for a tree-shaped `Menu` / `MenuItem` model with stable command IDs.
+- Add a test for notification and deep-link request value objects.
+
+**Step 2: Run targeted tests to verify failure**
+
+Run:
+- `cargo test -p blinc_platform --test shell_api -- --nocapture`
+
+Expected: compile failures because shell modules are not yet defined.
+
+**Step 3: Commit the red tests**
+
+```bash
+git add crates/blinc_platform/tests/shell_api.rs crates/blinc_platform/src/lib.rs
+git commit -m "test: add desktop shell integration contracts"
+```
+
+### Task 2: Add Shared Shell Modules
+
+**Files:**
+- Create: `crates/blinc_platform/src/shortcuts.rs`
+- Create: `crates/blinc_platform/src/menu.rs`
+- Create: `crates/blinc_platform/src/tray.rs`
+- Create: `crates/blinc_platform/src/notifications.rs`
+- Create: `crates/blinc_platform/src/app_links.rs`
+- Modify: `crates/blinc_platform/src/event.rs`
+- Modify: `crates/blinc_platform/src/lib.rs`
+
+**Step 1: Implement shared value types**
+
+- Add `Shortcut`, `ShortcutScope`, `ShortcutAction`, `Menu`, `MenuItem`, `TrayMenu`, `NotificationRequest`, and `AppLinkEvent`.
+
+**Step 2: Extend platform events**
+
+- Add event variants for menu command dispatch, tray activation, shortcut activation, and app-link open requests.
+
+**Step 3: Re-run shared API tests**
+
+Run:
+- `cargo test -p blinc_platform --test shell_api -- --nocapture`
+
+Expected: PASS.
+
+**Step 4: Commit the shared shell abstractions**
+
+```bash
+git add crates/blinc_platform/src/shortcuts.rs crates/blinc_platform/src/menu.rs crates/blinc_platform/src/tray.rs crates/blinc_platform/src/notifications.rs crates/blinc_platform/src/app_links.rs crates/blinc_platform/src/event.rs crates/blinc_platform/src/lib.rs crates/blinc_platform/tests/shell_api.rs
+git commit -m "feat: add shared desktop shell abstractions"
+```
+
+### Task 3: Implement Desktop Shortcuts, Menus, Tray, And Notifications
+
+**Files:**
+- Create: `extensions/blinc_platform_desktop/src/app_event_sink.rs`
+- Create: `extensions/blinc_platform_desktop/src/shortcuts.rs`
+- Create: `extensions/blinc_platform_desktop/src/menu.rs`
+- Create: `extensions/blinc_platform_desktop/src/tray.rs`
+- Create: `extensions/blinc_platform_desktop/src/notifications.rs`
+- Create: `extensions/blinc_platform_desktop/src/app_links.rs`
+- Modify: `extensions/blinc_platform_desktop/src/event_loop.rs`
+- Modify: `extensions/blinc_platform_desktop/src/lib.rs`
+- Modify: `extensions/blinc_platform_desktop/Cargo.toml`
+- Create: `extensions/blinc_platform_desktop/tests/shell_runtime.rs`
+- Modify: `extensions/blinc_platform_desktop/tests/support.rs`
+
+**Step 1: Write the failing backend tests**
+
+- Add a test for accelerator registration and dispatch into shared shortcut events.
+- Add a test for menu command IDs routing back into the event loop.
+- Add a test for tray click activation and notification request submission through a backend stub.
+
+**Step 2: Run targeted backend tests to verify failure**
+
+Run:
+- Linux/CI: `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop --test shell_runtime -- --nocapture`
+- macOS/Windows/local GUI session: `cargo test -p blinc_platform_desktop --test shell_runtime -- --nocapture`
+
+Expected: failures because none of the desktop shell modules exist.
+
+**Step 3: Introduce an app-scope event sink**
+
+- Create `app_event_sink.rs` to queue `blinc_platform::Event` values before a window exists and after it closes.
+- Keep the sink internal to `blinc_platform_desktop` and store shared `blinc_platform::Event` values so no reverse dependency from `blinc_platform_desktop` back into `blinc_app` is introduced.
+- Make `event_loop.rs` drain that queue into the existing handler path when a window becomes available.
+
+**Step 4: Implement backend adapters**
+
+- Register local shortcuts per window and global shortcuts behind an opt-in scope.
+- Build native menus and tray items from the shared menu model.
+- Map notification requests into native desktop notification APIs.
+- Convert custom URL / deep-link callbacks into `AppLinkEvent`.
+
+**Step 5: Re-run backend and shared tests**
+
+Run:
+- Linux/CI: `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop --test shell_runtime -- --nocapture`
+- macOS/Windows/local GUI session: `cargo test -p blinc_platform_desktop --test shell_runtime -- --nocapture`
+- `cargo test -p blinc_platform --test shell_api -- --nocapture`
+
+Expected: PASS.
+
+**Step 6: Commit the desktop shell backend**
+
+```bash
+git add extensions/blinc_platform_desktop/src/app_event_sink.rs extensions/blinc_platform_desktop/src/shortcuts.rs extensions/blinc_platform_desktop/src/menu.rs extensions/blinc_platform_desktop/src/tray.rs extensions/blinc_platform_desktop/src/notifications.rs extensions/blinc_platform_desktop/src/app_links.rs extensions/blinc_platform_desktop/src/event_loop.rs extensions/blinc_platform_desktop/src/lib.rs extensions/blinc_platform_desktop/tests/support.rs extensions/blinc_platform_desktop/tests/shell_runtime.rs extensions/blinc_platform_desktop/Cargo.toml
+git commit -m "feat: add desktop shell integrations"
+```
+
+### Task 4: Add A Minimal App Runtime Hook
+
+**Files:**
+- Modify: `crates/blinc_app/src/windowed.rs`
+- Modify: `crates/blinc_app/src/app.rs`
+- Create: `crates/blinc_app/src/tests_shell.rs`
+- Modify: `crates/blinc_app/src/lib.rs`
+
+**Step 1: Write the failing runtime test**
+
+- Add `#[cfg(test)] mod tests_shell;` to `crates/blinc_app/src/lib.rs`, guarded the same way as the `windowed` module so the test harness compiles only when `--features windowed` is enabled.
+- Add a test for wiring shell-originated events into the existing app event pump without panicking.
+
+**Step 2: Run the targeted runtime test to verify failure**
+
+Run:
+- `cargo test -p blinc_app --features windowed tests_shell -- --nocapture`
+
+Expected: the app runtime has no knowledge of menu/shortcut/app-link event variants.
+
+**Step 3: Implement the minimal runtime hook**
+
+- Update event dispatch so the new shell events can be observed by applications.
+- Do not add app-level sugar APIs yet; only preserve the events.
+
+**Step 4: Re-run the runtime test**
+
+Run:
+- `cargo test -p blinc_app --features windowed tests_shell -- --nocapture`
+
+Expected: PASS.
+
+**Step 5: Commit the runtime hook**
+
+```bash
+git add crates/blinc_app/src/windowed.rs crates/blinc_app/src/app.rs crates/blinc_app/src/tests_shell.rs crates/blinc_app/src/lib.rs
+git commit -m "feat: route desktop shell events into app runtime"
+```

--- a/docs/plans/2026-03-06-desktop-windowing-foundation-impl-plan.md
+++ b/docs/plans/2026-03-06-desktop-windowing-foundation-impl-plan.md
@@ -1,0 +1,166 @@
+# Desktop Windowing Foundation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Expand the shared window/event abstraction and desktop backend so Blinc can behave like a real desktop shell rather than a fixed-size demo window.
+
+**Architecture:** First widen `blinc_platform` with explicit window state/value objects and richer events, then add compile-safe no-op/default follow-ups for Android, iOS, and Harmony, then implement the richer behavior in `blinc_platform_desktop` on top of `winit`, and finally lock behavior with shared API tests plus desktop runtime tests. GUI runtime tests must use a shared display probe and Linux `xvfb-run` wrapper instead of assuming a visible desktop session.
+
+**Tech Stack:** Rust 2021, `winit`, crate integration tests, desktop backend tests.
+
+---
+
+### Task 1: Add Red Tests For Window Control Contracts
+
+**Files:**
+- Create: `crates/blinc_platform/tests/window_api.rs`
+- Modify: `crates/blinc_platform/src/window.rs`
+- Modify: `crates/blinc_platform/src/event.rs`
+
+**Step 1: Write the failing tests**
+
+- Add a test for `WindowConfig` carrying `min_size`, `max_size`, `position`, `icon_path`, and startup visibility.
+- Add a test for new `WindowEvent` variants covering `Maximized`, `Minimized`, `Restored`, `Occluded`, and `MonitorChanged`.
+- Add a test for a new `MonitorInfo` / `WindowBounds` value type roundtrip.
+
+**Step 2: Run the targeted test to verify failure**
+
+Run:
+- `cargo test -p blinc_platform --test window_api -- --nocapture`
+
+Expected: compile failures or missing-symbol failures because the richer contracts do not exist yet.
+
+**Step 3: Commit the red tests**
+
+```bash
+git add crates/blinc_platform/tests/window_api.rs crates/blinc_platform/src/window.rs crates/blinc_platform/src/event.rs
+git commit -m "test: add windowing foundation contract coverage"
+```
+
+### Task 2: Add Shared Window And Monitor Primitives
+
+**Files:**
+- Modify: `crates/blinc_platform/src/window.rs`
+- Modify: `crates/blinc_platform/src/event.rs`
+- Modify: `crates/blinc_platform/src/lib.rs`
+- Modify: `extensions/blinc_platform_android/src/window.rs`
+- Modify: `extensions/blinc_platform_ios/src/window.rs`
+- Modify: `extensions/blinc_platform_harmony/src/window.rs`
+
+**Step 1: Extend `WindowConfig` minimally**
+
+- Add optional fields for minimum size, maximum size, startup position, visibility, and icon path.
+- Add builder methods for each new field instead of ad hoc setters later.
+
+**Step 2: Expand the `Window` trait**
+
+- Add methods for `set_size`, `set_min_size`, `set_max_size`, `set_position`, `set_visible`, `set_always_on_top`, `set_fullscreen`, `minimize`, `maximize`, `restore`, `set_decorations`, and `monitors`.
+- Introduce lightweight shared structs such as `WindowBounds`, `WindowPosition`, and `MonitorInfo`.
+
+**Step 3: Expand `WindowEvent`**
+
+- Add variants for maximize/minimize/restore/occlusion and monitor changes.
+- Keep the enum additive so current consumers can update via exhaustive matches.
+
+**Step 4: Add compile-safe follow-ups for non-desktop backends**
+
+- Update Android, iOS, and Harmony `Window` implementations to satisfy the widened trait with no-op or best-effort behavior where desktop-only features do not apply.
+- Preserve existing behavior by returning sensible defaults instead of faking desktop capabilities.
+
+**Step 5: Re-run the contract tests and cross-platform compile checks**
+
+Run:
+- `cargo test -p blinc_platform --test window_api -- --nocapture`
+- `cargo check -p blinc_platform_android`
+- `cargo check -p blinc_platform_ios`
+- `cargo check -p blinc_platform_harmony`
+
+Expected: shared API tests pass and all non-desktop platform crates still compile before the desktop backend implements every behavior.
+
+**Step 6: Commit the shared abstraction layer**
+
+```bash
+git add crates/blinc_platform/src/window.rs crates/blinc_platform/src/event.rs crates/blinc_platform/src/lib.rs crates/blinc_platform/tests/window_api.rs extensions/blinc_platform_android/src/window.rs extensions/blinc_platform_ios/src/window.rs extensions/blinc_platform_harmony/src/window.rs
+git commit -m "feat: extend shared desktop window contracts"
+```
+
+### Task 3: Implement Desktop Window Controls And Monitor Support
+
+**Files:**
+- Modify: `extensions/blinc_platform_desktop/src/window.rs`
+- Modify: `extensions/blinc_platform_desktop/src/event_loop.rs`
+- Modify: `extensions/blinc_platform_desktop/src/lib.rs`
+- Create: `extensions/blinc_platform_desktop/tests/window_runtime.rs`
+- Create: `extensions/blinc_platform_desktop/tests/support.rs`
+- Modify: `extensions/blinc_platform_desktop/Cargo.toml`
+
+**Step 1: Write the failing desktop runtime tests**
+
+- Add a test for applying min/max size and startup position from `WindowConfig`.
+- Add a test for forwarding focus/scale/maximize lifecycle events into the shared `WindowEvent` model.
+- Add a test for monitor enumeration returning at least the current monitor metadata when available.
+
+**Step 2: Run the targeted desktop test to verify failure**
+
+Run:
+- Linux/CI: `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop --test window_runtime -- --nocapture`
+- macOS/Windows/local GUI session: `cargo test -p blinc_platform_desktop --test window_runtime -- --nocapture`
+
+Expected: failures because the desktop backend currently exposes only title, cursor, redraw, focus, and visibility.
+
+**Step 3: Add a shared display guard for runtime tests**
+
+- Create `extensions/blinc_platform_desktop/tests/support.rs` with a `requires_display()` helper.
+- Skip GUI-runtime assertions cleanly when the environment cannot create a native window.
+
+**Step 4: Implement `DesktopWindow` methods**
+
+- Map new `Window` trait methods onto `winit::window::Window`.
+- Store any derived state that `winit` cannot query directly after mutation.
+- Respect `always_on_top`, fullscreen, visibility, and decorations from `WindowConfig`.
+
+**Step 5: Implement event-loop forwarding**
+
+- Translate `winit` maximize/minimize/occlusion/monitor movement signals into the shared `WindowEvent` variants.
+- Request redraw only when the new state requires a render pass.
+
+**Step 6: Re-run backend tests**
+
+Run:
+- Linux/CI: `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop --test window_runtime -- --nocapture`
+- macOS/Windows/local GUI session: `cargo test -p blinc_platform_desktop --test window_runtime -- --nocapture`
+- `cargo test -p blinc_platform --test window_api -- --nocapture`
+
+Expected: both shared and desktop tests pass.
+
+**Step 7: Commit the desktop backend foundation**
+
+```bash
+git add extensions/blinc_platform_desktop/src/window.rs extensions/blinc_platform_desktop/src/event_loop.rs extensions/blinc_platform_desktop/src/lib.rs extensions/blinc_platform_desktop/tests/support.rs extensions/blinc_platform_desktop/tests/window_runtime.rs extensions/blinc_platform_desktop/Cargo.toml
+git commit -m "feat: implement desktop window control foundation"
+```
+
+### Task 4: Verify And Format Before Higher Layers
+
+**Files:**
+- Modify only if verification reveals gaps.
+
+**Step 1: Run formatting**
+
+Run:
+- `cargo fmt --all`
+- `cargo fmt --all -- --check`
+
+Expected: formatting passes.
+
+**Step 2: Run broader smoke coverage**
+
+Run:
+- `cargo test -p blinc_platform -- --nocapture`
+- `cargo check -p blinc_platform_android`
+- `cargo check -p blinc_platform_ios`
+- `cargo check -p blinc_platform_harmony`
+- Linux/CI: `xvfb-run --auto-servernum cargo test -p blinc_platform_desktop -- --nocapture`
+- macOS/Windows/local GUI session: `cargo test -p blinc_platform_desktop -- --nocapture`
+
+Expected: no regressions in existing platform service tests, non-desktop crates still compile, and desktop runtime tests use the display-safe path.


### PR DESCRIPTION
## Summary
- add a master desktop platform execution plan and five split implementation plans
- document dependency ordering, verification steps, and desktop-specific execution constraints
- keep interview artifacts out of the PR and include only the docs/plans documents

## Test Plan
- [x] cargo fmt --all
- [x] cargo fmt --all -- --check
- [ ] cargo test --workspace --all-features (stopped per user request because this PR is docs-only)
