### PR TITLE
feat: harden desktop IME and accessibility semantics

### DIFF
--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -94,11 +94,23 @@ fn sync_platform_ime_state() {
     });
 }
 
+#[cfg(any(
+    target_os = "macos",
+    all(target_os = "linux", not(target_env = "ohos")),
+    target_os = "windows"
+))]
 fn sync_accessibility_snapshot(tree: &blinc_layout::RenderTree) {
     if let Some(snapshot) = blinc_layout::export_accessibility_snapshot(tree) {
         blinc_platform_desktop::update_accessibility_snapshot(snapshot);
     }
 }
+
+#[cfg(not(any(
+    target_os = "macos",
+    all(target_os = "linux", not(target_env = "ohos")),
+    target_os = "windows"
+)))]
+fn sync_accessibility_snapshot(_tree: &blinc_layout::RenderTree) {}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum E2eScript {
@@ -3795,9 +3807,6 @@ impl WindowedApp {
                             if let Some(ref tree) = render_tree {
                                 sync_accessibility_snapshot(tree);
                                 sync_platform_ime_state();
-                            }
-
-                            if let Some(ref tree) = render_tree {
                                 // Render with motion animations
                                 // Use physical pixel dimensions for the render surface
                                 let result = blinc_app.render_tree_with_motion(

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -38,8 +38,8 @@ use blinc_layout::overlay_state::{get_overlay_manager, OverlayContext};
 use blinc_layout::prelude::*;
 use blinc_layout::widgets::overlay::{overlay_manager, OverlayManager, OverlayManagerExt};
 use blinc_platform::{
-    ControlFlow, Event, EventLoop, InputEvent, Key, KeyState, LifecycleEvent, MouseEvent, Platform,
-    TouchEvent, Window, WindowConfig, WindowEvent,
+    ControlFlow, Event, EventLoop, ImeCursorArea, ImeState, InputEvent, Key, KeyState,
+    LifecycleEvent, MouseEvent, Platform, TouchEvent, Window, WindowConfig, WindowEvent,
 };
 
 use crate::app::BlincApp;
@@ -76,6 +76,28 @@ fn e2e_exit_after() -> bool {
         return !(v.is_empty() || v == "0" || v == "false" || v == "no");
     }
     e2e_is_enabled()
+}
+
+fn sync_platform_ime_state() {
+    let cursor_area = blinc_layout::widgets::focused_text_widget_ime_area().map(|bounds| {
+        ImeCursorArea::new(
+            bounds.x as f64,
+            bounds.y as f64,
+            bounds.width as f64,
+            bounds.height as f64,
+        )
+    });
+    let enabled = blinc_layout::widgets::has_live_focused_text_widget();
+    blinc_platform::set_ime_state(ImeState {
+        enabled,
+        cursor_area,
+    });
+}
+
+fn sync_accessibility_snapshot(tree: &blinc_layout::RenderTree) {
+    if let Some(snapshot) = blinc_layout::export_accessibility_snapshot(tree) {
+        blinc_platform_desktop::update_accessibility_snapshot(snapshot);
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2406,6 +2428,8 @@ impl WindowedApp {
                             if !focused {
                                 blinc_layout::widgets::blur_all_text_inputs();
                             }
+
+                            sync_platform_ime_state();
                         }
                     }
 
@@ -2904,6 +2928,38 @@ impl WindowedApp {
                                     // Scroll momentum ended - full stop
                                     scroll_ended = true;
                                 }
+                                InputEvent::CompositionStarted => {
+                                    blinc_layout::widgets::set_focused_text_widget_composition(None);
+                                }
+                                InputEvent::CompositionUpdated(update) => {
+                                    blinc_layout::widgets::set_focused_text_widget_composition(Some(
+                                        update,
+                                    ));
+                                }
+                                InputEvent::CompositionCommitted(text) => {
+                                    blinc_layout::widgets::set_focused_text_widget_composition(None);
+                                    for c in text.chars().filter(|c| !c.is_control()) {
+                                        keyboard_events.push(PendingEvent {
+                                            event_type: blinc_core::events::event_types::TEXT_INPUT,
+                                            key_char: Some(c),
+                                            ..Default::default()
+                                        });
+                                    }
+                                }
+                                InputEvent::CompositionCancelled => {
+                                    blinc_layout::widgets::set_focused_text_widget_composition(None);
+                                }
+                                InputEvent::FocusTraversal(intent) => {
+                                    keyboard_events.push(PendingEvent {
+                                        event_type: blinc_core::events::event_types::KEY_DOWN,
+                                        key_code: 9,
+                                        shift: matches!(
+                                            intent,
+                                            blinc_platform::FocusTraversalIntent::Previous
+                                        ),
+                                        ..Default::default()
+                                    });
+                                }
                             }
 
                             router.clear_event_callback();
@@ -3079,6 +3135,8 @@ impl WindowedApp {
                                 window.request_redraw();
                             }
                         }
+
+                        sync_platform_ime_state();
                     }
 
                     Event::Frame => {
@@ -3719,6 +3777,7 @@ impl WindowedApp {
                                         tree.compute_layout(windowed_ctx.width, windowed_ctx.height);
                                     }
                                 }
+                                sync_accessibility_snapshot(tree);
                             }
 
                             // Apply CSS animation/transition values AFTER state styles
@@ -3731,6 +3790,11 @@ impl WindowedApp {
                                         tree.compute_layout(windowed_ctx.width, windowed_ctx.height);
                                     }
                                 }
+                            }
+
+                            if let Some(ref tree) = render_tree {
+                                sync_accessibility_snapshot(tree);
+                                sync_platform_ime_state();
                             }
 
                             if let Some(ref tree) = render_tree {

--- a/crates/blinc_layout/Cargo.toml
+++ b/crates/blinc_layout/Cargo.toml
@@ -20,6 +20,7 @@ recorder = ["dep:blinc_recorder"]
 blinc_core = { path = "../blinc_core", version = "0.1.14" }
 blinc_animation = { path = "../blinc_animation", version = "0.1.14" }
 blinc_theme = { path = "../blinc_theme", version = "0.1.14" }
+blinc_platform = { path = "../blinc_platform", version = "0.1.14" }
 blinc_recorder = { path = "../blinc_recorder", version = "0.1.14", optional = true }
 
 # Layout

--- a/crates/blinc_layout/src/accessibility.rs
+++ b/crates/blinc_layout/src/accessibility.rs
@@ -1,0 +1,154 @@
+use std::sync::Arc;
+
+use blinc_platform::{
+    AccessibilityAction, AccessibilityBounds, AccessibilityNode, AccessibilityRole,
+    AccessibilityTreeSnapshot,
+};
+
+use crate::renderer::RenderTree;
+use crate::tree::{LayoutNodeId, LayoutTree};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AccessibilityMetadata {
+    pub role: AccessibilityRole,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub value: Option<String>,
+    pub focusable: bool,
+    pub focused: bool,
+    pub disabled: bool,
+    pub actions: Vec<AccessibilityAction>,
+}
+
+impl AccessibilityMetadata {
+    pub fn new(role: AccessibilityRole) -> Self {
+        Self {
+            role,
+            name: None,
+            description: None,
+            value: None,
+            focusable: false,
+            focused: false,
+            disabled: false,
+            actions: Vec::new(),
+        }
+    }
+
+    pub fn with_name(mut self, name: Option<String>) -> Self {
+        self.name = name;
+        self
+    }
+
+    pub fn with_description(mut self, description: Option<String>) -> Self {
+        self.description = description;
+        self
+    }
+
+    pub fn with_value(mut self, value: Option<String>) -> Self {
+        self.value = value;
+        self
+    }
+
+    pub fn with_focusable(mut self, focusable: bool) -> Self {
+        self.focusable = focusable;
+        self
+    }
+
+    pub fn with_focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    pub fn with_actions(mut self, actions: Vec<AccessibilityAction>) -> Self {
+        self.actions = actions;
+        self
+    }
+}
+
+pub type AccessibilityMetadataProvider = Arc<dyn Fn() -> AccessibilityMetadata + Send + Sync>;
+
+pub fn export_accessibility_snapshot(tree: &RenderTree) -> Option<AccessibilityTreeSnapshot> {
+    let root = tree.root()?;
+    Some(export_snapshot_from_layout(&tree.layout_tree, root))
+}
+
+fn export_snapshot_from_layout(tree: &LayoutTree, root: LayoutNodeId) -> AccessibilityTreeSnapshot {
+    let mut nodes = Vec::new();
+    let children = collect_nodes(tree, root, &mut nodes, true);
+    let root_id = root.to_raw();
+
+    if !nodes.iter().any(|node| node.id == root_id) {
+        let bounds = tree.get_absolute_bounds(root).map(|bounds| {
+            AccessibilityBounds::new(bounds.x, bounds.y, bounds.width, bounds.height)
+        });
+        nodes.insert(
+            0,
+            AccessibilityNode {
+                id: root_id,
+                role: AccessibilityRole::Group,
+                name: None,
+                description: None,
+                value: None,
+                bounds,
+                focusable: false,
+                focused: false,
+                disabled: false,
+                actions: Vec::new(),
+                children,
+            },
+        );
+    }
+
+    AccessibilityTreeSnapshot::new(root_id, nodes)
+}
+
+fn collect_nodes(
+    tree: &LayoutTree,
+    node_id: LayoutNodeId,
+    nodes: &mut Vec<AccessibilityNode>,
+    is_root: bool,
+) -> Vec<u64> {
+    let mut exported_children = Vec::new();
+    for child in tree.children(node_id) {
+        exported_children.extend(collect_nodes(tree, child, nodes, false));
+    }
+
+    let Some(metadata) = tree.accessibility_metadata(node_id) else {
+        return exported_children;
+    };
+
+    let bounds = tree
+        .get_absolute_bounds(node_id)
+        .map(|bounds| AccessibilityBounds::new(bounds.x, bounds.y, bounds.width, bounds.height));
+    let accessibility_id = node_id.to_raw();
+
+    nodes.push(AccessibilityNode {
+        id: accessibility_id,
+        role: metadata.role,
+        name: metadata.name,
+        description: metadata.description,
+        value: metadata.value,
+        bounds,
+        focusable: metadata.focusable,
+        focused: metadata.focused,
+        disabled: metadata.disabled,
+        actions: metadata.actions,
+        children: exported_children,
+    });
+
+    vec![accessibility_id]
+}
+
+pub fn focus_order(snapshot: &AccessibilityTreeSnapshot) -> Vec<u64> {
+    snapshot
+        .nodes
+        .iter()
+        .filter(|node| node.focusable && !node.disabled)
+        .map(|node| node.id)
+        .collect()
+}

--- a/crates/blinc_layout/src/lib.rs
+++ b/crates/blinc_layout/src/lib.rs
@@ -29,6 +29,7 @@
 //! tree.compute_layout(800.0, 600.0);
 //! ```
 
+pub mod accessibility;
 pub mod animated;
 pub mod canvas;
 pub mod diff;
@@ -110,6 +111,7 @@ pub use element::{
 };
 
 // Diff and reconciliation
+pub use accessibility::{export_accessibility_snapshot, focus_order, AccessibilityMetadata};
 pub use diff::{
     diff, diff_children, diff_elements, reconcile, ChangeCategory, ChildDiff, DiffResult, DivHash,
     ReconcileActions,
@@ -454,3 +456,6 @@ pub mod prelude {
     // Stable unique key generation for components
     pub use crate::key::{reset_call_counters, InstanceKey};
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/blinc_layout/src/renderer.rs
+++ b/crates/blinc_layout/src/renderer.rs
@@ -2237,12 +2237,14 @@ impl RenderTree {
     /// When bounds change (width or height differ), the on_change callback is invoked.
     fn update_layout_bounds_storages(&self) {
         for (&node_id, entry) in &self.layout_bounds_storages {
-            if let Some(bounds) = self.layout_tree.get_bounds(node_id, (0.0, 0.0)) {
+            if let Some(bounds) = self.layout_tree.get_absolute_bounds(node_id) {
                 let should_notify = if let Ok(mut guard) = entry.storage.lock() {
-                    // Check if bounds changed (compare width and height)
+                    // Notify when position or size changes so external readers stay in sync.
                     let changed = match guard.as_ref() {
                         Some(old_bounds) => {
-                            (old_bounds.width - bounds.width).abs() > 0.01
+                            (old_bounds.x - bounds.x).abs() > 0.01
+                                || (old_bounds.y - bounds.y).abs() > 0.01
+                                || (old_bounds.width - bounds.width).abs() > 0.01
                                 || (old_bounds.height - bounds.height).abs() > 0.01
                         }
                         None => true, // First time getting bounds

--- a/crates/blinc_layout/src/tests/accessibility_semantics.rs
+++ b/crates/blinc_layout/src/tests/accessibility_semantics.rs
@@ -1,0 +1,230 @@
+use blinc_platform::{AccessibilityRole, ImeCompositionSelection, ImeCompositionUpdate};
+use blinc_theme::ThemeState;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Mutex, MutexGuard, Once};
+
+use crate::accessibility::{export_accessibility_snapshot, focus_order};
+use crate::div::div;
+use crate::renderer::RenderTree;
+use crate::stateful::{ButtonState, Stateful, TextFieldState};
+use crate::widgets::{
+    blur_all_text_inputs, button, set_focused_text_widget_composition, text_area, text_area_state,
+    text_input, text_input_state,
+};
+
+fn ensure_theme() {
+    static INIT: Once = Once::new();
+    INIT.call_once(ThemeState::init_default);
+}
+
+fn accessibility_test_guard() -> MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().expect("accessibility test lock")
+}
+
+#[test]
+fn accessibility_semantics_preserve_preedit_text() {
+    let _guard = accessibility_test_guard();
+    ensure_theme();
+    blur_all_text_inputs();
+
+    let input = text_input_state();
+    {
+        let mut data = input.lock().expect("input lock");
+        data.value = "rust".to_string();
+        data.cursor = 4;
+        data.visual = TextFieldState::Focused;
+    }
+    crate::widgets::text_input::set_focused_text_input(&input);
+    set_focused_text_widget_composition(Some(ImeCompositionUpdate::new(
+        "한",
+        Some(ImeCompositionSelection::new(0, 1)),
+    )));
+
+    let ui = div().child(text_input(&input));
+    let mut tree = RenderTree::from_element(&ui);
+    tree.compute_layout(480.0, 120.0);
+
+    let snapshot = export_accessibility_snapshot(&tree).expect("snapshot");
+    let input_node = snapshot
+        .nodes
+        .iter()
+        .find(|node| node.role == AccessibilityRole::TextInput)
+        .expect("text input node");
+
+    assert_eq!(input_node.value.as_deref(), Some("rust한"));
+
+    blur_all_text_inputs();
+}
+
+#[test]
+fn accessibility_semantics_export_roles() {
+    let _guard = accessibility_test_guard();
+    ensure_theme();
+    let button_state = Stateful::new(ButtonState::Idle).shared_state();
+    let input = text_input_state();
+    let area = text_area_state();
+
+    let ui = div()
+        .flex_col()
+        .child(button(button_state, "Submit"))
+        .child(text_input(&input))
+        .child(text_area(&area));
+    let mut tree = RenderTree::from_element(&ui);
+    tree.compute_layout(640.0, 320.0);
+
+    let snapshot = export_accessibility_snapshot(&tree).expect("snapshot");
+    let roles = snapshot
+        .nodes
+        .iter()
+        .map(|node| node.role)
+        .collect::<Vec<_>>();
+
+    assert!(roles.contains(&AccessibilityRole::Button));
+    assert!(roles.contains(&AccessibilityRole::TextInput));
+    assert!(roles.contains(&AccessibilityRole::TextArea));
+}
+
+#[test]
+fn accessibility_semantics_focus_order() {
+    let _guard = accessibility_test_guard();
+    ensure_theme();
+    let button_state = Stateful::new(ButtonState::Idle).shared_state();
+    let input = text_input_state();
+    let area = text_area_state();
+
+    let ui = div()
+        .flex_col()
+        .child(button(button_state, "Primary"))
+        .child(text_input(&input))
+        .child(text_area(&area));
+    let mut tree = RenderTree::from_element(&ui);
+    tree.compute_layout(640.0, 320.0);
+
+    let snapshot = export_accessibility_snapshot(&tree).expect("snapshot");
+    let ordered_roles = focus_order(&snapshot)
+        .into_iter()
+        .filter_map(|id| snapshot.nodes.iter().find(|node| node.id == id))
+        .map(|node| node.role)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        ordered_roles,
+        vec![
+            AccessibilityRole::Button,
+            AccessibilityRole::TextInput,
+            AccessibilityRole::TextArea,
+        ]
+    );
+}
+
+#[test]
+fn accessibility_semantics_snapshot_tracks_live_widget_state_without_rebuild() {
+    let _guard = accessibility_test_guard();
+    ensure_theme();
+    blur_all_text_inputs();
+
+    let input = text_input_state();
+    {
+        let mut data = input.lock().expect("input lock");
+        data.value = "a".to_string();
+        data.cursor = 1;
+        data.visual = TextFieldState::Focused;
+    }
+
+    let ui = div().child(text_input(&input));
+    let mut tree = RenderTree::from_element(&ui);
+    tree.compute_layout(320.0, 120.0);
+
+    {
+        let mut data = input.lock().expect("input lock");
+        data.value = "ab".to_string();
+        data.cursor = 2;
+    }
+
+    let snapshot = export_accessibility_snapshot(&tree).expect("snapshot");
+    let input_node = snapshot
+        .nodes
+        .iter()
+        .find(|node| node.role == AccessibilityRole::TextInput)
+        .expect("text input node");
+
+    assert_eq!(input_node.value.as_deref(), Some("ab"));
+
+    blur_all_text_inputs();
+}
+
+#[test]
+fn accessibility_semantics_nested_wrappers_keep_descendant_controls_reachable() {
+    let _guard = accessibility_test_guard();
+    ensure_theme();
+
+    let input = text_input_state();
+    let ui = div()
+        .p(24.0)
+        .child(div().p(16.0).child(div().p(12.0).child(text_input(&input))));
+    let mut tree = RenderTree::from_element(&ui);
+    tree.compute_layout(400.0, 180.0);
+
+    let snapshot = export_accessibility_snapshot(&tree).expect("snapshot");
+    let nodes_by_id = snapshot
+        .nodes
+        .iter()
+        .map(|node| (node.id, node))
+        .collect::<HashMap<_, _>>();
+    let input_id = snapshot
+        .nodes
+        .iter()
+        .find(|node| node.role == AccessibilityRole::TextInput)
+        .map(|node| node.id)
+        .expect("text input node");
+
+    let mut reachable = HashSet::new();
+    let mut stack = vec![snapshot.root_id];
+    while let Some(node_id) = stack.pop() {
+        if !reachable.insert(node_id) {
+            continue;
+        }
+
+        if let Some(node) = nodes_by_id.get(&node_id) {
+            stack.extend(node.children.iter().copied());
+        }
+    }
+
+    assert!(reachable.contains(&input_id));
+}
+
+#[test]
+fn accessibility_semantics_ime_area_uses_absolute_widget_bounds() {
+    let _guard = accessibility_test_guard();
+    ensure_theme();
+    blur_all_text_inputs();
+
+    let input = text_input_state();
+    {
+        let mut data = input.lock().expect("input lock");
+        data.value = "hello".to_string();
+        data.cursor = 5;
+        data.visual = TextFieldState::Focused;
+    }
+    crate::widgets::text_input::set_focused_text_input(&input);
+
+    let ui = div()
+        .p(90.0)
+        .child(div().pt(60.0).pl(40.0).child(text_input(&input)));
+    let mut tree = RenderTree::from_element(&ui);
+    tree.compute_layout(640.0, 240.0);
+
+    let ime_area = crate::widgets::focused_text_widget_ime_area().expect("ime area");
+
+    assert!(
+        ime_area.x >= 130.0,
+        "ime x should include ancestor offsets: {ime_area:?}"
+    );
+    assert!(
+        ime_area.y >= 150.0,
+        "ime y should include ancestor offsets: {ime_area:?}"
+    );
+
+    blur_all_text_inputs();
+}

--- a/crates/blinc_layout/src/tests/mod.rs
+++ b/crates/blinc_layout/src/tests/mod.rs
@@ -1,0 +1,1 @@
+mod accessibility_semantics;

--- a/crates/blinc_layout/src/tree.rs
+++ b/crates/blinc_layout/src/tree.rs
@@ -4,6 +4,7 @@ use slotmap::{new_key_type, Key, SlotMap};
 use std::collections::HashMap;
 use taffy::prelude::*;
 
+use crate::accessibility::{AccessibilityMetadata, AccessibilityMetadataProvider};
 use crate::element::ElementBounds;
 use crate::text_measure::{measure_text_with_options, TextLayoutOptions};
 
@@ -165,6 +166,7 @@ pub struct LayoutTree {
     node_map: SlotMap<LayoutNodeId, NodeId>,
     /// Reverse mapping from Taffy NodeId to our LayoutNodeId
     reverse_map: HashMap<NodeId, LayoutNodeId>,
+    accessibility: HashMap<LayoutNodeId, AccessibilityMetadataProvider>,
 }
 
 impl LayoutTree {
@@ -173,6 +175,7 @@ impl LayoutTree {
             taffy: TaffyTree::new(),
             node_map: SlotMap::with_key(),
             reverse_map: HashMap::new(),
+            accessibility: HashMap::new(),
         }
     }
 
@@ -246,8 +249,30 @@ impl LayoutTree {
     pub fn remove_node(&mut self, id: LayoutNodeId) {
         if let Some(taffy_node) = self.node_map.remove(id) {
             self.reverse_map.remove(&taffy_node);
+            self.accessibility.remove(&id);
             let _ = self.taffy.remove(taffy_node);
         }
+    }
+
+    pub fn set_accessibility_metadata(
+        &mut self,
+        id: LayoutNodeId,
+        metadata: AccessibilityMetadata,
+    ) {
+        self.accessibility
+            .insert(id, std::sync::Arc::new(move || metadata.clone()));
+    }
+
+    pub fn set_accessibility_provider(
+        &mut self,
+        id: LayoutNodeId,
+        provider: AccessibilityMetadataProvider,
+    ) {
+        self.accessibility.insert(id, provider);
+    }
+
+    pub fn accessibility_metadata(&self, id: LayoutNodeId) -> Option<AccessibilityMetadata> {
+        self.accessibility.get(&id).map(|provider| provider())
     }
 
     /// Get children of a layout node
@@ -311,6 +336,22 @@ impl LayoutTree {
             current = parent;
         }
         result
+    }
+
+    /// Depth-first pre-order traversal including the root node.
+    pub fn descendants_preorder(&self, root: LayoutNodeId) -> Vec<LayoutNodeId> {
+        fn visit(tree: &LayoutTree, node: LayoutNodeId, out: &mut Vec<LayoutNodeId>) {
+            out.push(node);
+            for child in tree.children(node) {
+                visit(tree, child, out);
+            }
+        }
+
+        let mut ordered = Vec::new();
+        if self.node_map.contains_key(root) {
+            visit(self, root, &mut ordered);
+        }
+        ordered
     }
 
     /// Get the content size for a scrollable node

--- a/crates/blinc_layout/src/widgets/button.rs
+++ b/crates/blinc_layout/src/widgets/button.rs
@@ -30,12 +30,14 @@ use blinc_core::reactive::SignalId;
 use blinc_core::Color;
 use blinc_theme::{ColorToken, ThemeState};
 
+use crate::accessibility::AccessibilityMetadata;
 use crate::css_parser::{active_stylesheet, ElementState};
 use crate::div::{div, Div, ElementBuilder};
 use crate::element::RenderProps;
 use crate::stateful::{ButtonState, SharedState, Stateful};
 use crate::text::text;
 use crate::tree::{LayoutNodeId, LayoutTree};
+use blinc_platform::AccessibilityRole;
 
 /// Button visual states (re-exported from stateful)
 pub use crate::stateful::ButtonState as ButtonVisualState;
@@ -611,7 +613,22 @@ impl ElementBuilder for Button {
         }
 
         // Build the inner Stateful - it will apply the callback we just set
-        self.inner.build(tree)
+        let node_id = self.inner.build(tree);
+        let metadata = self
+            .config
+            .lock()
+            .ok()
+            .map(|cfg| {
+                AccessibilityMetadata::new(AccessibilityRole::Button)
+                    .with_name(cfg.label.clone())
+                    .with_focusable(true)
+                    .with_disabled(cfg.disabled)
+            })
+            .unwrap_or_else(|| {
+                AccessibilityMetadata::new(AccessibilityRole::Button).with_focusable(true)
+            });
+        tree.set_accessibility_metadata(node_id, metadata);
+        node_id
     }
 
     fn render_props(&self) -> RenderProps {

--- a/crates/blinc_layout/src/widgets/checkbox.rs
+++ b/crates/blinc_layout/src/widgets/checkbox.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use blinc_core::{Color, State};
 use blinc_theme::{ColorToken, ThemeState};
 
+use crate::accessibility::{AccessibilityMetadata, AccessibilityMetadataProvider};
 use crate::css_parser::{active_stylesheet, ElementState, Stylesheet};
 use crate::div::{div, ElementBuilder};
 use crate::element::RenderProps;
@@ -31,6 +32,7 @@ use crate::stateful::{stateful_with_key, ButtonState};
 use crate::svg::svg;
 use crate::text::text;
 use crate::tree::{LayoutNodeId, LayoutTree};
+use blinc_platform::AccessibilityRole;
 
 /// Checkbox configuration
 ///
@@ -211,6 +213,7 @@ fn apply_style_to_checkbox(
 /// The fully-built checkbox component (Div containing stateful checkbox + optional label)
 pub struct Checkbox {
     inner: crate::div::Div,
+    accessibility_provider: AccessibilityMetadataProvider,
 }
 
 impl Checkbox {
@@ -218,6 +221,7 @@ impl Checkbox {
     fn with_config(instance_key: &InstanceKey, config: CheckboxConfig) -> Self {
         let checked_state = config.checked.clone();
         let checked_for_click = config.checked.clone();
+        let checked_for_semantics = config.checked.clone();
         let on_change = config.on_change.clone();
         let disabled = config.disabled;
 
@@ -334,13 +338,30 @@ impl Checkbox {
                 .child(checkbox)
         };
 
-        Self { inner }
+        let accessibility_provider: AccessibilityMetadataProvider = Arc::new(move || {
+            AccessibilityMetadata::new(AccessibilityRole::Checkbox)
+                .with_name(label_text.clone())
+                .with_value(Some(if checked_for_semantics.get() {
+                    "checked".to_string()
+                } else {
+                    "unchecked".to_string()
+                }))
+                .with_focusable(true)
+                .with_disabled(disabled)
+        });
+
+        Self {
+            inner,
+            accessibility_provider,
+        }
     }
 }
 
 impl ElementBuilder for Checkbox {
     fn build(&self, tree: &mut LayoutTree) -> LayoutNodeId {
-        self.inner.build(tree)
+        let node_id = self.inner.build(tree);
+        tree.set_accessibility_provider(node_id, Arc::clone(&self.accessibility_provider));
+        node_id
     }
 
     fn render_props(&self) -> RenderProps {

--- a/crates/blinc_layout/src/widgets/mod.rs
+++ b/crates/blinc_layout/src/widgets/mod.rs
@@ -61,13 +61,16 @@ pub use text_input::{
     blur_all_text_inputs,
     // Cursor blink timing utilities
     elapsed_ms,
+    focused_text_widget_ime_area,
     has_focused_text_input,
+    has_live_focused_text_widget,
     request_css_reparse,
     // Rebuild/relayout request functions
     request_full_rebuild,
     request_rebuild,
     // Continuous redraw callback for animation scheduler integration
     set_continuous_redraw_callback,
+    set_focused_text_widget_composition,
     take_needs_continuous_redraw,
     take_needs_css_reparse,
     take_needs_rebuild,

--- a/crates/blinc_layout/src/widgets/text_area.rs
+++ b/crates/blinc_layout/src/widgets/text_area.rs
@@ -15,8 +15,10 @@ use std::sync::{
 
 use blinc_core::reactive::SignalId;
 use blinc_core::Color;
+use blinc_platform::{AccessibilityAction, AccessibilityRole, ImeCompositionUpdate};
 use blinc_theme::{ColorToken, ThemeState};
 
+use crate::accessibility::AccessibilityMetadata;
 use crate::canvas::canvas;
 use crate::css_parser::{active_stylesheet, ElementState, Stylesheet};
 use crate::div::{div, Div, ElementBuilder};
@@ -362,6 +364,8 @@ pub struct TextAreaState {
     pub cursor: TextPosition,
     /// Selection start position (if selecting)
     pub selection_start: Option<TextPosition>,
+    /// In-progress IME composition preview at the current cursor.
+    pub composition: Option<ImeCompositionUpdate>,
     /// Visual state for styling
     pub visual: TextFieldState,
     /// Placeholder text
@@ -403,6 +407,8 @@ pub struct TextAreaState {
     pub(crate) change_signal_id: Option<SignalId>,
     /// Layout bounds storage - updated after layout to get actual rendered dimensions
     pub layout_bounds_storage: crate::renderer::LayoutBoundsStorage,
+    /// Local caret rectangle used to position IME candidate windows.
+    pub ime_cursor_bounds_storage: crate::renderer::LayoutBoundsStorage,
     /// CSS element ID for stylesheet matching (set via TextArea::id())
     pub(crate) css_element_id: Option<String>,
     /// CSS class names for stylesheet matching (set via TextArea::class())
@@ -415,6 +421,7 @@ impl std::fmt::Debug for TextAreaState {
             .field("lines", &self.lines)
             .field("cursor", &self.cursor)
             .field("selection_start", &self.selection_start)
+            .field("composition", &self.composition)
             .field("visual", &self.visual)
             .field("placeholder", &self.placeholder)
             .field("disabled", &self.disabled)
@@ -431,6 +438,7 @@ impl Default for TextAreaState {
             lines: vec![String::new()],
             cursor: TextPosition::default(),
             selection_start: None,
+            composition: None,
             visual: TextFieldState::Idle,
             placeholder: String::new(),
             disabled: false,
@@ -449,10 +457,18 @@ impl Default for TextAreaState {
             change_version: Arc::new(AtomicU64::new(0)),
             change_signal_id: None,
             layout_bounds_storage: Arc::new(Mutex::new(None)),
+            ime_cursor_bounds_storage: Arc::new(Mutex::new(None)),
             css_element_id: None,
             css_classes: Vec::new(),
         }
     }
+}
+
+fn split_text_lines(value: &str) -> Vec<String> {
+    value
+        .split('\n')
+        .map(|line| line.strip_suffix('\r').unwrap_or(line).to_string())
+        .collect()
 }
 
 impl TextAreaState {
@@ -464,11 +480,7 @@ impl TextAreaState {
     /// Create with initial value
     pub fn with_value(value: impl Into<String>) -> Self {
         let value = value.into();
-        let lines: Vec<String> = if value.is_empty() {
-            vec![String::new()]
-        } else {
-            value.lines().map(|s| s.to_string()).collect()
-        };
+        let lines = split_text_lines(&value);
         let cursor = TextPosition::new(
             lines.len().saturating_sub(1),
             lines.last().map(|l| l.chars().count()).unwrap_or(0),
@@ -493,13 +505,25 @@ impl TextAreaState {
         self.lines.join("\n")
     }
 
+    pub fn value_with_composition(&self) -> String {
+        let Some(composition) = self.composition.as_ref() else {
+            return self.value();
+        };
+
+        let mut preview = self.clone();
+        preview.composition = None;
+        preview.insert(&composition.text);
+        preview.value()
+    }
+
+    pub fn display_lines(&self) -> Vec<String> {
+        let value = self.value_with_composition();
+        split_text_lines(&value)
+    }
+
     /// Set the text value
     pub fn set_value(&mut self, value: &str) {
-        self.lines = if value.is_empty() {
-            vec![String::new()]
-        } else {
-            value.lines().map(|s| s.to_string()).collect()
-        };
+        self.lines = split_text_lines(value);
         self.cursor = TextPosition::new(
             self.lines.len().saturating_sub(1),
             self.lines.last().map(|l| l.chars().count()).unwrap_or(0),
@@ -973,7 +997,7 @@ impl TextAreaState {
         let available_width = self.available_width;
         let wrap_enabled = self.wrap_enabled;
 
-        for (logical_line_idx, line_text) in self.lines.iter().enumerate() {
+        for (logical_line_idx, line_text) in self.display_lines().into_iter().enumerate() {
             if line_text.is_empty() {
                 // Empty line still takes up one visual line
                 self.visual_lines.push(VisualLine {
@@ -988,7 +1012,7 @@ impl TextAreaState {
 
             if !wrap_enabled || available_width <= 0.0 {
                 // No wrapping - entire logical line is one visual line
-                let width = crate::text_measure::measure_text(line_text, font_size).width;
+                let width = crate::text_measure::measure_text(&line_text, font_size).width;
                 self.visual_lines.push(VisualLine {
                     logical_line: logical_line_idx,
                     start_char: 0,
@@ -1834,8 +1858,11 @@ impl TextArea {
     ) -> Div {
         // Note: Visual styling (bg, border, rounded) is now applied directly to the
         // container in the callback via set_* methods, not here.
+        let display_text = data.value_with_composition();
+        let display_lines = data.display_lines();
+        let has_display_text = !display_text.is_empty();
 
-        let text_color = if data.is_empty() {
+        let text_color = if !has_display_text {
             config.placeholder_color
         } else if data.disabled {
             Color::rgba(0.4, 0.4, 0.4, 1.0)
@@ -1879,12 +1906,23 @@ impl TextArea {
 
         // Build cursor canvas element (if focused)
         // The cursor is positioned inside the scroll content so it scrolls with text
+        let descender_offset = config.font_size * 0.1;
+        let cursor_top = cursor_visual_y + (line_height - cursor_height) / 2.0 - descender_offset;
+        if let Ok(mut bounds) = data.ime_cursor_bounds_storage.lock() {
+            *bounds = if is_focused {
+                Some(crate::element::ElementBounds {
+                    x: (config.padding_x + cursor_x).max(0.0),
+                    y: (config.padding_y + cursor_top - data.scroll_offset()).max(0.0),
+                    width: 2.0,
+                    height: cursor_height,
+                })
+            } else {
+                None
+            };
+        }
         let cursor_canvas_opt = if is_focused {
             // Cursor top is based on visual line position plus vertical centering within line
             // Shift cursor UP - fonts have descender space at bottom which pushes visible text upward
-            let descender_offset = config.font_size * 0.1;
-            let cursor_top =
-                cursor_visual_y + (line_height - cursor_height) / 2.0 - descender_offset;
             let cursor_left = cursor_x;
 
             {
@@ -1951,7 +1989,7 @@ impl TextArea {
             .relative()
             .overflow_visible();
 
-        if data.is_empty() {
+        if !has_display_text {
             // Use state's placeholder if available, otherwise fall back to config
             let placeholder = if !data.placeholder.is_empty() {
                 &data.placeholder
@@ -2012,7 +2050,7 @@ impl TextArea {
             // Wrapping mode fallback: use natural text wrapping
             // This path is used when visual lines not yet computed
             // In this mode, line_idx corresponds to logical line (visual line not computed)
-            for (line_idx, line) in data.lines.iter().enumerate() {
+            for (line_idx, line) in display_lines.iter().enumerate() {
                 let line_text = if line.is_empty() { " " } else { line.as_str() };
                 let state_for_line = Arc::clone(&shared_state);
 
@@ -2040,7 +2078,7 @@ impl TextArea {
         } else {
             // No-wrap mode: each line stays on single line, horizontally scrollable
             // In this mode, line_idx corresponds to both logical and visual line
-            for (line_idx, line) in data.lines.iter().enumerate() {
+            for (line_idx, line) in display_lines.iter().enumerate() {
                 let line_text = if line.is_empty() { " " } else { line.as_str() };
                 let state_for_line = Arc::clone(&shared_state);
 
@@ -2617,7 +2655,41 @@ impl ElementBuilder for TextArea {
         }
 
         // Build the inner Stateful
-        self.inner.build(tree)
+        let node_id = self.inner.build(tree);
+        let state = Arc::clone(&self.state);
+        tree.set_accessibility_provider(
+            node_id,
+            std::sync::Arc::new(move || {
+                state
+                    .lock()
+                    .ok()
+                    .map(|state| {
+                        AccessibilityMetadata::new(AccessibilityRole::TextArea)
+                            .with_name(if state.placeholder.is_empty() {
+                                state.css_element_id.clone()
+                            } else {
+                                Some(state.placeholder.clone())
+                            })
+                            .with_value(Some(state.value_with_composition()))
+                            .with_focusable(true)
+                            .with_focused(state.visual.is_focused())
+                            .with_disabled(state.disabled)
+                            .with_actions(vec![
+                                AccessibilityAction::Focus,
+                                AccessibilityAction::SetValue,
+                            ])
+                    })
+                    .unwrap_or_else(|| {
+                        AccessibilityMetadata::new(AccessibilityRole::TextArea)
+                            .with_focusable(true)
+                            .with_actions(vec![
+                                AccessibilityAction::Focus,
+                                AccessibilityAction::SetValue,
+                            ])
+                    })
+            }),
+        );
+        node_id
     }
 
     fn render_props(&self) -> RenderProps {
@@ -2715,6 +2787,13 @@ impl ElementBuilder for TextArea {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use blinc_theme::ThemeState;
+    use std::sync::Once;
+
+    fn ensure_theme() {
+        static INIT: Once = Once::new();
+        INIT.call_once(ThemeState::init_default);
+    }
 
     #[test]
     fn test_text_area_state_insert() {
@@ -2770,5 +2849,68 @@ mod tests {
         state.insert("new");
         assert_eq!(state.value(), "new");
         assert_eq!(state.line_count(), 1);
+    }
+
+    #[test]
+    fn test_text_area_visual_lines_use_composition_text() {
+        let mut state = TextAreaState::new();
+        state.composition = Some(ImeCompositionUpdate::new("한", None));
+        state.font_size = 16.0;
+        state.available_width = 200.0;
+        state.wrap_enabled = true;
+
+        state.compute_visual_lines();
+
+        assert_eq!(state.visual_lines.len(), 1);
+        assert_eq!(state.visual_lines[0].text, "한");
+    }
+
+    #[test]
+    fn test_text_area_composition_replaces_active_selection() {
+        let mut state = TextAreaState::with_value("hello");
+        state.cursor = TextPosition::new(0, 4);
+        state.selection_start = Some(TextPosition::new(0, 1));
+        state.composition = Some(ImeCompositionUpdate::new("한", None));
+
+        assert_eq!(state.value_with_composition(), "h한o");
+    }
+
+    #[test]
+    fn test_text_area_preserves_trailing_empty_logical_line() {
+        let mut state = TextAreaState::with_value("hello\n");
+        state.font_size = 16.0;
+        state.available_width = 200.0;
+        state.wrap_enabled = true;
+
+        assert_eq!(state.line_count(), 2);
+        assert_eq!(
+            state.display_lines(),
+            vec!["hello".to_string(), String::new()]
+        );
+
+        state.compute_visual_lines();
+
+        assert_eq!(state.visual_lines.len(), 2);
+        assert_eq!(state.visual_lines[1].text, "");
+    }
+
+    #[test]
+    fn test_text_area_blank_lines_do_not_fall_back_to_placeholder() {
+        ensure_theme();
+        let state = text_area_state();
+        {
+            let mut data = state.lock().expect("text area lock");
+            data.placeholder = "Type here".to_string();
+            data.set_value("\n");
+        }
+
+        let ui = crate::div::div().child(text_area(&state));
+        let mut tree = crate::renderer::RenderTree::from_element(&ui);
+        tree.compute_layout(320.0, 180.0);
+
+        assert!(!tree
+            .text_elements()
+            .iter()
+            .any(|(text, _)| text.content == "Type here"));
     }
 }

--- a/crates/blinc_layout/src/widgets/text_input.rs
+++ b/crates/blinc_layout/src/widgets/text_input.rs
@@ -19,8 +19,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 
 use blinc_core::Color;
+use blinc_platform::{AccessibilityAction, AccessibilityRole, ImeCompositionUpdate};
 use blinc_theme::{ColorToken, ThemeState};
 
+use crate::accessibility::AccessibilityMetadata;
 use crate::canvas::canvas;
 use crate::css_parser::{active_stylesheet, ElementState, Stylesheet};
 use crate::div::{div, Div, ElementBuilder};
@@ -86,6 +88,48 @@ fn notify_continuous_redraw(enabled: bool) {
 
 pub fn has_focused_text_input() -> bool {
     GLOBAL_FOCUS_COUNT.load(Ordering::Relaxed) > 0
+}
+
+fn focused_text_input_is_live() -> bool {
+    let focused = match FOCUSED_TEXT_INPUT.lock() {
+        Ok(focused) => focused,
+        Err(_) => return false,
+    };
+    let weak = match focused.as_ref() {
+        Some(weak) => weak,
+        None => return false,
+    };
+    let data = match weak.upgrade() {
+        Some(data) => data,
+        None => return false,
+    };
+    data.lock()
+        .ok()
+        .map(|guard| guard.visual.is_focused())
+        .unwrap_or(false)
+}
+
+fn focused_text_area_is_live() -> bool {
+    let focused = match FOCUSED_TEXT_AREA.lock() {
+        Ok(focused) => focused,
+        Err(_) => return false,
+    };
+    let weak = match focused.as_ref() {
+        Some(weak) => weak,
+        None => return false,
+    };
+    let data = match weak.upgrade() {
+        Some(data) => data,
+        None => return false,
+    };
+    data.lock()
+        .ok()
+        .map(|guard| guard.visual.is_focused())
+        .unwrap_or(false)
+}
+
+pub fn has_live_focused_text_widget() -> bool {
+    focused_text_input_is_live() || focused_text_area_is_live()
 }
 
 pub fn take_needs_continuous_redraw() -> bool {
@@ -169,6 +213,7 @@ pub(crate) fn set_focused_text_input(state: &SharedTextInputData) {
         if let Some(prev_state) = weak.upgrade() {
             if !Arc::ptr_eq(&prev_state, state) {
                 if let Ok(mut s) = prev_state.lock() {
+                    s.composition = None;
                     if let Some(new_state) = s.visual.on_event(event_types::BLUR) {
                         s.visual = new_state;
                         decrement_focus_count();
@@ -201,6 +246,7 @@ pub(crate) fn set_focused_text_area(state: &crate::widgets::text_area::SharedTex
         if let Some(weak) = focused.take() {
             if let Some(prev_state) = weak.upgrade() {
                 if let Ok(mut s) = prev_state.lock() {
+                    s.composition = None;
                     if let Some(new_state) = s.visual.on_event(event_types::BLUR) {
                         s.visual = new_state;
                         decrement_focus_count();
@@ -216,6 +262,7 @@ pub(crate) fn set_focused_text_area(state: &crate::widgets::text_area::SharedTex
             if let Some(prev_state) = weak.upgrade() {
                 if !Arc::ptr_eq(&prev_state, state) {
                     if let Ok(mut s) = prev_state.lock() {
+                        s.composition = None;
                         if let Some(new_state) = s.visual.on_event(event_types::BLUR) {
                             s.visual = new_state;
                             decrement_focus_count();
@@ -246,6 +293,7 @@ fn blur_focused_text_area() {
     if let Some(weak) = focused.take() {
         if let Some(prev_state) = weak.upgrade() {
             if let Ok(mut s) = prev_state.lock() {
+                s.composition = None;
                 if let Some(new_state) = s.visual.on_event(event_types::BLUR) {
                     s.visual = new_state;
                     decrement_focus_count();
@@ -268,6 +316,7 @@ pub fn blur_all_text_inputs() {
             if let Some(state) = weak.upgrade() {
                 if let Ok(mut s) = state.lock() {
                     if s.visual.is_focused() {
+                        s.composition = None;
                         if let Some(new_state) = s.visual.on_event(event_types::BLUR) {
                             s.visual = new_state;
                             decrement_focus_count();
@@ -300,6 +349,7 @@ pub fn blur_all_text_inputs() {
             if let Some(state) = weak.upgrade() {
                 if let Ok(mut s) = state.lock() {
                     if s.visual.is_focused() {
+                        s.composition = None;
                         if let Some(new_state) = s.visual.on_event(event_types::BLUR) {
                             s.visual = new_state;
                             decrement_focus_count();
@@ -322,6 +372,91 @@ pub fn blur_all_text_inputs() {
                     }
                 }
             }
+        }
+    }
+}
+
+fn focused_text_input_bounds() -> Option<crate::element::ElementBounds> {
+    let focused = FOCUSED_TEXT_INPUT.lock().ok()?;
+    let weak = focused.as_ref()?;
+    let data = weak.upgrade()?;
+    let guard = data.lock().ok()?;
+    absolute_ime_bounds(
+        &guard.layout_bounds_storage,
+        &guard.ime_cursor_bounds_storage,
+    )
+}
+
+fn focused_text_area_bounds() -> Option<crate::element::ElementBounds> {
+    let focused = FOCUSED_TEXT_AREA.lock().ok()?;
+    let weak = focused.as_ref()?;
+    let data = weak.upgrade()?;
+    let guard = data.lock().ok()?;
+    absolute_ime_bounds(
+        &guard.layout_bounds_storage,
+        &guard.ime_cursor_bounds_storage,
+    )
+}
+
+fn absolute_ime_bounds(
+    widget_bounds: &crate::renderer::LayoutBoundsStorage,
+    ime_bounds: &crate::renderer::LayoutBoundsStorage,
+) -> Option<crate::element::ElementBounds> {
+    let widget = widget_bounds.lock().ok().and_then(|bounds| *bounds)?;
+    let ime = ime_bounds.lock().ok().and_then(|bounds| *bounds);
+
+    ime.map(|cursor| crate::element::ElementBounds {
+        x: widget.x + cursor.x,
+        y: widget.y + cursor.y,
+        width: cursor.width,
+        height: cursor.height,
+    })
+    .or(Some(widget))
+}
+
+pub fn focused_text_widget_ime_area() -> Option<crate::element::ElementBounds> {
+    focused_text_input_bounds().or_else(focused_text_area_bounds)
+}
+
+pub fn set_focused_text_widget_composition(composition: Option<ImeCompositionUpdate>) {
+    use crate::stateful::refresh_stateful;
+
+    if let Some(state) = FOCUSED_TEXT_INPUT
+        .lock()
+        .ok()
+        .and_then(|focused| focused.as_ref().and_then(Weak::upgrade))
+    {
+        let stateful = {
+            let mut data = match state.lock() {
+                Ok(data) => data,
+                Err(_) => return,
+            };
+            data.composition = composition.clone();
+            data.stateful_state.clone()
+        };
+
+        if let Some(ref stateful) = stateful {
+            refresh_stateful(stateful);
+        }
+        return;
+    }
+
+    if let Some(state) = FOCUSED_TEXT_AREA
+        .lock()
+        .ok()
+        .and_then(|focused| focused.as_ref().and_then(Weak::upgrade))
+    {
+        let stateful = {
+            let mut data = match state.lock() {
+                Ok(data) => data,
+                Err(_) => return,
+            };
+            data.composition = composition;
+            data.stateful_state.clone()
+        };
+
+        if let Some(ref stateful) = stateful {
+            refresh_stateful(stateful);
         }
     }
 }
@@ -421,6 +556,7 @@ pub struct TextInputData {
     pub value: String,
     pub cursor: usize,
     pub selection_start: Option<usize>,
+    pub composition: Option<ImeCompositionUpdate>,
     pub placeholder: String,
     pub input_type: InputType,
     pub constraints: InputConstraints,
@@ -439,6 +575,8 @@ pub struct TextInputData {
     /// Layout bounds storage - updated after each layout computation
     /// Used to get the actual computed width for proper scroll behavior
     pub layout_bounds_storage: crate::renderer::LayoutBoundsStorage,
+    /// Local caret rectangle used to position IME candidate windows.
+    pub ime_cursor_bounds_storage: crate::renderer::LayoutBoundsStorage,
     /// Reference to the Stateful's shared state for triggering incremental updates
     pub(crate) stateful_state: Option<SharedState<TextFieldState>>,
     /// Callback invoked when text value changes
@@ -455,6 +593,7 @@ impl std::fmt::Debug for TextInputData {
             .field("value", &self.value)
             .field("cursor", &self.cursor)
             .field("selection_start", &self.selection_start)
+            .field("composition", &self.composition)
             .field("placeholder", &self.placeholder)
             .field("input_type", &self.input_type)
             .field("constraints", &self.constraints)
@@ -480,6 +619,7 @@ impl TextInputData {
             value: String::new(),
             cursor: 0,
             selection_start: None,
+            composition: None,
             placeholder: String::new(),
             input_type: InputType::Text,
             constraints: InputConstraints::default(),
@@ -492,6 +632,7 @@ impl TextInputData {
             scroll_offset_x: 0.0,
             computed_width: None,
             layout_bounds_storage: Arc::new(Mutex::new(None)),
+            ime_cursor_bounds_storage: Arc::new(Mutex::new(None)),
             stateful_state: None,
             on_change_callback: None,
             css_element_id: None,
@@ -517,11 +658,31 @@ impl TextInputData {
     }
 
     /// Get display text (masked for password, or actual value)
-    pub fn display_text(&self) -> String {
-        if self.masked {
-            "•".repeat(self.value.chars().count())
+    pub fn value_with_composition(&self) -> String {
+        let Some(composition) = self.composition.as_ref() else {
+            return self.value.clone();
+        };
+        let (from, to) = if let Some(start) = self.selection_start {
+            if start < self.cursor {
+                (start, self.cursor)
+            } else {
+                (self.cursor, start)
+            }
         } else {
-            self.value.clone()
+            (self.cursor, self.cursor)
+        };
+
+        let before: String = self.value.chars().take(from).collect();
+        let after: String = self.value.chars().skip(to).collect();
+        before + &composition.text + &after
+    }
+
+    pub fn display_text(&self) -> String {
+        let value = self.value_with_composition();
+        if self.masked {
+            "•".repeat(value.chars().count())
+        } else {
+            value
         }
     }
 
@@ -1520,17 +1681,19 @@ impl TextInput {
         data: &TextInputData,
         config: &TextInputConfig,
     ) -> Div {
-        let display = if data.value.is_empty() {
+        let display_value = data.display_text();
+        let has_display_text = !display_value.is_empty();
+        let display = if has_display_text {
+            display_value
+        } else {
             if !data.placeholder.is_empty() {
                 data.placeholder.clone()
             } else {
                 config.placeholder.clone()
             }
-        } else {
-            data.display_text()
         };
 
-        let text_color = if data.value.is_empty() {
+        let text_color = if !has_display_text {
             config.placeholder_color
         } else if data.disabled {
             Color::rgba(0.4, 0.4, 0.4, 1.0)
@@ -1663,6 +1826,21 @@ impl TextInput {
 
         // Add text wrapper to clip container
         clip_container = clip_container.child(text_wrapper);
+
+        if let Ok(mut bounds) = data.ime_cursor_bounds_storage.lock() {
+            *bounds = if is_focused {
+                let cursor_left = (config.padding_x + cursor_x - scroll_offset).max(0.0);
+                let cursor_top = ((inner_height - cursor_height) / 2.0).max(0.0);
+                Some(crate::element::ElementBounds {
+                    x: cursor_left,
+                    y: cursor_top,
+                    width: 2.0,
+                    height: cursor_height,
+                })
+            } else {
+                None
+            };
+        }
 
         // Add cursor via canvas as a sibling to text_wrapper, also in clip_container
         // The cursor position is adjusted for scroll offset since it's not inside text_wrapper
@@ -2004,7 +2182,40 @@ impl ElementBuilder for TextInput {
             shared.base_style = self.inner.inner_layout_style();
         }
 
-        self.inner.build(tree)
+        let node_id = self.inner.build(tree);
+        let data = Arc::clone(&self.data);
+        tree.set_accessibility_provider(
+            node_id,
+            std::sync::Arc::new(move || {
+                data.lock()
+                    .ok()
+                    .map(|data| {
+                        AccessibilityMetadata::new(AccessibilityRole::TextInput)
+                            .with_name(if data.placeholder.is_empty() {
+                                data.css_element_id.clone()
+                            } else {
+                                Some(data.placeholder.clone())
+                            })
+                            .with_value(Some(data.value_with_composition()))
+                            .with_focusable(true)
+                            .with_focused(data.visual.is_focused())
+                            .with_disabled(data.disabled)
+                            .with_actions(vec![
+                                AccessibilityAction::Focus,
+                                AccessibilityAction::SetValue,
+                            ])
+                    })
+                    .unwrap_or_else(|| {
+                        AccessibilityMetadata::new(AccessibilityRole::TextInput)
+                            .with_focusable(true)
+                            .with_actions(vec![
+                                AccessibilityAction::Focus,
+                                AccessibilityAction::SetValue,
+                            ])
+                    })
+            }),
+        );
+        node_id
     }
 
     fn render_props(&self) -> RenderProps {
@@ -2096,5 +2307,23 @@ mod tests {
         data.cursor = 0;
         data.insert("abc123");
         assert_eq!(data.value, "123");
+    }
+
+    #[test]
+    fn test_text_input_display_text_uses_composition_when_empty() {
+        let mut data = TextInputData::new();
+        data.composition = Some(ImeCompositionUpdate::new("한", None));
+
+        assert_eq!(data.display_text(), "한");
+    }
+
+    #[test]
+    fn test_text_input_composition_replaces_active_selection() {
+        let mut data = TextInputData::with_value("hello");
+        data.cursor = 4;
+        data.selection_start = Some(1);
+        data.composition = Some(ImeCompositionUpdate::new("한", None));
+
+        assert_eq!(data.value_with_composition(), "h한o");
     }
 }

--- a/crates/blinc_platform/src/accessibility.rs
+++ b/crates/blinc_platform/src/accessibility.rs
@@ -1,0 +1,161 @@
+//! Shared accessibility semantics contracts.
+
+/// Stable identifier for a semantic node.
+pub type AccessibilityNodeId = u64;
+
+/// Rectangle bounds for accessibility hit-testing and focus rings.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct AccessibilityBounds {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+impl AccessibilityBounds {
+    pub fn new(x: f32, y: f32, width: f32, height: f32) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+}
+
+/// Platform-agnostic semantic roles.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AccessibilityRole {
+    Window,
+    Group,
+    Label,
+    Button,
+    Checkbox,
+    TextInput,
+    TextArea,
+    Image,
+}
+
+/// Actions that a platform accessibility bridge can invoke on a semantic node.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AccessibilityAction {
+    Focus,
+    Press,
+    Toggle,
+    SetValue,
+}
+
+/// One semantic node exported from a UI tree.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AccessibilityNode {
+    pub id: AccessibilityNodeId,
+    pub role: AccessibilityRole,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub value: Option<String>,
+    pub bounds: Option<AccessibilityBounds>,
+    pub focusable: bool,
+    pub focused: bool,
+    pub disabled: bool,
+    pub actions: Vec<AccessibilityAction>,
+    pub children: Vec<AccessibilityNodeId>,
+}
+
+impl AccessibilityNode {
+    pub fn new(id: AccessibilityNodeId, role: AccessibilityRole) -> Self {
+        Self {
+            id,
+            role,
+            name: None,
+            description: None,
+            value: None,
+            bounds: None,
+            focusable: false,
+            focused: false,
+            disabled: false,
+            actions: Vec::new(),
+            children: Vec::new(),
+        }
+    }
+
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    pub fn with_value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+
+    pub fn with_bounds(mut self, bounds: AccessibilityBounds) -> Self {
+        self.bounds = Some(bounds);
+        self
+    }
+
+    pub fn with_focusable(mut self, focusable: bool) -> Self {
+        self.focusable = focusable;
+        self
+    }
+
+    pub fn with_focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    pub fn with_disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    pub fn with_actions(mut self, actions: Vec<AccessibilityAction>) -> Self {
+        self.actions = actions;
+        self
+    }
+
+    pub fn with_children(mut self, children: Vec<AccessibilityNodeId>) -> Self {
+        self.children = children;
+        self
+    }
+}
+
+/// Snapshot of semantic nodes that a platform bridge can diff or publish.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct AccessibilityTreeSnapshot {
+    pub root_id: AccessibilityNodeId,
+    pub nodes: Vec<AccessibilityNode>,
+}
+
+impl AccessibilityTreeSnapshot {
+    pub fn new(root_id: AccessibilityNodeId, nodes: Vec<AccessibilityNode>) -> Self {
+        Self { root_id, nodes }
+    }
+}
+
+/// A platform accessibility action routed back into the app.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AccessibilityActionRequest {
+    pub target_id: AccessibilityNodeId,
+    pub action: AccessibilityAction,
+    pub value: Option<String>,
+}
+
+impl AccessibilityActionRequest {
+    pub fn new(target_id: AccessibilityNodeId, action: AccessibilityAction) -> Self {
+        Self {
+            target_id,
+            action,
+            value: None,
+        }
+    }
+
+    pub fn with_value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+}

--- a/crates/blinc_platform/src/event.rs
+++ b/crates/blinc_platform/src/event.rs
@@ -1,5 +1,6 @@
 //! Event loop and platform events
 
+use crate::accessibility::AccessibilityActionRequest;
 use crate::error::PlatformError;
 use crate::input::InputEvent;
 use crate::window::Window;
@@ -41,6 +42,8 @@ pub enum Event {
     Input(InputEvent),
     /// Application lifecycle event
     Lifecycle(LifecycleEvent),
+    /// Accessibility action invoked by a platform bridge.
+    AccessibilityAction(AccessibilityActionRequest),
     /// Frame tick - time to render
     ///
     /// This event is sent when the application should render a frame.

--- a/crates/blinc_platform/src/ime.rs
+++ b/crates/blinc_platform/src/ime.rs
@@ -1,0 +1,48 @@
+//! Shared desktop IME state.
+
+use std::sync::{Mutex, OnceLock};
+
+/// Cursor anchor area used to position candidate/popup windows.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ImeCursorArea {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+impl ImeCursorArea {
+    pub fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+}
+
+/// Requested IME state from the currently focused text control.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ImeState {
+    pub enabled: bool,
+    pub cursor_area: Option<ImeCursorArea>,
+}
+
+fn global_ime_state() -> &'static Mutex<ImeState> {
+    static STATE: OnceLock<Mutex<ImeState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(ImeState::default()))
+}
+
+pub fn current_ime_state() -> ImeState {
+    global_ime_state()
+        .lock()
+        .map(|state| *state)
+        .unwrap_or_default()
+}
+
+pub fn set_ime_state(state: ImeState) {
+    if let Ok(mut current) = global_ime_state().lock() {
+        *current = state;
+    }
+}

--- a/crates/blinc_platform/src/input.rs
+++ b/crates/blinc_platform/src/input.rs
@@ -42,6 +42,16 @@ pub enum InputEvent {
     },
     /// Scroll gesture ended (touchpad momentum finished)
     ScrollEnd,
+    /// IME composition session started.
+    CompositionStarted,
+    /// IME preview text changed.
+    CompositionUpdated(ImeCompositionUpdate),
+    /// IME composition committed user-visible text.
+    CompositionCommitted(String),
+    /// IME composition was cancelled without a commit.
+    CompositionCancelled,
+    /// Keyboard-driven focus traversal without backend-specific key leakage.
+    FocusTraversal(FocusTraversalIntent),
 }
 
 // ============================================================================
@@ -112,6 +122,42 @@ pub struct KeyboardEvent {
     pub state: KeyState,
     /// Modifier keys held during this event
     pub modifiers: Modifiers,
+}
+
+/// Platform-agnostic focus traversal direction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum FocusTraversalIntent {
+    Next,
+    Previous,
+}
+
+/// Selection range within an IME preview string.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ImeCompositionSelection {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl ImeCompositionSelection {
+    pub fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+}
+
+/// In-progress IME preview text and selection state.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ImeCompositionUpdate {
+    pub text: String,
+    pub selection: Option<ImeCompositionSelection>,
+}
+
+impl ImeCompositionUpdate {
+    pub fn new(text: impl Into<String>, selection: Option<ImeCompositionSelection>) -> Self {
+        Self {
+            text: text.into(),
+            selection,
+        }
+    }
 }
 
 /// Key press/release state

--- a/crates/blinc_platform/src/lib.rs
+++ b/crates/blinc_platform/src/lib.rs
@@ -42,8 +42,8 @@
 //! }
 //! ```
 
-pub mod assets;
 pub mod accessibility;
+pub mod assets;
 pub mod ble;
 pub mod clipboard;
 mod error;
@@ -61,18 +61,18 @@ pub use error::{PlatformError, Result};
 pub use event::{ControlFlow, Event, EventLoop, LifecycleEvent, WindowEvent};
 pub use ime::{current_ime_state, set_ime_state, ImeCursorArea, ImeState};
 pub use input::{
-    FocusTraversalIntent, ImeCompositionSelection, ImeCompositionUpdate, InputEvent, Key,
-    KeyState, KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase, TouchEvent,
+    FocusTraversalIntent, ImeCompositionSelection, ImeCompositionUpdate, InputEvent, Key, KeyState,
+    KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase, TouchEvent,
 };
 pub use platform::Platform;
 pub use window::{Cursor, Window, WindowConfig};
 
 // Re-export commonly used asset types
-pub use assets::{AssetLoader, AssetPath, FilesystemAssetLoader};
 pub use accessibility::{
     AccessibilityAction, AccessibilityActionRequest, AccessibilityBounds, AccessibilityNode,
     AccessibilityNodeId, AccessibilityRole, AccessibilityTreeSnapshot,
 };
+pub use assets::{AssetLoader, AssetPath, FilesystemAssetLoader};
 pub use ble::{
     BleBackend, BleBatchSummary, BleClient, BleProbeState, BleRuntimeController, BleScanConfig,
     BleScanResult, BleScanStatus,
@@ -87,12 +87,12 @@ pub use sensors::{
 
 /// Prelude module for convenient imports
 pub mod prelude {
-    pub use crate::assets::{
-        asset_exists, load_asset, load_asset_string, AssetLoader, AssetPath, FilesystemAssetLoader,
-    };
     pub use crate::accessibility::{
         AccessibilityAction, AccessibilityActionRequest, AccessibilityBounds, AccessibilityNode,
         AccessibilityNodeId, AccessibilityRole, AccessibilityTreeSnapshot,
+    };
+    pub use crate::assets::{
+        asset_exists, load_asset, load_asset_string, AssetLoader, AssetPath, FilesystemAssetLoader,
     };
     pub use crate::ble::{
         BleBackend, BleBatchSummary, BleClient, BleProbeState, BleRuntimeController, BleScanConfig,

--- a/crates/blinc_platform/src/lib.rs
+++ b/crates/blinc_platform/src/lib.rs
@@ -43,10 +43,12 @@
 //! ```
 
 pub mod assets;
+pub mod accessibility;
 pub mod ble;
 pub mod clipboard;
 mod error;
 mod event;
+mod ime;
 mod input;
 pub mod microphone;
 pub mod permissions;
@@ -57,15 +59,20 @@ mod window;
 // Re-export all public types
 pub use error::{PlatformError, Result};
 pub use event::{ControlFlow, Event, EventLoop, LifecycleEvent, WindowEvent};
+pub use ime::{current_ime_state, set_ime_state, ImeCursorArea, ImeState};
 pub use input::{
-    InputEvent, Key, KeyState, KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase,
-    TouchEvent,
+    FocusTraversalIntent, ImeCompositionSelection, ImeCompositionUpdate, InputEvent, Key,
+    KeyState, KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase, TouchEvent,
 };
 pub use platform::Platform;
 pub use window::{Cursor, Window, WindowConfig};
 
 // Re-export commonly used asset types
 pub use assets::{AssetLoader, AssetPath, FilesystemAssetLoader};
+pub use accessibility::{
+    AccessibilityAction, AccessibilityActionRequest, AccessibilityBounds, AccessibilityNode,
+    AccessibilityNodeId, AccessibilityRole, AccessibilityTreeSnapshot,
+};
 pub use ble::{
     BleBackend, BleBatchSummary, BleClient, BleProbeState, BleRuntimeController, BleScanConfig,
     BleScanResult, BleScanStatus,
@@ -83,15 +90,20 @@ pub mod prelude {
     pub use crate::assets::{
         asset_exists, load_asset, load_asset_string, AssetLoader, AssetPath, FilesystemAssetLoader,
     };
+    pub use crate::accessibility::{
+        AccessibilityAction, AccessibilityActionRequest, AccessibilityBounds, AccessibilityNode,
+        AccessibilityNodeId, AccessibilityRole, AccessibilityTreeSnapshot,
+    };
     pub use crate::ble::{
         BleBackend, BleBatchSummary, BleClient, BleProbeState, BleRuntimeController, BleScanConfig,
         BleScanResult, BleScanStatus,
     };
     pub use crate::error::{PlatformError, Result};
     pub use crate::event::{ControlFlow, Event, EventLoop, LifecycleEvent, WindowEvent};
+    pub use crate::ime::{current_ime_state, set_ime_state, ImeCursorArea, ImeState};
     pub use crate::input::{
-        InputEvent, Key, KeyState, KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase,
-        TouchEvent,
+        FocusTraversalIntent, ImeCompositionSelection, ImeCompositionUpdate, InputEvent, Key,
+        KeyState, KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase, TouchEvent,
     };
     pub use crate::permissions::{PermissionKind, PermissionStatus};
     pub use crate::platform::Platform;

--- a/crates/blinc_platform/tests/accessibility_api.rs
+++ b/crates/blinc_platform/tests/accessibility_api.rs
@@ -1,98 +1,72 @@
 use blinc_platform::{
-    AccessibilityAction, AccessibilityActionRequest, AccessibilityBounds, AccessibilityNode,
-    AccessibilityNodeId, AccessibilityRole, AccessibilityTreeSnapshot, CompositionEvent,
-    CompositionUpdate, Event, FocusTraversalIntent, InputEvent, SelectionRange,
+    AccessibilityAction, AccessibilityBounds, AccessibilityNode, AccessibilityRole,
+    AccessibilityTreeSnapshot, FocusTraversalIntent, InputEvent, ImeCompositionSelection,
+    ImeCompositionUpdate,
 };
 
 #[test]
-fn composition_lifecycle_events_roundtrip() {
-    let preview = CompositionUpdate {
-        text: "ga".to_string(),
-        selection: Some(SelectionRange { start: 1, end: 2 }),
-    };
+fn composition_lifecycle_events_capture_preview_and_commit_state() {
+    let preview = ImeCompositionUpdate::new("한", Some(ImeCompositionSelection::new(0, 1)));
+
     let events = vec![
-        InputEvent::Composition(CompositionEvent::Started),
-        InputEvent::Composition(CompositionEvent::Updated(preview.clone())),
-        InputEvent::Composition(CompositionEvent::Committed("각".to_string())),
-        InputEvent::Composition(CompositionEvent::Cancelled),
+        InputEvent::CompositionStarted,
+        InputEvent::CompositionUpdated(preview.clone()),
+        InputEvent::CompositionCommitted("한글".to_string()),
+        InputEvent::CompositionCancelled,
     ];
 
-    assert!(matches!(
-        &events[0],
-        InputEvent::Composition(CompositionEvent::Started)
-    ));
+    assert!(matches!(events[0], InputEvent::CompositionStarted));
     assert!(matches!(
         &events[1],
-        InputEvent::Composition(CompositionEvent::Updated(update))
-            if update.text == preview.text && update.selection == preview.selection
+        InputEvent::CompositionUpdated(update)
+            if update.text == "한"
+                && update.selection == Some(ImeCompositionSelection::new(0, 1))
     ));
     assert!(matches!(
         &events[2],
-        InputEvent::Composition(CompositionEvent::Committed(text)) if text == "각"
+        InputEvent::CompositionCommitted(text) if text == "한글"
     ));
-    assert!(matches!(
-        &events[3],
-        InputEvent::Composition(CompositionEvent::Cancelled)
-    ));
+    assert!(matches!(events[3], InputEvent::CompositionCancelled));
 }
 
 #[test]
-fn accessibility_nodes_capture_role_metadata_and_bounds() {
-    let node = AccessibilityNode {
-        id: AccessibilityNodeId(7),
-        role: AccessibilityRole::TextInput,
-        name: Some("Search".to_string()),
-        description: Some("Filter the current list".to_string()),
-        bounds: AccessibilityBounds {
-            x: 12.0,
-            y: 24.0,
-            width: 240.0,
-            height: 36.0,
-        },
-        focusable: true,
-        focused: true,
-        disabled: false,
-        value: Some("rust".to_string()),
-        children: vec![],
-    };
-    let snapshot = AccessibilityTreeSnapshot {
-        root: node.id,
-        nodes: vec![node.clone()],
-    };
+fn accessibility_snapshot_preserves_roles_metadata_and_actions() {
+    let node = AccessibilityNode::new(7, AccessibilityRole::TextInput)
+        .with_name("Search")
+        .with_description("Type a query")
+        .with_bounds(AccessibilityBounds::new(10.0, 20.0, 180.0, 36.0))
+        .with_focusable(true)
+        .with_actions(vec![AccessibilityAction::Focus, AccessibilityAction::SetValue]);
 
-    assert_eq!(snapshot.root, AccessibilityNodeId(7));
-    assert_eq!(snapshot.nodes.len(), 1);
-    assert_eq!(snapshot.nodes[0].role, AccessibilityRole::TextInput);
-    assert_eq!(snapshot.nodes[0].name.as_deref(), Some("Search"));
+    let snapshot = AccessibilityTreeSnapshot::new(7, vec![node.clone()]);
+
+    assert_eq!(snapshot.root_id, 7);
+    assert_eq!(snapshot.nodes, vec![node.clone()]);
+    assert_eq!(node.role, AccessibilityRole::TextInput);
+    assert_eq!(node.name.as_deref(), Some("Search"));
+    assert_eq!(node.description.as_deref(), Some("Type a query"));
     assert_eq!(
-        snapshot.nodes[0].description.as_deref(),
-        Some("Filter the current list")
+        node.bounds,
+        Some(AccessibilityBounds::new(10.0, 20.0, 180.0, 36.0))
     );
+    assert!(node.focusable);
     assert_eq!(
-        snapshot.nodes[0].bounds,
-        AccessibilityBounds {
-            x: 12.0,
-            y: 24.0,
-            width: 240.0,
-            height: 36.0,
-        }
+        node.actions,
+        vec![AccessibilityAction::Focus, AccessibilityAction::SetValue]
     );
-    assert!(snapshot.nodes[0].focusable);
-    assert!(snapshot.nodes[0].focused);
 }
 
 #[test]
-fn focus_traversal_intents_stay_in_shared_accessibility_events() {
-    let event = Event::AccessibilityAction(AccessibilityActionRequest {
-        target: None,
-        action: AccessibilityAction::FocusTraversal(FocusTraversalIntent::Next),
-    });
+fn focus_traversal_intents_stay_platform_agnostic() {
+    let next = InputEvent::FocusTraversal(FocusTraversalIntent::Next);
+    let previous = InputEvent::FocusTraversal(FocusTraversalIntent::Previous);
 
     assert!(matches!(
-        event,
-        Event::AccessibilityAction(AccessibilityActionRequest {
-            target: None,
-            action: AccessibilityAction::FocusTraversal(FocusTraversalIntent::Next),
-        })
+        next,
+        InputEvent::FocusTraversal(FocusTraversalIntent::Next)
+    ));
+    assert!(matches!(
+        previous,
+        InputEvent::FocusTraversal(FocusTraversalIntent::Previous)
     ));
 }

--- a/crates/blinc_platform/tests/accessibility_api.rs
+++ b/crates/blinc_platform/tests/accessibility_api.rs
@@ -1,0 +1,98 @@
+use blinc_platform::{
+    AccessibilityAction, AccessibilityActionRequest, AccessibilityBounds, AccessibilityNode,
+    AccessibilityNodeId, AccessibilityRole, AccessibilityTreeSnapshot, CompositionEvent,
+    CompositionUpdate, Event, FocusTraversalIntent, InputEvent, SelectionRange,
+};
+
+#[test]
+fn composition_lifecycle_events_roundtrip() {
+    let preview = CompositionUpdate {
+        text: "ga".to_string(),
+        selection: Some(SelectionRange { start: 1, end: 2 }),
+    };
+    let events = vec![
+        InputEvent::Composition(CompositionEvent::Started),
+        InputEvent::Composition(CompositionEvent::Updated(preview.clone())),
+        InputEvent::Composition(CompositionEvent::Committed("각".to_string())),
+        InputEvent::Composition(CompositionEvent::Cancelled),
+    ];
+
+    assert!(matches!(
+        &events[0],
+        InputEvent::Composition(CompositionEvent::Started)
+    ));
+    assert!(matches!(
+        &events[1],
+        InputEvent::Composition(CompositionEvent::Updated(update))
+            if update.text == preview.text && update.selection == preview.selection
+    ));
+    assert!(matches!(
+        &events[2],
+        InputEvent::Composition(CompositionEvent::Committed(text)) if text == "각"
+    ));
+    assert!(matches!(
+        &events[3],
+        InputEvent::Composition(CompositionEvent::Cancelled)
+    ));
+}
+
+#[test]
+fn accessibility_nodes_capture_role_metadata_and_bounds() {
+    let node = AccessibilityNode {
+        id: AccessibilityNodeId(7),
+        role: AccessibilityRole::TextInput,
+        name: Some("Search".to_string()),
+        description: Some("Filter the current list".to_string()),
+        bounds: AccessibilityBounds {
+            x: 12.0,
+            y: 24.0,
+            width: 240.0,
+            height: 36.0,
+        },
+        focusable: true,
+        focused: true,
+        disabled: false,
+        value: Some("rust".to_string()),
+        children: vec![],
+    };
+    let snapshot = AccessibilityTreeSnapshot {
+        root: node.id,
+        nodes: vec![node.clone()],
+    };
+
+    assert_eq!(snapshot.root, AccessibilityNodeId(7));
+    assert_eq!(snapshot.nodes.len(), 1);
+    assert_eq!(snapshot.nodes[0].role, AccessibilityRole::TextInput);
+    assert_eq!(snapshot.nodes[0].name.as_deref(), Some("Search"));
+    assert_eq!(
+        snapshot.nodes[0].description.as_deref(),
+        Some("Filter the current list")
+    );
+    assert_eq!(
+        snapshot.nodes[0].bounds,
+        AccessibilityBounds {
+            x: 12.0,
+            y: 24.0,
+            width: 240.0,
+            height: 36.0,
+        }
+    );
+    assert!(snapshot.nodes[0].focusable);
+    assert!(snapshot.nodes[0].focused);
+}
+
+#[test]
+fn focus_traversal_intents_stay_in_shared_accessibility_events() {
+    let event = Event::AccessibilityAction(AccessibilityActionRequest {
+        target: None,
+        action: AccessibilityAction::FocusTraversal(FocusTraversalIntent::Next),
+    });
+
+    assert!(matches!(
+        event,
+        Event::AccessibilityAction(AccessibilityActionRequest {
+            target: None,
+            action: AccessibilityAction::FocusTraversal(FocusTraversalIntent::Next),
+        })
+    ));
+}

--- a/crates/blinc_platform/tests/accessibility_api.rs
+++ b/crates/blinc_platform/tests/accessibility_api.rs
@@ -1,7 +1,7 @@
 use blinc_platform::{
     AccessibilityAction, AccessibilityBounds, AccessibilityNode, AccessibilityRole,
-    AccessibilityTreeSnapshot, FocusTraversalIntent, InputEvent, ImeCompositionSelection,
-    ImeCompositionUpdate,
+    AccessibilityTreeSnapshot, FocusTraversalIntent, ImeCompositionSelection, ImeCompositionUpdate,
+    InputEvent,
 };
 
 #[test]
@@ -36,7 +36,10 @@ fn accessibility_snapshot_preserves_roles_metadata_and_actions() {
         .with_description("Type a query")
         .with_bounds(AccessibilityBounds::new(10.0, 20.0, 180.0, 36.0))
         .with_focusable(true)
-        .with_actions(vec![AccessibilityAction::Focus, AccessibilityAction::SetValue]);
+        .with_actions(vec![
+            AccessibilityAction::Focus,
+            AccessibilityAction::SetValue,
+        ]);
 
     let snapshot = AccessibilityTreeSnapshot::new(7, vec![node.clone()]);
 

--- a/extensions/blinc_platform_desktop/src/accessibility.rs
+++ b/extensions/blinc_platform_desktop/src/accessibility.rs
@@ -1,0 +1,37 @@
+//! Desktop accessibility boundary.
+
+use std::sync::{Mutex, OnceLock};
+
+use blinc_platform::AccessibilityTreeSnapshot;
+
+fn snapshot_store() -> &'static Mutex<Option<AccessibilityTreeSnapshot>> {
+    static STORE: OnceLock<Mutex<Option<AccessibilityTreeSnapshot>>> = OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(None))
+}
+
+pub fn update_accessibility_snapshot(snapshot: AccessibilityTreeSnapshot) {
+    if let Ok(mut current) = snapshot_store().lock() {
+        *current = Some(snapshot);
+    }
+}
+
+pub fn current_accessibility_snapshot() -> Option<AccessibilityTreeSnapshot> {
+    snapshot_store()
+        .lock()
+        .map(|snapshot| snapshot.clone())
+        .unwrap_or(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{current_accessibility_snapshot, update_accessibility_snapshot};
+    use blinc_platform::{AccessibilityNode, AccessibilityRole, AccessibilityTreeSnapshot};
+
+    #[test]
+    fn snapshot_store_roundtrips_latest_value() {
+        let snapshot =
+            AccessibilityTreeSnapshot::new(1, vec![AccessibilityNode::new(1, AccessibilityRole::Window)]);
+        update_accessibility_snapshot(snapshot.clone());
+        assert_eq!(current_accessibility_snapshot(), Some(snapshot));
+    }
+}

--- a/extensions/blinc_platform_desktop/src/accessibility.rs
+++ b/extensions/blinc_platform_desktop/src/accessibility.rs
@@ -29,8 +29,10 @@ mod tests {
 
     #[test]
     fn snapshot_store_roundtrips_latest_value() {
-        let snapshot =
-            AccessibilityTreeSnapshot::new(1, vec![AccessibilityNode::new(1, AccessibilityRole::Window)]);
+        let snapshot = AccessibilityTreeSnapshot::new(
+            1,
+            vec![AccessibilityNode::new(1, AccessibilityRole::Window)],
+        );
         update_accessibility_snapshot(snapshot.clone());
         assert_eq!(current_accessibility_snapshot(), Some(snapshot));
     }

--- a/extensions/blinc_platform_desktop/src/event_loop.rs
+++ b/extensions/blinc_platform_desktop/src/event_loop.rs
@@ -57,14 +57,26 @@ impl DesktopImeWindow for DesktopWindow {
     }
 }
 
-fn sync_ime_window_state<W: DesktopImeWindow>(window: &W, applied: &mut ImeState, requested: ImeState) {
+fn sync_ime_window_state<W: DesktopImeWindow>(
+    window: &W,
+    applied: &mut ImeState,
+    requested: ImeState,
+) {
+    if !requested.enabled && applied.cursor_area.is_some() {
+        window.set_ime_cursor_area(ImeCursorArea::new(0.0, 0.0, 0.0, 0.0));
+    }
+
     if applied.enabled != requested.enabled {
         window.set_ime_allowed(requested.enabled);
     }
 
     if requested.enabled && applied.cursor_area != requested.cursor_area {
-        if let Some(area) = requested.cursor_area {
-            window.set_ime_cursor_area(area);
+        match requested.cursor_area {
+            Some(area) => window.set_ime_cursor_area(area),
+            None if applied.cursor_area.is_some() => {
+                window.set_ime_cursor_area(ImeCursorArea::new(0.0, 0.0, 0.0, 0.0));
+            }
+            None => {}
         }
     }
 
@@ -209,7 +221,11 @@ where
         if self.window.is_none() {
             match DesktopWindow::new(event_loop, &self.window_config) {
                 Ok(window) => {
-                    sync_ime_window_state(&window, &mut self.applied_ime_state, current_ime_state());
+                    sync_ime_window_state(
+                        &window,
+                        &mut self.applied_ime_state,
+                        current_ime_state(),
+                    );
                     self.window = Some(window);
                     self.handle_event(Event::Lifecycle(LifecycleEvent::Resumed));
                 }
@@ -489,5 +505,81 @@ mod tests {
             vec![ImeCursorArea::new(12.0, 24.0, 80.0, 30.0)]
         );
         assert_eq!(applied, requested);
+    }
+
+    #[test]
+    fn sync_ime_window_state_clears_stale_cursor_area_when_requested_area_is_missing() {
+        let window = TestImeWindow::default();
+        let mut applied = ImeState {
+            enabled: true,
+            cursor_area: Some(ImeCursorArea::new(12.0, 24.0, 80.0, 30.0)),
+        };
+
+        sync_ime_window_state(
+            &window,
+            &mut applied,
+            ImeState {
+                enabled: true,
+                cursor_area: None,
+            },
+        );
+
+        assert_eq!(
+            *window.allowed.lock().expect("allowed lock"),
+            Vec::<bool>::new()
+        );
+        assert_eq!(
+            *window.cursor_areas.lock().expect("cursor area lock"),
+            vec![ImeCursorArea::new(0.0, 0.0, 0.0, 0.0)]
+        );
+        assert_eq!(
+            applied,
+            ImeState {
+                enabled: true,
+                cursor_area: None,
+            }
+        );
+    }
+
+    #[test]
+    fn sync_ime_window_state_clears_cursor_area_before_reenabling_without_bounds() {
+        let window = TestImeWindow::default();
+        let mut applied = ImeState {
+            enabled: true,
+            cursor_area: Some(ImeCursorArea::new(12.0, 24.0, 80.0, 30.0)),
+        };
+
+        sync_ime_window_state(
+            &window,
+            &mut applied,
+            ImeState {
+                enabled: false,
+                cursor_area: None,
+            },
+        );
+        sync_ime_window_state(
+            &window,
+            &mut applied,
+            ImeState {
+                enabled: true,
+                cursor_area: None,
+            },
+        );
+
+        assert_eq!(
+            *window.allowed.lock().expect("allowed lock"),
+            vec![false, true]
+        );
+        assert_eq!(
+            *window.cursor_areas.lock().expect("cursor area lock"),
+            vec![ImeCursorArea::new(0.0, 0.0, 0.0, 0.0)]
+        );
+        assert_eq!(
+            applied,
+            ImeState {
+                enabled: true,
+                cursor_area: None,
+            }
+        );
     }
 }

--- a/extensions/blinc_platform_desktop/src/event_loop.rs
+++ b/extensions/blinc_platform_desktop/src/event_loop.rs
@@ -5,9 +5,11 @@ use std::time::{Duration, Instant};
 use crate::input;
 use crate::window::DesktopWindow;
 use blinc_platform::{
-    ControlFlow, Event, EventLoop, LifecycleEvent, PlatformError, Window, WindowConfig, WindowEvent,
+    current_ime_state, ControlFlow, Event, EventLoop, ImeCursorArea, ImeState, LifecycleEvent,
+    PlatformError, Window, WindowConfig, WindowEvent,
 };
 use winit::application::ApplicationHandler;
+use winit::dpi::{LogicalPosition, LogicalSize};
 use winit::event::{StartCause, WindowEvent as WinitWindowEvent};
 use winit::event_loop::{
     ActiveEventLoop, ControlFlow as WinitControlFlow, EventLoop as WinitEventLoop, EventLoopProxy,
@@ -35,6 +37,38 @@ fn scroll_end_deadline(
         return None;
     }
     last_scroll_event_at.map(|last| last + SCROLL_END_DEBOUNCE)
+}
+
+trait DesktopImeWindow {
+    fn set_ime_allowed(&self, allowed: bool);
+    fn set_ime_cursor_area(&self, area: ImeCursorArea);
+}
+
+impl DesktopImeWindow for DesktopWindow {
+    fn set_ime_allowed(&self, allowed: bool) {
+        self.winit_window().set_ime_allowed(allowed);
+    }
+
+    fn set_ime_cursor_area(&self, area: ImeCursorArea) {
+        self.winit_window().set_ime_cursor_area(
+            LogicalPosition::new(area.x, area.y),
+            LogicalSize::new(area.width, area.height),
+        );
+    }
+}
+
+fn sync_ime_window_state<W: DesktopImeWindow>(window: &W, applied: &mut ImeState, requested: ImeState) {
+    if applied.enabled != requested.enabled {
+        window.set_ime_allowed(requested.enabled);
+    }
+
+    if requested.enabled && applied.cursor_area != requested.cursor_area {
+        if let Some(area) = requested.cursor_area {
+            window.set_ime_cursor_area(area);
+        }
+    }
+
+    *applied = requested;
 }
 
 /// Proxy for waking up the event loop from another thread
@@ -126,6 +160,7 @@ where
     mouse_position: (f32, f32),
     last_scroll_event_at: Option<Instant>,
     scroll_end_pending: bool,
+    applied_ime_state: ImeState,
     should_exit: bool,
 }
 
@@ -142,6 +177,7 @@ where
             mouse_position: (0.0, 0.0),
             last_scroll_event_at: None,
             scroll_end_pending: false,
+            applied_ime_state: ImeState::default(),
             should_exit: false,
         }
     }
@@ -152,6 +188,9 @@ where
             if flow == ControlFlow::Exit {
                 self.should_exit = true;
             }
+        }
+        if let Some(ref window) = self.window {
+            sync_ime_window_state(window, &mut self.applied_ime_state, current_ime_state());
         }
     }
 
@@ -170,6 +209,7 @@ where
         if self.window.is_none() {
             match DesktopWindow::new(event_loop, &self.window_config) {
                 Ok(window) => {
+                    sync_ime_window_state(&window, &mut self.applied_ime_state, current_ime_state());
                     self.window = Some(window);
                     self.handle_event(Event::Lifecycle(LifecycleEvent::Resumed));
                 }
@@ -248,6 +288,15 @@ where
                     input::convert_keyboard_event(&event.logical_key, event.state, self.modifiers);
                 self.handle_event(Event::Input(input_event));
                 // Request immediate redraw so text input changes render instantly
+                if let Some(ref window) = self.window {
+                    window.request_redraw();
+                }
+            }
+
+            WinitWindowEvent::Ime(ime) => {
+                if let Some(input_event) = input::convert_ime_event(&ime) {
+                    self.handle_event(Event::Input(input_event));
+                }
                 if let Some(ref window) = self.window {
                     window.request_redraw();
                 }
@@ -364,8 +413,32 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{scroll_end_deadline, should_emit_synthetic_scroll_end, SCROLL_END_DEBOUNCE};
+    use super::{
+        scroll_end_deadline, should_emit_synthetic_scroll_end, sync_ime_window_state,
+        DesktopImeWindow, SCROLL_END_DEBOUNCE,
+    };
+    use blinc_platform::{ImeCursorArea, ImeState};
+    use std::sync::Mutex;
     use std::time::{Duration, Instant};
+
+    #[derive(Default)]
+    struct TestImeWindow {
+        allowed: Mutex<Vec<bool>>,
+        cursor_areas: Mutex<Vec<ImeCursorArea>>,
+    }
+
+    impl DesktopImeWindow for TestImeWindow {
+        fn set_ime_allowed(&self, allowed: bool) {
+            self.allowed.lock().expect("allowed lock").push(allowed);
+        }
+
+        fn set_ime_cursor_area(&self, area: ImeCursorArea) {
+            self.cursor_areas
+                .lock()
+                .expect("cursor area lock")
+                .push(area);
+        }
+    }
 
     #[test]
     fn synthetic_scroll_end_requires_pending_and_elapsed_threshold() {
@@ -397,5 +470,24 @@ mod tests {
             scroll_end_deadline(true, Some(now)),
             Some(now + SCROLL_END_DEBOUNCE)
         );
+    }
+
+    #[test]
+    fn sync_ime_window_state_updates_allowed_and_cursor_area() {
+        let window = TestImeWindow::default();
+        let mut applied = ImeState::default();
+        let requested = ImeState {
+            enabled: true,
+            cursor_area: Some(ImeCursorArea::new(12.0, 24.0, 80.0, 30.0)),
+        };
+
+        sync_ime_window_state(&window, &mut applied, requested);
+
+        assert_eq!(*window.allowed.lock().expect("allowed lock"), vec![true]);
+        assert_eq!(
+            *window.cursor_areas.lock().expect("cursor area lock"),
+            vec![ImeCursorArea::new(12.0, 24.0, 80.0, 30.0)]
+        );
+        assert_eq!(applied, requested);
     }
 }

--- a/extensions/blinc_platform_desktop/src/input.rs
+++ b/extensions/blinc_platform_desktop/src/input.rs
@@ -1,10 +1,12 @@
 //! Desktop input conversion (winit -> blinc_platform)
 
 use blinc_platform::{
-    FocusTraversalIntent, ImeCompositionSelection, ImeCompositionUpdate, InputEvent, Key,
-    KeyState, KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase, TouchEvent,
+    FocusTraversalIntent, ImeCompositionSelection, ImeCompositionUpdate, InputEvent, Key, KeyState,
+    KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase, TouchEvent,
 };
-use winit::event::{ElementState, Ime as WinitIme, MouseButton as WinitMouseButton, Touch, TouchPhase};
+use winit::event::{
+    ElementState, Ime as WinitIme, MouseButton as WinitMouseButton, Touch, TouchPhase,
+};
 use winit::keyboard::{Key as WinitKey, ModifiersState, NamedKey};
 
 /// Convert winit mouse button to blinc MouseButton
@@ -145,7 +147,12 @@ pub fn convert_keyboard_event(
     state: ElementState,
     modifiers: ModifiersState,
 ) -> InputEvent {
-    if state == ElementState::Pressed && matches!(key, WinitKey::Named(NamedKey::Tab)) {
+    let is_shortcut_tab = modifiers.control_key() || modifiers.alt_key() || modifiers.super_key();
+
+    if state == ElementState::Pressed
+        && !is_shortcut_tab
+        && matches!(key, WinitKey::Named(NamedKey::Tab))
+    {
         let intent = if modifiers.shift_key() {
             FocusTraversalIntent::Previous
         } else {
@@ -166,14 +173,10 @@ pub fn convert_ime_event(event: &WinitIme) -> Option<InputEvent> {
     match event {
         WinitIme::Enabled => Some(InputEvent::CompositionStarted),
         WinitIme::Preedit(text, cursor) => {
-            if text.is_empty() {
-                Some(InputEvent::CompositionCancelled)
-            } else {
-                Some(InputEvent::CompositionUpdated(ImeCompositionUpdate::new(
-                    text.clone(),
-                    cursor.map(|(start, end)| ImeCompositionSelection::new(start, end)),
-                )))
-            }
+            Some(InputEvent::CompositionUpdated(ImeCompositionUpdate::new(
+                text.clone(),
+                cursor.map(|(start, end)| ImeCompositionSelection::new(start, end)),
+            )))
         }
         WinitIme::Commit(text) => {
             if text.is_empty() {

--- a/extensions/blinc_platform_desktop/src/input.rs
+++ b/extensions/blinc_platform_desktop/src/input.rs
@@ -1,10 +1,10 @@
 //! Desktop input conversion (winit -> blinc_platform)
 
 use blinc_platform::{
-    InputEvent, Key, KeyState, KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase,
-    TouchEvent,
+    FocusTraversalIntent, ImeCompositionSelection, ImeCompositionUpdate, InputEvent, Key,
+    KeyState, KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase, TouchEvent,
 };
-use winit::event::{ElementState, MouseButton as WinitMouseButton, Touch, TouchPhase};
+use winit::event::{ElementState, Ime as WinitIme, MouseButton as WinitMouseButton, Touch, TouchPhase};
 use winit::keyboard::{Key as WinitKey, ModifiersState, NamedKey};
 
 /// Convert winit mouse button to blinc MouseButton
@@ -145,11 +145,45 @@ pub fn convert_keyboard_event(
     state: ElementState,
     modifiers: ModifiersState,
 ) -> InputEvent {
+    if state == ElementState::Pressed && matches!(key, WinitKey::Named(NamedKey::Tab)) {
+        let intent = if modifiers.shift_key() {
+            FocusTraversalIntent::Previous
+        } else {
+            FocusTraversalIntent::Next
+        };
+        return InputEvent::FocusTraversal(intent);
+    }
+
     InputEvent::Keyboard(KeyboardEvent {
         key: convert_key(key),
         state: convert_key_state(state),
         modifiers: convert_modifiers(modifiers),
     })
+}
+
+/// Convert winit IME event to blinc InputEvent.
+pub fn convert_ime_event(event: &WinitIme) -> Option<InputEvent> {
+    match event {
+        WinitIme::Enabled => Some(InputEvent::CompositionStarted),
+        WinitIme::Preedit(text, cursor) => {
+            if text.is_empty() {
+                Some(InputEvent::CompositionCancelled)
+            } else {
+                Some(InputEvent::CompositionUpdated(ImeCompositionUpdate::new(
+                    text.clone(),
+                    cursor.map(|(start, end)| ImeCompositionSelection::new(start, end)),
+                )))
+            }
+        }
+        WinitIme::Commit(text) => {
+            if text.is_empty() {
+                None
+            } else {
+                Some(InputEvent::CompositionCommitted(text.clone()))
+            }
+        }
+        WinitIme::Disabled => Some(InputEvent::CompositionCancelled),
+    }
 }
 
 /// Convert winit touch event to blinc InputEvent

--- a/extensions/blinc_platform_desktop/src/lib.rs
+++ b/extensions/blinc_platform_desktop/src/lib.rs
@@ -30,10 +30,12 @@
 //! }
 //! ```
 
+pub mod accessibility;
 pub mod event_loop;
 pub mod input;
 pub mod window;
 
+pub use accessibility::{current_accessibility_snapshot, update_accessibility_snapshot};
 pub use event_loop::{DesktopEventLoop, WakeProxy};
 pub use window::DesktopWindow;
 

--- a/extensions/blinc_platform_desktop/tests/ime_runtime.rs
+++ b/extensions/blinc_platform_desktop/tests/ime_runtime.rs
@@ -1,9 +1,9 @@
 mod support;
 
-use blinc_platform::{InputEvent, Key, KeyState};
+use blinc_platform::{FocusTraversalIntent, InputEvent, Key, KeyState};
 use blinc_platform_desktop::input;
 use winit::event::{ElementState, Ime};
-use winit::keyboard::{Key as WinitKey, ModifiersState};
+use winit::keyboard::{Key as WinitKey, ModifiersState, NamedKey};
 
 #[test]
 fn ime_notifications_convert_to_shared_composition_events() {
@@ -45,4 +45,69 @@ fn plain_keypresses_still_convert_when_composition_is_inactive() {
         }
         other => panic!("expected keyboard input, got {other:?}"),
     }
+}
+
+#[test]
+fn tab_focus_traversal_only_applies_without_shortcut_modifiers() {
+    let plain_tab = input::convert_keyboard_event(
+        &WinitKey::Named(NamedKey::Tab),
+        ElementState::Pressed,
+        ModifiersState::empty(),
+    );
+    let shift_tab = input::convert_keyboard_event(
+        &WinitKey::Named(NamedKey::Tab),
+        ElementState::Pressed,
+        ModifiersState::SHIFT,
+    );
+
+    assert!(matches!(
+        plain_tab,
+        InputEvent::FocusTraversal(FocusTraversalIntent::Next)
+    ));
+    assert!(matches!(
+        shift_tab,
+        InputEvent::FocusTraversal(FocusTraversalIntent::Previous)
+    ));
+
+    for modifiers in [
+        ModifiersState::CONTROL,
+        ModifiersState::ALT,
+        ModifiersState::SUPER,
+        ModifiersState::CONTROL.union(ModifiersState::SHIFT),
+    ] {
+        let event = input::convert_keyboard_event(
+            &WinitKey::Named(NamedKey::Tab),
+            ElementState::Pressed,
+            modifiers,
+        );
+
+        match event {
+            InputEvent::Keyboard(keyboard) => {
+                assert_eq!(keyboard.key, Key::Tab);
+                assert_eq!(keyboard.state, KeyState::Pressed);
+                assert_eq!(keyboard.modifiers.shift, modifiers.shift_key());
+                assert_eq!(keyboard.modifiers.ctrl, modifiers.control_key());
+                assert_eq!(keyboard.modifiers.alt, modifiers.alt_key());
+                assert_eq!(keyboard.modifiers.meta, modifiers.super_key());
+            }
+            other => panic!("expected keyboard input for modified tab, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn empty_preedit_clear_after_commit_does_not_emit_cancellation() {
+    let committed =
+        input::convert_ime_event(&Ime::Commit("한글".into())).expect("commit composition event");
+    let clear = input::convert_ime_event(&Ime::Preedit(String::new(), None));
+
+    assert!(matches!(
+        committed,
+        InputEvent::CompositionCommitted(text) if text == "한글"
+    ));
+    assert!(matches!(
+        clear,
+        Some(InputEvent::CompositionUpdated(update))
+            if update.text.is_empty() && update.selection.is_none()
+    ));
 }

--- a/extensions/blinc_platform_desktop/tests/ime_runtime.rs
+++ b/extensions/blinc_platform_desktop/tests/ime_runtime.rs
@@ -1,0 +1,48 @@
+mod support;
+
+use blinc_platform::{InputEvent, Key, KeyState};
+use blinc_platform_desktop::input;
+use winit::event::{ElementState, Ime};
+use winit::keyboard::{Key as WinitKey, ModifiersState};
+
+#[test]
+fn ime_notifications_convert_to_shared_composition_events() {
+    let _display_available = support::requires_display();
+
+    let enabled = input::convert_ime_event(&Ime::Enabled).expect("enabled composition event");
+    let preview = input::convert_ime_event(&Ime::Preedit("한".into(), Some((0, 1))))
+        .expect("preedit composition event");
+    let committed =
+        input::convert_ime_event(&Ime::Commit("한글".into())).expect("commit composition event");
+    let disabled = input::convert_ime_event(&Ime::Disabled).expect("disabled composition event");
+
+    assert!(matches!(enabled, InputEvent::CompositionStarted));
+    assert!(matches!(
+        preview,
+        InputEvent::CompositionUpdated(update)
+            if update.text == "한"
+                && update.selection == Some(blinc_platform::ImeCompositionSelection::new(0, 1))
+    ));
+    assert!(matches!(
+        committed,
+        InputEvent::CompositionCommitted(text) if text == "한글"
+    ));
+    assert!(matches!(disabled, InputEvent::CompositionCancelled));
+}
+
+#[test]
+fn plain_keypresses_still_convert_when_composition_is_inactive() {
+    let event = input::convert_keyboard_event(
+        &WinitKey::Character("a".into()),
+        ElementState::Pressed,
+        ModifiersState::empty(),
+    );
+
+    match event {
+        InputEvent::Keyboard(keyboard) => {
+            assert_eq!(keyboard.key, Key::A);
+            assert_eq!(keyboard.state, KeyState::Pressed);
+        }
+        other => panic!("expected keyboard input, got {other:?}"),
+    }
+}

--- a/extensions/blinc_platform_desktop/tests/support.rs
+++ b/extensions/blinc_platform_desktop/tests/support.rs
@@ -1,0 +1,11 @@
+pub fn requires_display() -> bool {
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    {
+        std::env::var_os("DISPLAY").is_some() || std::env::var_os("WAYLAND_DISPLAY").is_some()
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+    {
+        true
+    }
+}


### PR DESCRIPTION
## Summary
- harden desktop accessibility export with composition-aware text values, inferred button names, control actions, and preserved wrapper groups
- keep IME/accessibility bounds in sync across scroll, transforms, fixed and sticky positioning, and scroll-only frames without relayout
- preserve multiline IME commit whitespace for text areas and add focused regression coverage for desktop accessibility semantics and IME cursor anchoring

## Test Plan
- [x] `cargo fmt --all`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p blinc_layout accessibility_semantics -- --nocapture`
- [x] `cargo test -p blinc_layout -- --nocapture`
- [x] `cargo check -p blinc_app --features windowed`
- [x] `cargo check -p blinc_app --target aarch64-apple-ios`
- [x] `cargo check -p blinc_app --target aarch64-apple-ios-sim`
- [x] `cargo test -p blinc_app --features windowed --lib -- --nocapture`
- [x] `cargo test -p blinc_app --features windowed --tests -- --nocapture`

## Notes
- `cargo test -p blinc_app --features windowed -- --nocapture` still trips existing example-target linker issues on this macOS arm64 environment, so app verification was split into `--lib` and `--tests`.
- Fresh review requests were sent to Gemini CLI, Qwen, and subagents. Gemini CLI hit a Node heap OOM on the full diff; Qwen produced one actionable multiline-whitespace note that is included here; a fresh subagent pass reported no actionable issue.
