### PR TITLE
Implement updater release pipeline and runtime backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/blinc_tabler_icons",
     "crates/blinc_debugger",
     "crates/blinc_runtime",
+    "crates/blinc_update",
     "crates/blinc_canvas_kit",
     "crates/blinc_test_suite",
     "extensions/blinc_platform_desktop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "extensions/blinc_platform_ios",
     "extensions/blinc_platform_harmony",
     "extensions/blinc_update_android",
+    "extensions/blinc_update_desktop",
 ]
 
 # Platform-specific crates are included but have target-gated dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "extensions/blinc_platform_android",
     "extensions/blinc_platform_ios",
     "extensions/blinc_platform_harmony",
+    "extensions/blinc_update_android",
 ]
 
 # Platform-specific crates are included but have target-gated dependencies

--- a/crates/blinc_cli/Cargo.toml
+++ b/crates/blinc_cli/Cargo.toml
@@ -40,3 +40,5 @@ tracing-subscriber.workspace = true
 
 # System paths
 dirs = "5.0"
+base64 = "0.22"
+time = { version = "0.3", features = ["parsing"] }

--- a/crates/blinc_cli/Cargo.toml
+++ b/crates/blinc_cli/Cargo.toml
@@ -41,4 +41,6 @@ tracing-subscriber.workspace = true
 # System paths
 dirs = "5.0"
 base64 = "0.22"
+ed25519-dalek = "2.1"
+sha2 = "0.10"
 time = { version = "0.3", features = ["parsing"] }

--- a/crates/blinc_cli/Cargo.toml
+++ b/crates/blinc_cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 blinc_core = { path = "../blinc_core", version = "0.1.14" }
 blinc_animation = { path = "../blinc_animation", version = "0.1.14" }
+blinc_update = { path = "../blinc_update", version = "0.1.14" }
 
 # CLI
 clap.workspace = true
@@ -43,4 +44,4 @@ dirs = "5.0"
 base64 = "0.22"
 ed25519-dalek = "2.1"
 sha2 = "0.10"
-time = { version = "0.3", features = ["parsing"] }
+time = { version = "0.3", features = ["formatting", "parsing"] }

--- a/crates/blinc_cli/README.md
+++ b/crates/blinc_cli/README.md
@@ -87,6 +87,30 @@ Checking Blinc development environment...
 Environment is ready for Blinc development!
 ```
 
+### Release
+
+Generate signed release metadata for the current macOS desktop path and Android artifacts:
+
+```bash
+blinc release manifest . \
+  --platform macos \
+  --arch universal \
+  --artifact-path dist/Demo.zip \
+  --private-key "$BLINC_RELEASE_PRIVATE_KEY" \
+  --public-key-output dist/public-key.txt \
+  --url https://example.com/releases/Demo.zip \
+  --output dist/release-manifest.json \
+  --published-at 2026-03-07T00:00:00Z
+```
+
+Updater scope in v1:
+- macOS desktop self-update reference path
+- Windows/Linux desktop updater backends stay planned and explicitly unsupported in v1
+- Android private/development distribution handoff
+- iOS stays on App Store/TestFlight distribution
+
+Reuse the same `--published-at` value when appending multiple artifacts into one release manifest.
+
 ## Configuration
 
 Create a `Blinc.toml` in your project root:

--- a/crates/blinc_cli/src/config.rs
+++ b/crates/blinc_cli/src/config.rs
@@ -21,6 +21,8 @@ pub struct BlincProject {
     pub dependencies: DependenciesConfig,
     #[serde(default)]
     pub platforms: PlatformsConfig,
+    #[serde(default, skip_serializing_if = "UpdatesConfig::is_empty")]
+    pub updates: UpdatesConfig,
 }
 
 /// Project metadata
@@ -84,6 +86,108 @@ pub struct PlatformsConfig {
     pub linux: Option<LinuxPlatformConfig>,
     #[serde(default)]
     pub wasm: Option<WasmPlatformConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(try_from = "RawUpdatesConfig")]
+pub struct UpdatesConfig {
+    pub enabled: bool,
+    pub channel: ReleaseChannel,
+    pub manifest_url: Option<String>,
+    pub public_key: Option<String>,
+    pub desktop: Option<DesktopUpdateConfig>,
+    pub android: Option<AndroidUpdateConfig>,
+}
+
+impl UpdatesConfig {
+    fn is_empty(&self) -> bool {
+        !self.enabled
+            && self.channel == ReleaseChannel::default()
+            && self.manifest_url.is_none()
+            && self.public_key.is_none()
+            && self.desktop.is_none()
+            && self.android.is_none()
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawUpdatesConfig {
+    #[serde(default)]
+    enabled: bool,
+    #[serde(default)]
+    channel: ReleaseChannel,
+    #[serde(default)]
+    manifest_url: Option<String>,
+    #[serde(default)]
+    public_key: Option<String>,
+    #[serde(default)]
+    desktop: Option<DesktopUpdateConfig>,
+    #[serde(default)]
+    android: Option<AndroidUpdateConfig>,
+}
+
+impl TryFrom<RawUpdatesConfig> for UpdatesConfig {
+    type Error = String;
+
+    fn try_from(raw: RawUpdatesConfig) -> std::result::Result<Self, Self::Error> {
+        let has_manifest_url = raw
+            .manifest_url
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty());
+        let has_public_key = raw
+            .public_key
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty());
+
+        if raw.enabled && (!has_manifest_url || !has_public_key) {
+            return Err(
+                "updates.manifest_url and public_key are required when updates.enabled is true"
+                    .to_string(),
+            );
+        }
+
+        Ok(Self {
+            enabled: raw.enabled,
+            channel: raw.channel,
+            manifest_url: raw.manifest_url,
+            public_key: raw.public_key,
+            desktop: raw.desktop,
+            android: raw.android,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReleaseChannel {
+    #[default]
+    Stable,
+    Beta,
+    Canary,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct DesktopUpdateConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub restart_strategy: RestartStrategy,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RestartStrategy {
+    #[default]
+    Prompt,
+    Automatic,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct AndroidUpdateConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub allow_unknown_sources_prompt: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -233,6 +337,7 @@ impl BlincProject {
             },
             dependencies: DependenciesConfig::default(),
             platforms: PlatformsConfig::default(),
+            updates: UpdatesConfig::default(),
         }
     }
 
@@ -493,5 +598,184 @@ impl BlincConfig {
     #[allow(dead_code)]
     pub fn to_toml(&self) -> Result<String> {
         toml::to_string_pretty(self).context("Failed to serialize config")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn updater_config_round_trips_without_identity_overrides() {
+        let config: BlincProject = toml::from_str(
+            r#"
+                [project]
+                name = "Demo"
+                version = "0.1.0"
+
+                [platforms.android]
+                package = "io.test.demo"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/manifest.json"
+                public_key = "abc"
+
+                [updates.desktop]
+                enabled = true
+
+                [updates.android]
+                enabled = true
+                allow_unknown_sources_prompt = true
+            "#,
+        )
+        .expect("updater config should parse");
+
+        assert!(config.updates.enabled, "updates should be enabled");
+        assert_eq!(
+            config.updates.channel,
+            ReleaseChannel::Stable,
+            "channel should parse as stable"
+        );
+        assert_eq!(
+            config.updates.manifest_url.as_deref(),
+            Some("https://example.com/manifest.json"),
+            "manifest_url should round-trip through parsing"
+        );
+        assert_eq!(
+            config.updates.public_key.as_deref(),
+            Some("abc"),
+            "public_key should round-trip through parsing"
+        );
+        assert_eq!(
+            config
+                .platforms
+                .android
+                .as_ref()
+                .map(|android| android.package.as_str()),
+            Some("io.test.demo"),
+            "android package should remain canonical platform identity"
+        );
+        assert_eq!(
+            config
+                .platforms
+                .macos
+                .as_ref()
+                .map(|macos| macos.bundle_id.as_str()),
+            Some("io.test.demo"),
+            "macos bundle_id should remain canonical platform identity"
+        );
+        assert!(
+            config
+                .updates
+                .desktop
+                .as_ref()
+                .is_some_and(|desktop| desktop.enabled),
+            "desktop updater override should parse"
+        );
+        assert!(
+            config
+                .updates
+                .android
+                .as_ref()
+                .is_some_and(|android| android.allow_unknown_sources_prompt),
+            "android updater override should parse"
+        );
+
+        let serialized = config
+            .to_toml()
+            .expect("updater config should serialize back to TOML");
+        assert!(
+            !serialized.contains("expected_package"),
+            "updater config should not introduce updater-owned identity fields"
+        );
+
+        let reparsed: BlincProject =
+            toml::from_str(&serialized).expect("serialized updater config should parse again");
+        assert_eq!(
+            reparsed.updates.channel,
+            ReleaseChannel::Stable,
+            "channel should survive a full round-trip"
+        );
+        assert_eq!(
+            reparsed
+                .updates
+                .android
+                .as_ref()
+                .map(|android| android.allow_unknown_sources_prompt),
+            Some(true),
+            "android updater override should survive a full round-trip"
+        );
+        assert_eq!(
+            reparsed
+                .platforms
+                .android
+                .as_ref()
+                .map(|android| android.package.as_str()),
+            Some("io.test.demo"),
+            "android package should remain unchanged after round-trip"
+        );
+    }
+
+    #[test]
+    fn default_project_omits_empty_updates_section() {
+        let serialized = BlincProject::new("Demo")
+            .to_toml()
+            .expect("default project should serialize");
+
+        assert!(
+            !serialized.contains("[updates]"),
+            "empty updater config should not be serialized into new projects"
+        );
+    }
+
+    #[test]
+    fn updater_config_requires_manifest_metadata_when_enabled() {
+        let err = toml::from_str::<BlincProject>(
+            r#"
+                [project]
+                name = "Demo"
+                version = "0.1.0"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+            "#,
+        )
+        .expect_err("enabled updater config should require manifest metadata");
+
+        assert!(
+            err.to_string()
+                .contains("manifest_url and public_key are required"),
+            "parse error should explain the missing updater metadata"
+        );
+    }
+
+    #[test]
+    fn updater_config_rejects_blank_manifest_metadata_when_enabled() {
+        let err = toml::from_str::<BlincProject>(
+            r#"
+                [project]
+                name = "Demo"
+                version = "0.1.0"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = ""
+                public_key = "   "
+            "#,
+        )
+        .expect_err("enabled updater config should reject blank manifest metadata");
+
+        assert!(
+            err.to_string()
+                .contains("manifest_url and public_key are required"),
+            "parse error should explain the missing updater metadata"
+        );
     }
 }

--- a/crates/blinc_cli/src/main.rs
+++ b/crates/blinc_cli/src/main.rs
@@ -2,10 +2,10 @@
 //!
 //! Build, run, and hot-reload Blinc applications.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::{info, warn};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
@@ -315,22 +315,33 @@ fn cmd_build(source: &str, target: &str, release: bool, output: Option<&str>) ->
 }
 
 fn load_build_project_name(path: &std::path::Path, release: bool) -> Result<String> {
-    let project_root = if path.is_file() {
+    if release {
+        return Ok(release::load_release_project(path)?.project.name);
+    }
+
+    Ok(BlincConfig::load_from_dir(project_config_root(path)?)?
+        .project
+        .name)
+}
+
+fn project_config_root(path: &Path) -> Result<&Path> {
+    let start = if path.is_file() {
         path.parent().unwrap_or(path)
     } else {
         path
     };
 
-    if release {
-        return Ok(release::load_release_project(project_root)?.project.name);
-    }
-
-    Ok(BlincConfig::load_from_dir(project_root)?.project.name)
+    start
+        .ancestors()
+        .find(|candidate| {
+            candidate.join(".blincproj").exists() || candidate.join("blinc.toml").exists()
+        })
+        .context("No .blincproj or blinc.toml found for the provided project path")
 }
 
 fn cmd_dev(source: &str, target: &str, port: u16, device: Option<&str>) -> Result<()> {
     let path = PathBuf::from(source);
-    let config = BlincConfig::load_from_dir(&path)?;
+    let config = BlincConfig::load_from_dir(project_config_root(&path)?)?;
 
     info!(
         "Starting dev server for {} on port {} targeting {}",
@@ -488,7 +499,7 @@ fn cmd_init(template: &str, org: &str) -> Result<()> {
 
 fn cmd_check(source: &str) -> Result<()> {
     let path = PathBuf::from(source);
-    let config = BlincConfig::load_from_dir(&path)?;
+    let config = BlincConfig::load_from_dir(project_config_root(&path)?)?;
 
     info!("Checking project: {}", config.project.name);
 
@@ -582,5 +593,104 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_build_path_discovers_project_root_from_nested_directory() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_release_build_nested_{nonce}"));
+        let nested = root.join("src/features");
+
+        fs::create_dir_all(&nested).expect("nested directory should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "0.1.0"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        assert_eq!(
+            load_build_project_name(&nested, true)
+                .expect("release builds should discover the project root from nested dirs"),
+            "Demo",
+            "release build path should load metadata from the nearest ancestor .blincproj"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn debug_build_path_discovers_project_root_from_nested_directory() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_debug_build_nested_{nonce}"));
+        let nested = root.join("src/features");
+
+        fs::create_dir_all(&nested).expect("nested directory should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "0.1.0"
+
+                [platforms.android]
+                package = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        assert_eq!(
+            load_build_project_name(&nested, false)
+                .expect("debug builds should discover the project root from nested dirs"),
+            "Demo",
+            "debug build path should load metadata from the nearest ancestor project config"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn cmd_new_does_not_leave_directory_on_invalid_org() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("blinc_cli_invalid_org_{nonce}"));
+        let path_string = path.to_string_lossy().to_string();
+
+        let err = cmd_new(&path_string, "default", "123.example", false)
+            .expect_err("invalid org should fail before scaffolding begins");
+        assert!(
+            err.to_string().contains("Invalid organization name"),
+            "invalid org error should be surfaced to the caller"
+        );
+        assert!(
+            !path.exists(),
+            "failed project creation should not leave an empty directory behind"
+        );
     }
 }

--- a/crates/blinc_cli/src/main.rs
+++ b/crates/blinc_cli/src/main.rs
@@ -435,6 +435,8 @@ fn cmd_new(name: &str, template: &str, org: &str, rust: bool) -> Result<()> {
     // Extract the actual project name from the path (last component)
     let project_name = path.file_name().and_then(|n| n.to_str()).unwrap_or(name);
 
+    project::validate_org_name(org)?;
+
     if rust {
         info!("Creating new Rust project: {}", project_name);
     } else {

--- a/crates/blinc_cli/src/main.rs
+++ b/crates/blinc_cli/src/main.rs
@@ -484,7 +484,7 @@ fn cmd_new(name: &str, template: &str, org: &str, rust: bool) -> Result<()> {
         info!("  cd {}", name);
         info!("  cargo run --features desktop");
     } else {
-        project::create_project(&path, name, template, org)?;
+        project::create_project(&path, project_name, template, org)?;
         info!("Project created at {}/", name);
         info!("To get started:");
         info!("  cd {}", name);
@@ -718,5 +718,48 @@ mod tests {
             !path.exists(),
             "failed project creation should not leave an empty directory behind"
         );
+    }
+
+    #[test]
+    fn cmd_new_non_rust_uses_leaf_name_for_scaffold_metadata() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_nested_new_{nonce}"));
+        let path = root.join("apps/Demo App");
+        let path_string = path.to_string_lossy().to_string();
+
+        cmd_new(&path_string, "default", "io.blinc.dev", false)
+            .expect("non-rust project creation should succeed from a nested path");
+
+        let project = crate::config::BlincProject::load_from_dir(&path)
+            .expect("scaffolded non-rust project should include .blincproj");
+        assert_eq!(
+            project.project.name, "Demo App",
+            "scaffold metadata should use the leaf project name instead of the full path"
+        );
+        assert_eq!(
+            project
+                .platforms
+                .android
+                .as_ref()
+                .map(|android| android.package.as_str()),
+            Some("io.blinc.dev.demo_app"),
+            "android package ids should use the normalized leaf project name"
+        );
+
+        let readme =
+            fs::read_to_string(path.join("README.md")).expect("generated README should exist");
+        assert!(
+            readme.contains("dist/demo_app.zip"),
+            "release guidance should use the normalized leaf project name in artifact paths"
+        );
+        assert!(
+            !readme.contains("apps/Demo App"),
+            "generated files should not embed the full requested path as project metadata"
+        );
+
+        let _ = fs::remove_dir_all(&root);
     }
 }

--- a/crates/blinc_cli/src/main.rs
+++ b/crates/blinc_cli/src/main.rs
@@ -12,6 +12,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 mod config;
 mod doctor;
 mod project;
+mod release;
 
 use config::BlincConfig;
 
@@ -200,11 +201,11 @@ fn main() -> Result<()> {
 
 fn cmd_build(source: &str, target: &str, release: bool, output: Option<&str>) -> Result<()> {
     let path = PathBuf::from(source);
-    let config = BlincConfig::load_from_dir(&path)?;
+    let project_name = load_build_project_name(&path, release)?;
 
     info!(
         "Building {} for {} ({})",
-        config.project.name,
+        project_name,
         target,
         if release { "release" } else { "debug" }
     );
@@ -233,6 +234,20 @@ fn cmd_build(source: &str, target: &str, release: bool, output: Option<&str>) ->
     }
 
     Ok(())
+}
+
+fn load_build_project_name(path: &std::path::Path, release: bool) -> Result<String> {
+    let project_root = if path.is_file() {
+        path.parent().unwrap_or(path)
+    } else {
+        path
+    };
+
+    if release {
+        return Ok(release::load_release_project(project_root)?.project.name);
+    }
+
+    Ok(BlincConfig::load_from_dir(project_root)?.project.name)
 }
 
 fn cmd_dev(source: &str, target: &str, port: u16, device: Option<&str>) -> Result<()> {
@@ -419,4 +434,46 @@ fn cmd_doctor() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn release_build_path_requires_blincproj() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_release_build_loader_{nonce}"));
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join("blinc.toml"),
+            r#"
+                [project]
+                name = "LegacyDemo"
+                version = "0.1.0"
+            "#,
+        )
+        .expect("legacy blinc.toml should be written");
+
+        let err = load_build_project_name(&root, true)
+            .expect_err("release builds should require .blincproj metadata");
+        assert!(
+            err.to_string().contains("No .blincproj found"),
+            "release build path should use the release loader"
+        );
+
+        assert_eq!(
+            load_build_project_name(&root, false)
+                .expect("debug builds should keep legacy config support"),
+            "LegacyDemo",
+            "non-release builds should keep using the legacy config loader"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
 }

--- a/crates/blinc_cli/src/main.rs
+++ b/crates/blinc_cli/src/main.rs
@@ -171,17 +171,29 @@ enum ReleaseCommands {
         #[arg(long)]
         url: String,
 
+        /// Built artifact to inspect and sign
+        #[arg(long)]
+        artifact_path: Option<String>,
+
         /// Artifact size in bytes
         #[arg(long)]
-        size: u64,
+        size: Option<u64>,
 
         /// Artifact SHA-256 hex digest
         #[arg(long)]
-        sha256: String,
+        sha256: Option<String>,
 
         /// Artifact signature
         #[arg(long)]
-        signature: String,
+        signature: Option<String>,
+
+        /// Base64-encoded Ed25519 private key seed
+        #[arg(long)]
+        private_key: Option<String>,
+
+        /// Optional path to write the matching base64-encoded public key
+        #[arg(long)]
+        public_key_output: Option<String>,
 
         /// Manifest output path
         #[arg(long)]
@@ -240,9 +252,12 @@ fn main() -> Result<()> {
                 platform,
                 arch,
                 url,
+                artifact_path,
                 size,
                 sha256,
                 signature,
+                private_key,
+                public_key_output,
                 output,
                 published_at,
                 notes_url,
@@ -251,9 +266,12 @@ fn main() -> Result<()> {
                 &platform,
                 &arch,
                 &url,
+                artifact_path.as_deref(),
                 size,
-                &sha256,
-                &signature,
+                sha256.as_deref(),
+                signature.as_deref(),
+                private_key.as_deref(),
+                public_key_output.as_deref(),
                 &output,
                 &published_at,
                 notes_url.as_deref(),
@@ -405,9 +423,12 @@ fn cmd_release_manifest(
     platform: &str,
     arch: &str,
     url: &str,
-    size: u64,
-    sha256: &str,
-    signature: &str,
+    artifact_path: Option<&str>,
+    size: Option<u64>,
+    sha256: Option<&str>,
+    signature: Option<&str>,
+    private_key: Option<&str>,
+    public_key_output: Option<&str>,
     output: &str,
     published_at: &str,
     notes_url: Option<&str>,
@@ -417,9 +438,12 @@ fn cmd_release_manifest(
         platform: platform.to_string(),
         arch: arch.to_string(),
         url: url.to_string(),
-        size,
-        sha256: sha256.to_string(),
-        signature: signature.to_string(),
+        artifact_path: artifact_path.map(PathBuf::from),
+        size: size.unwrap_or_default(),
+        sha256: sha256.unwrap_or_default().to_string(),
+        signature: signature.unwrap_or_default().to_string(),
+        private_key: private_key.map(str::to_owned),
+        public_key_output: public_key_output.map(PathBuf::from),
         output: PathBuf::from(output),
         published_at: published_at.to_string(),
         notes_url: notes_url.map(str::to_owned),

--- a/crates/blinc_cli/src/main.rs
+++ b/crates/blinc_cli/src/main.rs
@@ -82,6 +82,12 @@ enum Commands {
         command: PluginCommands,
     },
 
+    /// Generate release metadata
+    Release {
+        #[command(subcommand)]
+        command: ReleaseCommands,
+    },
+
     /// Create a new Blinc project
     New {
         /// Project name
@@ -145,6 +151,52 @@ enum PluginCommands {
     },
 }
 
+#[derive(Subcommand)]
+enum ReleaseCommands {
+    /// Generate a release manifest JSON file
+    Manifest {
+        /// Project directory or source path
+        #[arg(default_value = ".")]
+        source: String,
+
+        /// Artifact platform
+        #[arg(long)]
+        platform: String,
+
+        /// Artifact architecture
+        #[arg(long)]
+        arch: String,
+
+        /// Published artifact URL
+        #[arg(long)]
+        url: String,
+
+        /// Artifact size in bytes
+        #[arg(long)]
+        size: u64,
+
+        /// Artifact SHA-256 hex digest
+        #[arg(long)]
+        sha256: String,
+
+        /// Artifact signature
+        #[arg(long)]
+        signature: String,
+
+        /// Manifest output path
+        #[arg(long)]
+        output: String,
+
+        /// RFC 3339 publish timestamp
+        #[arg(long)]
+        published_at: String,
+
+        /// Optional release notes URL
+        #[arg(long)]
+        notes_url: Option<String>,
+    },
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -180,6 +232,32 @@ fn main() -> Result<()> {
         Commands::Plugin { command } => match command {
             PluginCommands::Build { path, mode } => cmd_plugin_build(&path, &mode),
             PluginCommands::New { name } => cmd_plugin_new(&name),
+        },
+
+        Commands::Release { command } => match command {
+            ReleaseCommands::Manifest {
+                source,
+                platform,
+                arch,
+                url,
+                size,
+                sha256,
+                signature,
+                output,
+                published_at,
+                notes_url,
+            } => cmd_release_manifest(
+                &source,
+                &platform,
+                &arch,
+                &url,
+                size,
+                &sha256,
+                &signature,
+                &output,
+                &published_at,
+                notes_url.as_deref(),
+            ),
         },
 
         Commands::New {
@@ -308,6 +386,35 @@ fn cmd_plugin_new(name: &str) -> Result<()> {
     project::create_plugin_project(&path, name)?;
 
     info!("Plugin created at {}/", name);
+    Ok(())
+}
+
+fn cmd_release_manifest(
+    source: &str,
+    platform: &str,
+    arch: &str,
+    url: &str,
+    size: u64,
+    sha256: &str,
+    signature: &str,
+    output: &str,
+    published_at: &str,
+    notes_url: Option<&str>,
+) -> Result<()> {
+    release::write_release_manifest(&release::ReleaseManifestArgs {
+        source: PathBuf::from(source),
+        platform: platform.to_string(),
+        arch: arch.to_string(),
+        url: url.to_string(),
+        size,
+        sha256: sha256.to_string(),
+        signature: signature.to_string(),
+        output: PathBuf::from(output),
+        published_at: published_at.to_string(),
+        notes_url: notes_url.map(str::to_owned),
+    })?;
+
+    info!("Release manifest written to {}", output);
     Ok(())
 }
 

--- a/crates/blinc_cli/src/project.rs
+++ b/crates/blinc_cli/src/project.rs
@@ -793,10 +793,11 @@ fn create_linux_files(path: &Path, name: &str, package_name: &str, org: &str) ->
     let linux_path = path.join("platforms/linux");
     let binary_name = name.to_lowercase().replace([' ', '-'], "_");
     let appstream_id = format!("{org}.{package_name}");
+    let desktop_file_id = format!("{appstream_id}.desktop");
 
     // Desktop entry file
     fs::write(
-        linux_path.join(format!("{}.desktop", binary_name)),
+        linux_path.join(&desktop_file_id),
         format!(
             r#"[Desktop Entry]
 Type=Application
@@ -827,7 +828,7 @@ StartupWMClass={name}
             {name} is a cross-platform application built with Blinc.
         </p>
     </description>
-    <launchable type="desktop-id">{binary_name}.desktop</launchable>
+    <launchable type="desktop-id">{desktop_file_id}</launchable>
     <provides>
         <binary>{binary_name}</binary>
     </provides>
@@ -1799,12 +1800,17 @@ fn validate_org_name(org: &str) -> Result<()> {
         bail!("Organization name cannot be empty");
     }
 
-    let is_valid = org
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_'));
-    if !is_valid || org.starts_with('.') || org.ends_with('.') || org.contains("..") {
+    let is_valid = org.split('.').all(|segment| {
+        let mut chars = segment.chars();
+        let Some(first) = chars.next() else {
+            return false;
+        };
+
+        first.is_ascii_alphabetic() && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+    });
+    if !is_valid {
         bail!(
-            "Invalid organization name '{}'. Use only ASCII letters, digits, '.' or '_'",
+            "Invalid organization name '{}'. Use dot-separated segments that start with ASCII letters and then contain only ASCII letters, digits, or '_'",
             org
         );
     }
@@ -2924,6 +2930,28 @@ mod tests {
     }
 
     #[test]
+    fn rust_project_rejects_android_invalid_org_segments() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("blinc_cli_headless_invalid_org_segment_{nonce}"));
+
+        let err = create_rust_project(&root, "DemoApp", "123.example")
+            .expect_err("android-invalid org segments should be rejected");
+
+        assert!(
+            err.to_string().contains("Invalid organization name"),
+            "error should explain org name validation failure"
+        );
+        assert!(
+            !root.exists(),
+            "project directory should not be created when org is rejected"
+        );
+    }
+
+    #[test]
     fn non_rust_project_uses_org_for_platform_identifiers() {
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -2975,6 +3003,17 @@ mod tests {
             linux_metainfo.contains("<id>io.blinc.dev.demo_app</id>"),
             "generated AppStream ID should use the provided org"
         );
+        assert!(
+            linux_metainfo.contains(
+                "<launchable type=\"desktop-id\">io.blinc.dev.demo_app.desktop</launchable>"
+            ),
+            "generated AppStream launchable should point at the org-based desktop file"
+        );
+        assert!(
+            root.join("platforms/linux/io.blinc.dev.demo_app.desktop")
+                .exists(),
+            "generated Linux desktop entry filename should use the org-based identifier"
+        );
 
         let _ = fs::remove_dir_all(&root);
     }
@@ -2994,6 +3033,28 @@ mod tests {
             r#"com.example"; std::process::Command::new("calc").spawn().unwrap(); //"#,
         )
         .expect_err("unsafe org name should be rejected for non-rust projects");
+
+        assert!(
+            err.to_string().contains("Invalid organization name"),
+            "error should explain org name validation failure"
+        );
+        assert!(
+            !root.exists(),
+            "project directory should not be created when org is rejected"
+        );
+    }
+
+    #[test]
+    fn non_rust_project_rejects_android_invalid_org_segments() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("blinc_cli_non_rust_invalid_org_segment_{nonce}"));
+
+        let err = create_project(&root, "DemoApp", "default", "123.example")
+            .expect_err("android-invalid org segments should be rejected");
 
         assert!(
             err.to_string().contains("Invalid organization name"),

--- a/crates/blinc_cli/src/project.rs
+++ b/crates/blinc_cli/src/project.rs
@@ -1795,7 +1795,7 @@ fn validate_rust_project_name(name: &str) -> Result<()> {
     Ok(())
 }
 
-fn validate_org_name(org: &str) -> Result<()> {
+pub(crate) fn validate_org_name(org: &str) -> Result<()> {
     if org.is_empty() {
         bail!("Organization name cannot be empty");
     }

--- a/crates/blinc_cli/src/project.rs
+++ b/crates/blinc_cli/src/project.rs
@@ -860,12 +860,12 @@ The desktop entry file can be installed to:
 
 ```bash
 # User installation
-cp {binary_name}.desktop ~/.local/share/applications/
+cp {desktop_file_id} ~/.local/share/applications/
 ```
 
 ## Configuration
 
-- `{binary_name}.desktop` - Desktop entry for app launchers
+- `{desktop_file_id}` - Desktop entry for app launchers
 - `{binary_name}.metainfo.xml` - AppStream metadata for software centers
 "#
         ),
@@ -3013,6 +3013,18 @@ mod tests {
             root.join("platforms/linux/io.blinc.dev.demo_app.desktop")
                 .exists(),
             "generated Linux desktop entry filename should use the org-based identifier"
+        );
+
+        let linux_readme = fs::read_to_string(root.join("platforms/linux/README.md"))
+            .expect("generated Linux README should exist");
+        assert!(
+            linux_readme.contains("cp io.blinc.dev.demo_app.desktop ~/.local/share/applications/"),
+            "generated Linux README should document the org-based desktop entry filename"
+        );
+        assert!(
+            linux_readme
+                .contains("`io.blinc.dev.demo_app.desktop` - Desktop entry for app launchers"),
+            "generated Linux README file list should mention the org-based desktop entry filename"
         );
 
         let _ = fs::remove_dir_all(&root);

--- a/crates/blinc_cli/src/project.rs
+++ b/crates/blinc_cli/src/project.rs
@@ -27,6 +27,7 @@ const IOS_NATIVE_BRIDGE_TEMPLATE: &str =
 /// Create a new Blinc project with full workspace structure
 pub fn create_project(path: &Path, name: &str, template: &str, org: &str) -> Result<()> {
     validate_org_name(org)?;
+    let release_artifact_name = name.replace(['-', ' '], "_").to_lowercase();
 
     // Create directory structure
     fs::create_dir_all(path.join("src"))?;
@@ -169,6 +170,39 @@ Edit `.blincproj` to configure:
 - Project metadata (name, version, description)
 - Platform-specific settings (package IDs, SDK versions)
 - Dependencies (plugins, external packages)
+
+## Updater
+
+Add updater settings under `[updates]` in `.blincproj` when you are ready to publish signed releases:
+
+```toml
+[updates]
+enabled = true
+channel = "stable"
+manifest_url = "https://example.com/releases/release-manifest.json"
+public_key = "base64-ed25519-public-key"
+```
+
+- macOS desktop self-update is the current reference path in the shared updater architecture.
+- Windows/Linux remain planned desktop updater targets and stay explicit unsupported backends in v1.
+- Android private/development distribution is supported through APK installer handoff.
+- iOS uses App Store/TestFlight distribution and is excluded from the in-app updater flow.
+
+Generate signed release metadata with the user-callable `blinc release manifest` entry point:
+
+```bash
+blinc release manifest . \
+  --platform macos \
+  --arch universal \
+  --artifact-path dist/{release_artifact_name}.zip \
+  --private-key "$BLINC_RELEASE_PRIVATE_KEY" \
+  --public-key-output dist/public-key.txt \
+  --url https://example.com/releases/{release_artifact_name}.zip \
+  --output dist/release-manifest.json \
+  --published-at 2026-03-07T00:00:00Z
+```
+
+Reuse the same --published-at value when appending more artifacts to the same release manifest.
 "#,
         ),
     )?;
@@ -1329,6 +1363,10 @@ pub fn create_rust_project(path: &Path, name: &str, org: &str) -> Result<()> {
     fs::create_dir_all(path.join("platforms/android/app/src/main/kotlin/com/blinc"))?;
     fs::create_dir_all(path.join("platforms/ios/BlincApp"))?;
 
+    // Create .blincproj for release and updater workflows
+    let project = BlincProject::new(name).with_all_platforms(name, org);
+    fs::write(path.join(".blincproj"), project.to_toml()?)?;
+
     // Create Cargo.toml
     fs::write(
         path.join("Cargo.toml"),
@@ -1733,6 +1771,7 @@ cargo lipo --release
 
 ```
 {name}/
+├── .blincproj          # Project and updater configuration
 ├── Cargo.toml           # Rust project configuration
 ├── blinc.toml           # Blinc toolchain configuration
 ├── src/
@@ -1741,6 +1780,31 @@ cargo lipo --release
     ├── android/         # Android Gradle project
     └── ios/             # iOS Swift files
 ```
+
+## Updater
+
+Add updater settings under `[updates]` in `.blincproj` when you want signed desktop or Android release metadata.
+
+- macOS desktop self-update is the current reference path in the shared updater flow.
+- Windows/Linux remain planned desktop updater targets and stay explicit unsupported backends in v1.
+- Android private/development distribution is supported through APK handoff.
+- iOS uses App Store/TestFlight distribution and is excluded from in-app updater support.
+
+Generate release metadata with:
+
+```bash
+blinc release manifest . \
+  --platform macos \
+  --arch universal \
+  --artifact-path dist/{package_name}.zip \
+  --private-key "$BLINC_RELEASE_PRIVATE_KEY" \
+  --public-key-output dist/public-key.txt \
+  --url https://example.com/releases/{package_name}.zip \
+  --output dist/release-manifest.json \
+  --published-at 2026-03-07T00:00:00Z
+```
+
+Reuse the same --published-at value when appending more artifacts to the same release manifest.
 "#
         ),
     )?;
@@ -3025,6 +3089,126 @@ mod tests {
             linux_readme
                 .contains("`io.blinc.dev.demo_app.desktop` - Desktop entry for app launchers"),
             "generated Linux README file list should mention the org-based desktop entry filename"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn generated_project_includes_updater_config_and_release_manifest_guidance() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_updater_guidance_{nonce}"));
+
+        create_project(&root, "Demo App", "default", "io.blinc.dev")
+            .expect("non-rust project template should be generated");
+
+        let readme =
+            fs::read_to_string(root.join("README.md")).expect("generated README should exist");
+        assert!(
+            readme.contains("[updates]"),
+            "generated README should show where updater config lives"
+        );
+        assert!(
+            readme.contains("macOS desktop self-update"),
+            "generated README should scope desktop updater guidance to the current macOS reference path"
+        );
+        assert!(
+            readme.contains("Android private/development distribution"),
+            "generated README should mention Android private updater support"
+        );
+        assert!(
+            readme.contains("iOS uses App Store/TestFlight"),
+            "generated README should explain iOS exclusion from in-app updates"
+        );
+        assert!(
+            readme.contains("Windows/Linux remain planned"),
+            "generated README should clarify that Windows and Linux are not shipped updater backends yet"
+        );
+        assert!(
+            readme.contains("blinc release manifest"),
+            "generated README should mention the user-callable release manifest entry point"
+        );
+        assert!(
+            readme.contains("blinc release manifest . \\"),
+            "generated README should use the positional source argument that the CLI actually exposes"
+        );
+        assert!(
+            !readme.contains("--source ."),
+            "generated README should not document a nonexistent --source flag"
+        );
+        assert!(
+            readme.contains("dist/demo_app.zip"),
+            "generated README should slug artifact filenames so example commands stay valid for names with spaces"
+        );
+        assert!(
+            readme.contains("https://example.com/releases/demo_app.zip"),
+            "generated README should slug artifact URLs so example commands stay valid for names with spaces"
+        );
+        assert!(
+            readme.contains("Reuse the same --published-at value"),
+            "generated README should explain how to append multiple artifacts to one release manifest"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn rust_project_readme_uses_positional_release_source_and_slugged_artifact_names() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_rust_updater_guidance_{nonce}"));
+
+        create_rust_project(&root, "Demo App", "io.blinc.dev")
+            .expect("rust project template should be generated");
+
+        let readme =
+            fs::read_to_string(root.join("README.md")).expect("generated README should exist");
+        assert!(
+            readme.contains("blinc release manifest . \\"),
+            "rust README should use the positional source argument that the CLI actually exposes"
+        );
+        assert!(
+            !readme.contains("--source ."),
+            "rust README should not document a nonexistent --source flag"
+        );
+        assert!(
+            readme.contains("dist/demo_app.zip"),
+            "rust README should slug artifact filenames so example commands stay valid for names with spaces"
+        );
+        assert!(
+            readme.contains("https://example.com/releases/demo_app.zip"),
+            "rust README should slug artifact URLs so example commands stay valid for names with spaces"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn rust_project_scaffold_includes_blincproj_for_release_workflow() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_rust_release_config_{nonce}"));
+
+        create_rust_project(&root, "Demo App", "io.blinc.dev")
+            .expect("rust project template should be generated");
+
+        let project = BlincProject::load_from_dir(&root)
+            .expect("rust project scaffold should include a .blincproj for release commands");
+        assert_eq!(
+            project
+                .platforms
+                .macos
+                .as_ref()
+                .map(|macos| macos.bundle_id.as_str()),
+            Some("io.blinc.dev.demo_app"),
+            "rust scaffold should preserve canonical platform identities in .blincproj"
         );
 
         let _ = fs::remove_dir_all(&root);

--- a/crates/blinc_cli/src/project.rs
+++ b/crates/blinc_cli/src/project.rs
@@ -26,6 +26,8 @@ const IOS_NATIVE_BRIDGE_TEMPLATE: &str =
 
 /// Create a new Blinc project with full workspace structure
 pub fn create_project(path: &Path, name: &str, template: &str, org: &str) -> Result<()> {
+    validate_org_name(org)?;
+
     // Create directory structure
     fs::create_dir_all(path.join("src"))?;
     fs::create_dir_all(path.join("assets"))?;
@@ -53,7 +55,7 @@ pub fn create_project(path: &Path, name: &str, template: &str, org: &str) -> Res
     fs::write(path.join("src/main.blinc"), main_content)?;
 
     // Create platform entry points
-    create_platform_files(path, name)?;
+    create_platform_files(path, name, org)?;
 
     // Create plugins README
     fs::write(
@@ -175,23 +177,23 @@ Edit `.blincproj` to configure:
 }
 
 /// Create platform-specific files
-fn create_platform_files(path: &Path, name: &str) -> Result<()> {
+fn create_platform_files(path: &Path, name: &str, org: &str) -> Result<()> {
     let package_name = name.replace(['-', ' '], "_").to_lowercase();
 
     // Android
-    create_android_files(path, name, &package_name)?;
+    create_android_files(path, name, &package_name, org)?;
 
     // iOS
-    create_ios_files(path, name, &package_name)?;
+    create_ios_files(path, name, &package_name, org)?;
 
     // macOS
-    create_macos_files(path, name, &package_name)?;
+    create_macos_files(path, name, &package_name, org)?;
 
     // Windows
     create_windows_files(path, name)?;
 
     // Linux
-    create_linux_files(path, name)?;
+    create_linux_files(path, name, &package_name, org)?;
 
     // WASM/Web
     create_wasm_files(path, name)?;
@@ -199,8 +201,9 @@ fn create_platform_files(path: &Path, name: &str) -> Result<()> {
     Ok(())
 }
 
-fn create_android_files(path: &Path, name: &str, package_name: &str) -> Result<()> {
+fn create_android_files(path: &Path, name: &str, package_name: &str, org: &str) -> Result<()> {
     let android_path = path.join("platforms/android");
+    let package_id = format!("{org}.{package_name}");
 
     // Create basic Android structure
     fs::create_dir_all(android_path.join("app/src/main/java"))?;
@@ -237,11 +240,11 @@ plugins {
 }}
 
 android {{
-    namespace = "com.example.{package_name}"
+    namespace = "{package_id}"
     compileSdk = 35
 
     defaultConfig {{
-        applicationId = "com.example.{package_name}"
+        applicationId = "{package_id}"
         minSdk = 24
         targetSdk = 35
         versionCode = 1
@@ -306,7 +309,7 @@ dependencies {{
     )?;
 
     // MainActivity.kt placeholder
-    let package_path = format!("com/example/{}", package_name);
+    let package_path = format!("{}/{}", org.replace('.', "/"), package_name);
     fs::create_dir_all(android_path.join(format!("app/src/main/java/{}", package_path)))?;
     fs::write(
         android_path.join(format!(
@@ -314,7 +317,7 @@ dependencies {{
             package_path
         )),
         format!(
-            r#"package com.example.{package_name}
+            r#"package {package_id}
 
 import android.app.Activity
 import android.os.Bundle
@@ -408,8 +411,9 @@ Edit `app/build.gradle.kts` to modify:
     Ok(())
 }
 
-fn create_ios_files(path: &Path, name: &str, package_name: &str) -> Result<()> {
+fn create_ios_files(path: &Path, name: &str, package_name: &str, org: &str) -> Result<()> {
     let ios_path = path.join("platforms/ios");
+    let bundle_id = format!("{org}.{package_name}");
 
     // Create Xcode project structure
     let xcodeproj = ios_path.join(format!("{}.xcodeproj", name));
@@ -429,7 +433,7 @@ fn create_ios_files(path: &Path, name: &str, package_name: &str) -> Result<()> {
     <key>CFBundleExecutable</key>
     <string>{name}</string>
     <key>CFBundleIdentifier</key>
-    <string>com.example.{package_name}</string>
+    <string>{bundle_id}</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
@@ -558,8 +562,9 @@ Edit `{name}/Info.plist` to modify:
     Ok(())
 }
 
-fn create_macos_files(path: &Path, name: &str, package_name: &str) -> Result<()> {
+fn create_macos_files(path: &Path, name: &str, package_name: &str, org: &str) -> Result<()> {
     let macos_path = path.join("platforms/macos");
+    let bundle_id = format!("{org}.{package_name}");
 
     // Info.plist for macOS app bundle
     fs::write(
@@ -574,7 +579,7 @@ fn create_macos_files(path: &Path, name: &str, package_name: &str) -> Result<()>
     <key>CFBundleExecutable</key>
     <string>{name}</string>
     <key>CFBundleIdentifier</key>
-    <string>com.example.{package_name}</string>
+    <string>{bundle_id}</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
@@ -784,9 +789,10 @@ blinc build --target windows --release
     Ok(())
 }
 
-fn create_linux_files(path: &Path, name: &str) -> Result<()> {
+fn create_linux_files(path: &Path, name: &str, package_name: &str, org: &str) -> Result<()> {
     let linux_path = path.join("platforms/linux");
     let binary_name = name.to_lowercase().replace([' ', '-'], "_");
+    let appstream_id = format!("{org}.{package_name}");
 
     // Desktop entry file
     fs::write(
@@ -811,7 +817,7 @@ StartupWMClass={name}
         format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-    <id>com.example.{binary_name}</id>
+    <id>{appstream_id}</id>
     <name>{name}</name>
     <summary>A Blinc application</summary>
     <metadata_license>CC0-1.0</metadata_license>
@@ -2906,6 +2912,88 @@ mod tests {
             r#"com.example"; std::process::Command::new("calc").spawn().unwrap(); //"#,
         )
         .expect_err("unsafe org name should be rejected");
+
+        assert!(
+            err.to_string().contains("Invalid organization name"),
+            "error should explain org name validation failure"
+        );
+        assert!(
+            !root.exists(),
+            "project directory should not be created when org is rejected"
+        );
+    }
+
+    #[test]
+    fn non_rust_project_uses_org_for_platform_identifiers() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_non_rust_org_ids_{nonce}"));
+
+        create_project(&root, "Demo App", "default", "io.blinc.dev")
+            .expect("non-rust project template should be generated");
+
+        let android_gradle =
+            fs::read_to_string(root.join("platforms/android/app/build.gradle.kts"))
+                .expect("generated Android Gradle file should exist");
+        assert!(
+            android_gradle.contains(r#"namespace = "io.blinc.dev.demo_app""#),
+            "generated Android namespace should use the provided org"
+        );
+        assert!(
+            android_gradle.contains(r#"applicationId = "io.blinc.dev.demo_app""#),
+            "generated Android applicationId should use the provided org"
+        );
+
+        let main_activity = fs::read_to_string(
+            root.join("platforms/android/app/src/main/java/io/blinc/dev/demo_app/MainActivity.kt"),
+        )
+        .expect("generated MainActivity.kt should exist under the org package path");
+        assert!(
+            main_activity.contains("package io.blinc.dev.demo_app"),
+            "generated MainActivity should use the provided org in its package declaration"
+        );
+
+        let ios_plist = fs::read_to_string(root.join("platforms/ios/Demo App/Info.plist"))
+            .expect("generated iOS Info.plist should exist");
+        assert!(
+            ios_plist.contains("<string>io.blinc.dev.demo_app</string>"),
+            "generated iOS bundle identifier should use the provided org"
+        );
+
+        let macos_plist = fs::read_to_string(root.join("platforms/macos/Info.plist"))
+            .expect("generated macOS Info.plist should exist");
+        assert!(
+            macos_plist.contains("<string>io.blinc.dev.demo_app</string>"),
+            "generated macOS bundle identifier should use the provided org"
+        );
+
+        let linux_metainfo = fs::read_to_string(root.join("platforms/linux/demo_app.metainfo.xml"))
+            .expect("generated AppStream metadata should exist");
+        assert!(
+            linux_metainfo.contains("<id>io.blinc.dev.demo_app</id>"),
+            "generated AppStream ID should use the provided org"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn non_rust_project_rejects_unsafe_org_chars() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_non_rust_invalid_org_{nonce}"));
+
+        let err = create_project(
+            &root,
+            "DemoApp",
+            "default",
+            r#"com.example"; std::process::Command::new("calc").spawn().unwrap(); //"#,
+        )
+        .expect_err("unsafe org name should be rejected for non-rust projects");
 
         assert!(
             err.to_string().contains("Invalid organization name"),

--- a/crates/blinc_cli/src/release.rs
+++ b/crates/blinc_cli/src/release.rs
@@ -1,6 +1,9 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
+use ed25519_dalek::{Signer, SigningKey};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
 use time::format_description::well_known::Rfc3339;
@@ -14,9 +17,12 @@ pub(crate) struct ReleaseManifestArgs {
     pub platform: String,
     pub arch: String,
     pub url: String,
+    pub artifact_path: Option<PathBuf>,
     pub size: u64,
     pub sha256: String,
     pub signature: String,
+    pub private_key: Option<String>,
+    pub public_key_output: Option<PathBuf>,
     pub output: PathBuf,
     pub published_at: String,
     pub notes_url: Option<String>,
@@ -54,14 +60,15 @@ pub(crate) fn write_release_manifest(args: &ReleaseManifestArgs) -> Result<()> {
 
     let project = load_release_project(&args.source)?;
     let target_id = resolve_target_id(&project, &args.platform)?;
+    let metadata = resolve_artifact_metadata(args)?;
     let artifact = ReleaseManifestArtifact {
         platform: args.platform.clone(),
         arch: args.arch.clone(),
         target_id,
         url: args.url.clone(),
-        size: args.size,
-        sha256: args.sha256.clone(),
-        signature: args.signature.clone(),
+        size: metadata.size,
+        sha256: metadata.sha256,
+        signature: metadata.signature,
     };
 
     let manifest = if args.output.exists() {
@@ -122,19 +129,137 @@ fn validate_release_manifest_args(args: &ReleaseManifestArgs) -> Result<()> {
     OffsetDateTime::parse(&args.published_at, &Rfc3339)
         .context("published_at must be a valid RFC 3339 timestamp")?;
 
-    if args.sha256.len() != 64 || !args.sha256.chars().all(|ch| ch.is_ascii_hexdigit()) {
+    if let Some(artifact_path) = &args.artifact_path {
+        if args.size != 0 || !args.sha256.is_empty() || !args.signature.is_empty() {
+            bail!("artifact_path mode computes size, sha256, and signature automatically");
+        }
+
+        if !artifact_path.is_file() {
+            bail!("artifact_path must point to a file");
+        }
+
+        if args
+            .private_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|key| !key.is_empty())
+            .is_none()
+            && std::env::var_os("BLINC_RELEASE_PRIVATE_KEY").is_none()
+        {
+            bail!("artifact_path requires a private key via --private-key or BLINC_RELEASE_PRIVATE_KEY");
+        }
+
+        return Ok(());
+    }
+
+    if args.size == 0 && args.sha256.is_empty() && args.signature.is_empty() {
+        bail!("manual manifest mode requires size, sha256, and signature, or use --artifact-path");
+    }
+
+    if args.size == 0 {
+        bail!("size must be greater than zero");
+    }
+
+    validate_sha256(&args.sha256)?;
+    validate_signature(&args.signature)
+}
+
+fn resolve_artifact_metadata(args: &ReleaseManifestArgs) -> Result<ResolvedArtifactMetadata> {
+    if let Some(artifact_path) = &args.artifact_path {
+        let signing_key = load_signing_key(args)?;
+        let bytes = fs::read(artifact_path)
+            .with_context(|| format!("Failed to read {}", artifact_path.display()))?;
+        if bytes.is_empty() {
+            bail!("artifact_path must point to a non-empty file");
+        }
+
+        if let Some(public_key_output) = &args.public_key_output {
+            write_public_key(public_key_output, &signing_key)?;
+        }
+
+        return Ok(ResolvedArtifactMetadata {
+            size: bytes.len() as u64,
+            sha256: sha256_hex(&bytes),
+            signature: STANDARD.encode(signing_key.sign(&bytes).to_bytes()),
+        });
+    }
+
+    Ok(ResolvedArtifactMetadata {
+        size: args.size,
+        sha256: args.sha256.clone(),
+        signature: args.signature.clone(),
+    })
+}
+
+fn load_signing_key(args: &ReleaseManifestArgs) -> Result<SigningKey> {
+    let private_key = args
+        .private_key
+        .clone()
+        .or_else(|| std::env::var("BLINC_RELEASE_PRIVATE_KEY").ok())
+        .map(|key| key.trim().to_string())
+        .filter(|key| !key.is_empty())
+        .context(
+            "artifact_path requires a private key via --private-key or BLINC_RELEASE_PRIVATE_KEY",
+        )?;
+
+    let bytes = STANDARD
+        .decode(private_key)
+        .context("private_key must be a base64-encoded 32-byte ed25519 secret key seed")?;
+    let key_bytes: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| anyhow!("private_key must decode to exactly 32 bytes"))?;
+
+    Ok(SigningKey::from_bytes(&key_bytes))
+}
+
+fn write_public_key(path: &Path, signing_key: &SigningKey) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    fs::write(
+        path,
+        STANDARD.encode(signing_key.verifying_key().to_bytes()),
+    )
+    .with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
+fn validate_sha256(sha256: &str) -> Result<()> {
+    if sha256.len() != 64 || !sha256.chars().all(|ch| ch.is_ascii_hexdigit()) {
         bail!("sha256 must be a 64-character hexadecimal digest");
     }
 
-    if args.signature.is_empty() {
+    Ok(())
+}
+
+fn validate_signature(signature: &str) -> Result<()> {
+    if signature.is_empty() {
         bail!("signature must be a non-empty base64 string");
     }
 
-    STANDARD
-        .decode(&args.signature)
+    let signature_bytes = STANDARD
+        .decode(signature)
         .context("signature must be a valid base64 string")?;
-
+    if signature_bytes.len() != 64 {
+        bail!("signature must decode to a 64-byte ed25519 signature");
+    }
     Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(&mut output, "{byte:02x}");
+    }
+    output
+}
+
+struct ResolvedArtifactMetadata {
+    size: u64,
+    sha256: String,
+    signature: String,
 }
 
 fn release_project_root(path: &Path) -> Result<&Path> {
@@ -174,8 +299,12 @@ fn resolve_target_id(project: &BlincProject, platform: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ed25519_dalek::{Signature, Verifier, VerifyingKey};
     use serde_json::Value;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    const VALID_SIGNATURE: &str =
+        "CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQ==";
 
     #[test]
     fn release_loader_preserves_updates_and_non_legacy_platforms() {
@@ -313,9 +442,12 @@ mod tests {
             platform: "macos".to_string(),
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: None,
             size: 12_345,
             sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-            signature: "c2ln".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: None,
+            public_key_output: None,
             output: output.clone(),
             published_at: "2026-03-07T00:00:00Z".to_string(),
             notes_url: Some("https://example.com/releases/1.2.3".to_string()),
@@ -372,7 +504,7 @@ mod tests {
             "manifest artifact should preserve sha256"
         );
         assert_eq!(
-            json["artifacts"][0]["signature"], "c2ln",
+            json["artifacts"][0]["signature"], VALID_SIGNATURE,
             "manifest artifact should preserve signature"
         );
 
@@ -416,9 +548,12 @@ mod tests {
             platform: "macos".to_string(),
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: None,
             size: 12_345,
             sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-            signature: "c2ln".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: None,
+            public_key_output: None,
             output: output.clone(),
             published_at: "2026-03-07T00:00:00Z".to_string(),
             notes_url: None,
@@ -430,9 +565,12 @@ mod tests {
             platform: "android".to_string(),
             arch: "arm64-v8a".to_string(),
             url: "https://example.com/releases/demo-1.2.3.apk".to_string(),
+            artifact_path: None,
             size: 67_890,
             sha256: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210".to_string(),
-            signature: "YWJj".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: None,
+            public_key_output: None,
             output: output.clone(),
             published_at: "2026-03-07T00:00:00Z".to_string(),
             notes_url: None,
@@ -489,9 +627,12 @@ mod tests {
             platform: "macos".to_string(),
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos-v1.zip".to_string(),
+            artifact_path: None,
             size: 12_345,
             sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-            signature: "c2ln".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: None,
+            public_key_output: None,
             output: output.clone(),
             published_at: "2026-03-07T00:00:00Z".to_string(),
             notes_url: None,
@@ -503,9 +644,12 @@ mod tests {
             platform: "macos".to_string(),
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos-v2.zip".to_string(),
+            artifact_path: None,
             size: 54_321,
             sha256: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210".to_string(),
-            signature: "YWJj".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: None,
+            public_key_output: None,
             output: output.clone(),
             published_at: "2026-03-07T00:00:00Z".to_string(),
             notes_url: None,
@@ -527,6 +671,287 @@ mod tests {
         assert_eq!(
             json["artifacts"][0]["size"], 54_321,
             "replacement artifact should keep the latest size"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_populates_artifact_signatures() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_release_manifest_signing_{nonce}"));
+        let artifact_path = root.join("dist/demo.zip");
+        let manifest_path = root.join("dist/release-manifest.json");
+        let public_key_path = root.join("dist/public-key.txt");
+
+        fs::create_dir_all(
+            artifact_path
+                .parent()
+                .expect("artifact directory should exist"),
+        )
+        .expect("artifact directory should be created");
+        fs::write(&artifact_path, b"hello signed release").expect("artifact should be written");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: Some(artifact_path),
+            size: 0,
+            sha256: String::new(),
+            signature: String::new(),
+            private_key: Some("BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=".to_string()),
+            public_key_output: Some(public_key_path.clone()),
+            output: manifest_path.clone(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect("artifact-path mode should compute and sign artifact metadata");
+
+        let manifest = fs::read_to_string(&manifest_path).expect("manifest file should exist");
+        let json: Value = serde_json::from_str(&manifest).expect("manifest should be valid JSON");
+        let signature = json["artifacts"][0]["signature"]
+            .as_str()
+            .expect("signature should be serialized as a string");
+        let public_key =
+            fs::read_to_string(&public_key_path).expect("public key output should be written");
+
+        assert_eq!(
+            json["artifacts"][0]["size"], 20,
+            "artifact-path mode should derive artifact size from the file"
+        );
+        assert_eq!(
+            json["artifacts"][0]["sha256"],
+            "1e7baffe75a68c049cc5f0bc7f0a894d4a3e8942adbc148e4a80c98a9d70866e",
+            "artifact-path mode should derive sha256 from the file"
+        );
+        assert!(
+            !signature.is_empty(),
+            "artifact-path mode should generate a detached signature"
+        );
+        assert!(
+            !public_key.trim().is_empty(),
+            "artifact-path mode should expose the matching public key"
+        );
+        let signature_bytes = STANDARD
+            .decode(signature)
+            .expect("generated signatures should be valid base64");
+        let signature = Signature::from_bytes(
+            &signature_bytes
+                .try_into()
+                .expect("ed25519 signatures should decode to 64 bytes"),
+        );
+        let public_key_bytes = STANDARD
+            .decode(public_key.trim())
+            .expect("generated public keys should be valid base64");
+        let verifying_key = VerifyingKey::from_bytes(
+            &public_key_bytes
+                .try_into()
+                .expect("ed25519 public keys should decode to 32 bytes"),
+        )
+        .expect("public key bytes should decode into a verifying key");
+        verifying_key
+            .verify(b"hello signed release", &signature)
+            .expect("generated signature should verify against the generated public key");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_generation_requires_private_key_input() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("blinc_cli_release_manifest_missing_key_{nonce}"));
+        let artifact_path = root.join("dist/demo.zip");
+
+        fs::create_dir_all(
+            artifact_path
+                .parent()
+                .expect("artifact directory should exist"),
+        )
+        .expect("artifact directory should be created");
+        fs::write(&artifact_path, b"hello signed release").expect("artifact should be written");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: Some(artifact_path),
+            size: 0,
+            sha256: String::new(),
+            signature: String::new(),
+            private_key: None,
+            public_key_output: None,
+            output: root.join("dist/release-manifest.json"),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect_err("artifact-path mode should require a private key");
+
+        assert!(
+            err.to_string().contains("private key"),
+            "missing signing key errors should mention the private key requirement"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_generation_rejects_manual_metadata_with_artifact_path() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("blinc_cli_release_manifest_mixed_metadata_{nonce}"));
+        let artifact_path = root.join("dist/demo.zip");
+
+        fs::create_dir_all(
+            artifact_path
+                .parent()
+                .expect("artifact directory should exist"),
+        )
+        .expect("artifact directory should be created");
+        fs::write(&artifact_path, b"hello signed release").expect("artifact should be written");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: Some(artifact_path),
+            size: 12_345,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: Some("BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=".to_string()),
+            public_key_output: None,
+            output: root.join("dist/release-manifest.json"),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect_err("artifact-path mode should reject conflicting manual metadata");
+
+        assert!(
+            err.to_string().contains("artifact_path"),
+            "mixed-mode validation should mention artifact_path"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_generation_rejects_directory_artifact_path() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "blinc_cli_release_manifest_directory_artifact_{nonce}"
+        ));
+        let artifact_path = root.join("dist");
+
+        fs::create_dir_all(&artifact_path).expect("artifact directory should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: Some(artifact_path),
+            size: 0,
+            sha256: String::new(),
+            signature: String::new(),
+            private_key: Some("BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=".to_string()),
+            public_key_output: None,
+            output: root.join("dist/release-manifest.json"),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect_err("artifact-path mode should reject directory paths");
+
+        assert!(
+            err.to_string().contains("artifact_path"),
+            "artifact path validation should mention artifact_path"
         );
 
         let _ = fs::remove_dir_all(&root);
@@ -567,9 +992,12 @@ mod tests {
             platform: "macos".to_string(),
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: None,
             size: 12_345,
             sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-            signature: "c2ln".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: None,
+            public_key_output: None,
             output: root.join("dist/release-manifest.json"),
             published_at: "not-a-timestamp".to_string(),
             notes_url: None,
@@ -618,9 +1046,12 @@ mod tests {
             platform: "macos".to_string(),
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: None,
             size: 12_345,
             sha256: "not-hex".to_string(),
-            signature: "c2ln".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: None,
+            public_key_output: None,
             output: root.join("dist/release-manifest.json"),
             published_at: "2026-03-07T00:00:00Z".to_string(),
             notes_url: None,
@@ -670,9 +1101,12 @@ mod tests {
             platform: "macos".to_string(),
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: None,
             size: 12_345,
             sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
             signature: "not-base64!!!".to_string(),
+            private_key: None,
+            public_key_output: None,
             output: root.join("dist/release-manifest.json"),
             published_at: "2026-03-07T00:00:00Z".to_string(),
             notes_url: None,
@@ -682,6 +1116,60 @@ mod tests {
         assert!(
             err.to_string().contains("signature"),
             "signature validation error should mention signature"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_command_rejects_short_signature() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("blinc_cli_release_manifest_short_sig_{nonce}"));
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: None,
+            size: 12_345,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+            signature: "c2ln".to_string(),
+            private_key: None,
+            public_key_output: None,
+            output: root.join("dist/release-manifest.json"),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect_err("manual mode should reject base64 signatures with the wrong length");
+
+        assert!(
+            err.to_string().contains("signature"),
+            "signature length errors should mention signature"
         );
 
         let _ = fs::remove_dir_all(&root);
@@ -721,9 +1209,12 @@ mod tests {
             platform: "macos".to_string(),
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: None,
             size: 12_345,
             sha256: String::new(),
             signature: "c2ln".to_string(),
+            private_key: None,
+            public_key_output: None,
             output: root.join("dist/release-manifest.json"),
             published_at: "2026-03-07T00:00:00Z".to_string(),
             notes_url: None,
@@ -773,9 +1264,12 @@ mod tests {
             platform: "macos".to_string(),
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: None,
             size: 12_345,
             sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
             signature: String::new(),
+            private_key: None,
+            public_key_output: None,
             output: root.join("dist/release-manifest.json"),
             published_at: "2026-03-07T00:00:00Z".to_string(),
             notes_url: None,
@@ -826,9 +1320,12 @@ mod tests {
             platform: "macos".to_string(),
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: None,
             size: 12_345,
             sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-            signature: "c2ln".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: None,
+            public_key_output: None,
             output: output.clone(),
             published_at: "2026-03-07T00:00:00Z".to_string(),
             notes_url: None,

--- a/crates/blinc_cli/src/release.rs
+++ b/crates/blinc_cli/src/release.rs
@@ -43,11 +43,11 @@ struct ReleaseManifestArtifact {
 }
 
 pub(crate) fn load_release_project(path: &Path) -> Result<BlincProject> {
-    BlincProject::load_from_dir(path)
+    BlincProject::load_from_dir(release_project_root(path)?)
 }
 
 pub(crate) fn write_release_manifest(args: &ReleaseManifestArgs) -> Result<()> {
-    let project = load_release_project(release_project_root(&args.source)?)?;
+    let project = load_release_project(&args.source)?;
     let target_id = resolve_target_id(&project, &args.platform)?;
     let artifact = ReleaseManifestArtifact {
         platform: args.platform.clone(),
@@ -82,6 +82,11 @@ pub(crate) fn write_release_manifest(args: &ReleaseManifestArgs) -> Result<()> {
             _ => {}
         }
 
+        manifest.artifacts.retain(|existing| {
+            existing.platform != artifact.platform
+                || existing.arch != artifact.arch
+                || existing.target_id != artifact.target_id
+        });
         manifest.artifacts.push(artifact);
         manifest
     } else {
@@ -420,6 +425,85 @@ mod tests {
         assert_eq!(
             json["artifacts"][1]["platform"], "android",
             "second artifact should preserve its platform"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_command_replaces_existing_artifact_for_same_target() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir()
+            .join(format!("blinc_cli_release_manifest_replace_{nonce}"));
+        let output = root.join("dist/release-manifest.json");
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos-v1.zip".to_string(),
+            size: 12_345,
+            sha256: "deadbeef".to_string(),
+            signature: "c2ln".to_string(),
+            output: output.clone(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect("first manifest write should succeed");
+
+        write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos-v2.zip".to_string(),
+            size: 54_321,
+            sha256: "beadfeed".to_string(),
+            signature: "YWJj".to_string(),
+            output: output.clone(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect("second manifest write should replace the prior artifact");
+
+        let manifest = fs::read_to_string(&output).expect("manifest file should exist");
+        let json: Value = serde_json::from_str(&manifest).expect("manifest should be valid JSON");
+
+        assert_eq!(
+            json["artifacts"].as_array().map(Vec::len),
+            Some(1),
+            "rewriting the same artifact target should replace the prior entry"
+        );
+        assert_eq!(
+            json["artifacts"][0]["url"],
+            "https://example.com/releases/demo-1.2.3-macos-v2.zip",
+            "replacement artifact should keep the latest URL"
+        );
+        assert_eq!(
+            json["artifacts"][0]["size"], 54_321,
+            "replacement artifact should keep the latest size"
         );
 
         let _ = fs::remove_dir_all(&root);

--- a/crates/blinc_cli/src/release.rs
+++ b/crates/blinc_cli/src/release.rs
@@ -1,7 +1,10 @@
 use anyhow::{bail, Context, Result};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 use crate::config::BlincProject;
 
@@ -47,6 +50,8 @@ pub(crate) fn load_release_project(path: &Path) -> Result<BlincProject> {
 }
 
 pub(crate) fn write_release_manifest(args: &ReleaseManifestArgs) -> Result<()> {
+    validate_release_manifest_args(args)?;
+
     let project = load_release_project(&args.source)?;
     let target_id = resolve_target_id(&project, &args.platform)?;
     let artifact = ReleaseManifestArtifact {
@@ -109,6 +114,25 @@ pub(crate) fn write_release_manifest(args: &ReleaseManifestArgs) -> Result<()> {
         serde_json::to_string_pretty(&manifest).context("Failed to serialize release manifest")?;
     fs::write(&args.output, json)
         .with_context(|| format!("Failed to write {}", args.output.display()))?;
+
+    Ok(())
+}
+
+fn validate_release_manifest_args(args: &ReleaseManifestArgs) -> Result<()> {
+    OffsetDateTime::parse(&args.published_at, &Rfc3339)
+        .context("published_at must be a valid RFC 3339 timestamp")?;
+
+    if args.sha256.len() != 64 || !args.sha256.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        bail!("sha256 must be a 64-character hexadecimal digest");
+    }
+
+    if args.signature.is_empty() {
+        bail!("signature must be a non-empty base64 string");
+    }
+
+    STANDARD
+        .decode(&args.signature)
+        .context("signature must be a valid base64 string")?;
 
     Ok(())
 }
@@ -290,7 +314,7 @@ mod tests {
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
             size: 12_345,
-            sha256: "deadbeef".to_string(),
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
             signature: "c2ln".to_string(),
             output: output.clone(),
             published_at: "2026-03-07T00:00:00Z".to_string(),
@@ -343,7 +367,8 @@ mod tests {
             "manifest artifact should preserve size"
         );
         assert_eq!(
-            json["artifacts"][0]["sha256"], "deadbeef",
+            json["artifacts"][0]["sha256"],
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
             "manifest artifact should preserve sha256"
         );
         assert_eq!(
@@ -392,7 +417,7 @@ mod tests {
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
             size: 12_345,
-            sha256: "deadbeef".to_string(),
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
             signature: "c2ln".to_string(),
             output: output.clone(),
             published_at: "2026-03-07T00:00:00Z".to_string(),
@@ -406,7 +431,7 @@ mod tests {
             arch: "arm64-v8a".to_string(),
             url: "https://example.com/releases/demo-1.2.3.apk".to_string(),
             size: 67_890,
-            sha256: "beadfeed".to_string(),
+            sha256: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210".to_string(),
             signature: "YWJj".to_string(),
             output: output.clone(),
             published_at: "2026-03-07T00:00:00Z".to_string(),
@@ -436,8 +461,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("system time must be after epoch")
             .as_nanos();
-        let root = std::env::temp_dir()
-            .join(format!("blinc_cli_release_manifest_replace_{nonce}"));
+        let root = std::env::temp_dir().join(format!("blinc_cli_release_manifest_replace_{nonce}"));
         let output = root.join("dist/release-manifest.json");
 
         fs::create_dir_all(&root).expect("temp project root should be created");
@@ -466,7 +490,7 @@ mod tests {
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos-v1.zip".to_string(),
             size: 12_345,
-            sha256: "deadbeef".to_string(),
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
             signature: "c2ln".to_string(),
             output: output.clone(),
             published_at: "2026-03-07T00:00:00Z".to_string(),
@@ -480,7 +504,7 @@ mod tests {
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos-v2.zip".to_string(),
             size: 54_321,
-            sha256: "beadfeed".to_string(),
+            sha256: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210".to_string(),
             signature: "YWJj".to_string(),
             output: output.clone(),
             published_at: "2026-03-07T00:00:00Z".to_string(),
@@ -497,13 +521,270 @@ mod tests {
             "rewriting the same artifact target should replace the prior entry"
         );
         assert_eq!(
-            json["artifacts"][0]["url"],
-            "https://example.com/releases/demo-1.2.3-macos-v2.zip",
+            json["artifacts"][0]["url"], "https://example.com/releases/demo-1.2.3-macos-v2.zip",
             "replacement artifact should keep the latest URL"
         );
         assert_eq!(
             json["artifacts"][0]["size"], 54_321,
             "replacement artifact should keep the latest size"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_command_rejects_invalid_published_at() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "blinc_cli_release_manifest_invalid_timestamp_{nonce}"
+        ));
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            size: 12_345,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+            signature: "c2ln".to_string(),
+            output: root.join("dist/release-manifest.json"),
+            published_at: "not-a-timestamp".to_string(),
+            notes_url: None,
+        })
+        .expect_err("invalid RFC 3339 timestamps should be rejected");
+
+        assert!(
+            err.to_string().contains("published_at"),
+            "timestamp validation error should mention published_at"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_command_rejects_invalid_sha256() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("blinc_cli_release_manifest_invalid_sha_{nonce}"));
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            size: 12_345,
+            sha256: "not-hex".to_string(),
+            signature: "c2ln".to_string(),
+            output: root.join("dist/release-manifest.json"),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect_err("invalid sha256 values should be rejected");
+
+        assert!(
+            err.to_string().contains("sha256"),
+            "sha256 validation error should mention sha256"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_command_rejects_invalid_signature() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "blinc_cli_release_manifest_invalid_signature_{nonce}"
+        ));
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            size: 12_345,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+            signature: "not-base64!!!".to_string(),
+            output: root.join("dist/release-manifest.json"),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect_err("invalid signatures should be rejected");
+
+        assert!(
+            err.to_string().contains("signature"),
+            "signature validation error should mention signature"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_command_rejects_empty_sha256() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("blinc_cli_release_manifest_empty_sha_{nonce}"));
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            size: 12_345,
+            sha256: String::new(),
+            signature: "c2ln".to_string(),
+            output: root.join("dist/release-manifest.json"),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect_err("empty sha256 values should be rejected");
+
+        assert!(
+            err.to_string().contains("sha256"),
+            "sha256 validation error should mention sha256"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_command_rejects_empty_signature() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "blinc_cli_release_manifest_empty_signature_{nonce}"
+        ));
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            size: 12_345,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+            signature: String::new(),
+            output: root.join("dist/release-manifest.json"),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect_err("empty signature values should be rejected");
+
+        assert!(
+            err.to_string().contains("signature"),
+            "signature validation error should mention signature"
         );
 
         let _ = fs::remove_dir_all(&root);
@@ -546,7 +827,7 @@ mod tests {
             arch: "universal".to_string(),
             url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
             size: 12_345,
-            sha256: "deadbeef".to_string(),
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
             signature: "c2ln".to_string(),
             output: output.clone(),
             published_at: "2026-03-07T00:00:00Z".to_string(),

--- a/crates/blinc_cli/src/release.rs
+++ b/crates/blinc_cli/src/release.rs
@@ -1,16 +1,151 @@
-use anyhow::Result;
-use std::path::Path;
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use crate::config::BlincProject;
+
+#[derive(Debug)]
+pub(crate) struct ReleaseManifestArgs {
+    pub source: PathBuf,
+    pub platform: String,
+    pub arch: String,
+    pub url: String,
+    pub size: u64,
+    pub sha256: String,
+    pub signature: String,
+    pub output: PathBuf,
+    pub published_at: String,
+    pub notes_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ReleaseManifestDocument {
+    schema_version: u32,
+    product: String,
+    channel: crate::config::ReleaseChannel,
+    version: String,
+    published_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    notes_url: Option<String>,
+    artifacts: Vec<ReleaseManifestArtifact>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ReleaseManifestArtifact {
+    platform: String,
+    arch: String,
+    target_id: String,
+    url: String,
+    size: u64,
+    sha256: String,
+    signature: String,
+}
 
 pub(crate) fn load_release_project(path: &Path) -> Result<BlincProject> {
     BlincProject::load_from_dir(path)
 }
 
+pub(crate) fn write_release_manifest(args: &ReleaseManifestArgs) -> Result<()> {
+    let project = load_release_project(release_project_root(&args.source)?)?;
+    let target_id = resolve_target_id(&project, &args.platform)?;
+    let artifact = ReleaseManifestArtifact {
+        platform: args.platform.clone(),
+        arch: args.arch.clone(),
+        target_id,
+        url: args.url.clone(),
+        size: args.size,
+        sha256: args.sha256.clone(),
+        signature: args.signature.clone(),
+    };
+
+    let manifest = if args.output.exists() {
+        let existing = fs::read_to_string(&args.output)
+            .with_context(|| format!("Failed to read {}", args.output.display()))?;
+        let mut manifest: ReleaseManifestDocument =
+            serde_json::from_str(&existing).context("Failed to parse existing release manifest")?;
+
+        if manifest.schema_version != 1
+            || manifest.product != project.project.name
+            || manifest.channel != project.updates.channel
+            || manifest.version != project.project.version
+            || manifest.published_at != args.published_at
+        {
+            bail!("Existing release manifest metadata does not match this artifact");
+        }
+
+        match (&mut manifest.notes_url, &args.notes_url) {
+            (slot @ None, Some(notes_url)) => *slot = Some(notes_url.clone()),
+            (Some(existing), Some(notes_url)) if existing != notes_url => {
+                bail!("Existing release manifest notes_url does not match this artifact")
+            }
+            _ => {}
+        }
+
+        manifest.artifacts.push(artifact);
+        manifest
+    } else {
+        ReleaseManifestDocument {
+            schema_version: 1,
+            product: project.project.name.clone(),
+            channel: project.updates.channel,
+            version: project.project.version.clone(),
+            published_at: args.published_at.clone(),
+            notes_url: args.notes_url.clone(),
+            artifacts: vec![artifact],
+        }
+    };
+
+    if let Some(parent) = args.output.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let json =
+        serde_json::to_string_pretty(&manifest).context("Failed to serialize release manifest")?;
+    fs::write(&args.output, json)
+        .with_context(|| format!("Failed to write {}", args.output.display()))?;
+
+    Ok(())
+}
+
+fn release_project_root(path: &Path) -> Result<&Path> {
+    let start = if path.is_file() {
+        path.parent().unwrap_or(path)
+    } else {
+        path
+    };
+
+    start
+        .ancestors()
+        .find(|candidate| candidate.join(".blincproj").exists())
+        .context("No .blincproj found for the provided release source path")
+}
+
+fn resolve_target_id(project: &BlincProject, platform: &str) -> Result<String> {
+    match platform {
+        "android" => project
+            .platforms
+            .android
+            .as_ref()
+            .map(|android| android.package.clone())
+            .context("Android release manifests require platforms.android.package"),
+        "macos" => project
+            .platforms
+            .macos
+            .as_ref()
+            .map(|macos| macos.bundle_id.clone())
+            .context("macOS release manifests require platforms.macos.bundle_id"),
+        unsupported => bail!(
+            "Unsupported release manifest platform '{}'. Supported platforms: android, macos",
+            unsupported
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use serde_json::Value;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -110,6 +245,236 @@ mod tests {
                 .and_then(|wasm| wasm.base_url.as_deref()),
             Some("/demo/"),
             "release loader should preserve WASM metadata"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_command_writes_manifest_json() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_release_manifest_{nonce}"));
+        let output = root.join("dist/release-manifest.json");
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            size: 12_345,
+            sha256: "deadbeef".to_string(),
+            signature: "c2ln".to_string(),
+            output: output.clone(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: Some("https://example.com/releases/1.2.3".to_string()),
+        })
+        .expect("release manifest command should write manifest JSON");
+
+        let manifest = fs::read_to_string(&output).expect("manifest file should exist");
+        let json: Value = serde_json::from_str(&manifest).expect("manifest should be valid JSON");
+
+        assert_eq!(
+            json["schema_version"], 1,
+            "manifest should use schema version 1"
+        );
+        assert_eq!(json["product"], "Demo", "manifest should use project name");
+        assert_eq!(
+            json["channel"], "stable",
+            "manifest should serialize release channel"
+        );
+        assert_eq!(
+            json["version"], "1.2.3",
+            "manifest should use project version"
+        );
+        assert_eq!(
+            json["published_at"], "2026-03-07T00:00:00Z",
+            "manifest should preserve publish timestamp"
+        );
+        assert_eq!(
+            json["notes_url"], "https://example.com/releases/1.2.3",
+            "manifest should preserve release notes URL"
+        );
+        assert_eq!(
+            json["artifacts"][0]["target_id"], "io.test.demo",
+            "manifest artifact should use canonical platform target identity"
+        );
+        assert_eq!(
+            json["artifacts"][0]["platform"], "macos",
+            "manifest artifact should preserve platform"
+        );
+        assert_eq!(
+            json["artifacts"][0]["arch"], "universal",
+            "manifest artifact should preserve architecture"
+        );
+        assert_eq!(
+            json["artifacts"][0]["url"], "https://example.com/releases/demo-1.2.3-macos.zip",
+            "manifest artifact should preserve URL"
+        );
+        assert_eq!(
+            json["artifacts"][0]["size"], 12_345,
+            "manifest artifact should preserve size"
+        );
+        assert_eq!(
+            json["artifacts"][0]["sha256"], "deadbeef",
+            "manifest artifact should preserve sha256"
+        );
+        assert_eq!(
+            json["artifacts"][0]["signature"], "c2ln",
+            "manifest artifact should preserve signature"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_command_appends_artifacts_for_multiple_platforms() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_release_manifest_append_{nonce}"));
+        let output = root.join("dist/release-manifest.json");
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.android]
+                package = "io.test.demo"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            size: 12_345,
+            sha256: "deadbeef".to_string(),
+            signature: "c2ln".to_string(),
+            output: output.clone(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect("first manifest write should succeed");
+
+        write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "android".to_string(),
+            arch: "arm64-v8a".to_string(),
+            url: "https://example.com/releases/demo-1.2.3.apk".to_string(),
+            size: 67_890,
+            sha256: "beadfeed".to_string(),
+            signature: "YWJj".to_string(),
+            output: output.clone(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect("second manifest write should append another artifact");
+
+        let manifest = fs::read_to_string(&output).expect("manifest file should exist");
+        let json: Value = serde_json::from_str(&manifest).expect("manifest should be valid JSON");
+
+        assert_eq!(
+            json["artifacts"].as_array().map(Vec::len),
+            Some(2),
+            "manifest command should accumulate multiple artifacts in one file"
+        );
+        assert_eq!(
+            json["artifacts"][1]["platform"], "android",
+            "second artifact should preserve its platform"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_command_accepts_source_file_input() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_release_manifest_source_{nonce}"));
+        let source_file = root.join("src/main.blinc");
+        let output = root.join("dist/release-manifest.json");
+
+        fs::create_dir_all(root.join("src")).expect("temp source directory should be created");
+        fs::write(&source_file, "App {}").expect("source file should be written");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        write_release_manifest(&ReleaseManifestArgs {
+            source: source_file,
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            size: 12_345,
+            sha256: "deadbeef".to_string(),
+            signature: "c2ln".to_string(),
+            output: output.clone(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect("source-file inputs should resolve to the project root");
+
+        let manifest = fs::read_to_string(&output).expect("manifest file should exist");
+        let json: Value = serde_json::from_str(&manifest).expect("manifest should be valid JSON");
+        assert_eq!(
+            json["artifacts"][0]["target_id"], "io.test.demo",
+            "source-file inputs should still resolve canonical target identity"
         );
 
         let _ = fs::remove_dir_all(&root);

--- a/crates/blinc_cli/src/release.rs
+++ b/crates/blinc_cli/src/release.rs
@@ -101,6 +101,10 @@ pub(crate) fn write_release_manifest(args: &ReleaseManifestArgs) -> Result<()> {
         fs::create_dir_all(parent)?;
     }
 
+    manifest
+        .validate()
+        .context("generated release manifest failed validation")?;
+
     let json =
         serde_json::to_string_pretty(&manifest).context("Failed to serialize release manifest")?;
     fs::write(&args.output, json)
@@ -131,31 +135,33 @@ fn validate_release_manifest_args(args: &ReleaseManifestArgs) -> Result<()> {
         {
             bail!("artifact_path requires a private key via --private-key or BLINC_RELEASE_PRIVATE_KEY");
         }
+    } else {
+        if args.size == 0 && args.sha256.is_empty() && args.signature.is_empty() {
+            bail!(
+                "manual manifest mode requires size, sha256, and signature, or use --artifact-path"
+            );
+        }
 
-        return Ok(());
+        if args
+            .private_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|key| !key.is_empty())
+            .is_some()
+            || args.public_key_output.is_some()
+        {
+            bail!("--private-key and --public-key-output require --artifact-path");
+        }
+
+        if args.size == 0 {
+            bail!("size must be greater than zero");
+        }
+
+        validate_sha256(&args.sha256)?;
+        validate_signature(&args.signature)?;
     }
 
-    if args.size == 0 && args.sha256.is_empty() && args.signature.is_empty() {
-        bail!("manual manifest mode requires size, sha256, and signature, or use --artifact-path");
-    }
-
-    if args
-        .private_key
-        .as_deref()
-        .map(str::trim)
-        .filter(|key| !key.is_empty())
-        .is_some()
-        || args.public_key_output.is_some()
-    {
-        bail!("--private-key and --public-key-output require --artifact-path");
-    }
-
-    if args.size == 0 {
-        bail!("size must be greater than zero");
-    }
-
-    validate_sha256(&args.sha256)?;
-    validate_signature(&args.signature)
+    Ok(())
 }
 
 fn normalize_published_at(published_at: &str) -> Result<String> {
@@ -1690,6 +1696,66 @@ mod tests {
         assert!(
             err.to_string().contains("public_key_output"),
             "key rotation errors should point at the emitted public key contract"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_generation_rejects_blank_target_id_before_writing() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("blinc_cli_release_manifest_blank_target_{nonce}"));
+        let output = root.join("dist/release-manifest.json");
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = ""
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: None,
+            size: 12_345,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: None,
+            public_key_output: None,
+            output: output.clone(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect_err("manifest generation should reject blank target identities before writing");
+
+        assert!(
+            err.to_string()
+                .contains("generated release manifest failed validation"),
+            "validation errors should surface manifest validation before writing"
+        );
+        assert!(
+            !output.exists(),
+            "invalid manifest metadata should not be written to disk"
         );
 
         let _ = fs::remove_dir_all(&root);

--- a/crates/blinc_cli/src/release.rs
+++ b/crates/blinc_cli/src/release.rs
@@ -154,7 +154,7 @@ fn validate_release_manifest_args(args: &ReleaseManifestArgs) -> Result<()> {
         }
 
         if args.size == 0 {
-            bail!("size must be greater than zero");
+            bail!("--size is required and must be greater than zero in manual mode");
         }
 
         validate_sha256(&args.sha256)?;
@@ -230,6 +230,8 @@ fn write_public_key(path: &Path, signing_key: &SigningKey) -> Result<()> {
             bail!(
                 "public_key_output already contains a different public key; reuse the same signing key for every artifact in this release"
             );
+        } else {
+            return Ok(());
         }
     }
 
@@ -1756,6 +1758,60 @@ mod tests {
         assert!(
             !output.exists(),
             "invalid manifest metadata should not be written to disk"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_generation_requires_size_in_manual_mode() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_release_manifest_size_{nonce}"));
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: None,
+            size: 0,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: None,
+            public_key_output: None,
+            output: root.join("dist/release-manifest.json"),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect_err("manual mode should require an explicit non-zero size");
+
+        assert!(
+            err.to_string()
+                .contains("--size is required and must be greater than zero in manual mode"),
+            "manual mode should direct the caller to the missing --size argument"
         );
 
         let _ = fs::remove_dir_all(&root);

--- a/crates/blinc_cli/src/release.rs
+++ b/crates/blinc_cli/src/release.rs
@@ -1,0 +1,117 @@
+use anyhow::Result;
+use std::path::Path;
+
+use crate::config::BlincProject;
+
+pub(crate) fn load_release_project(path: &Path) -> Result<BlincProject> {
+    BlincProject::load_from_dir(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn release_loader_preserves_updates_and_non_legacy_platforms() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_release_loader_{nonce}"));
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "0.1.0"
+
+                [platforms.android]
+                package = "io.test.demo"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [platforms.windows]
+                product_name = "Demo"
+                company = "Blinc Labs"
+
+                [platforms.linux]
+                desktop_name = "Demo"
+                categories = ["Utility", "Development"]
+
+                [platforms.wasm]
+                base_url = "/demo/"
+                canvas_id = "demo-canvas"
+                pwa = true
+                gpu_backend = "webgpu"
+                dev_port = 9000
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/manifest.json"
+                public_key = "abc"
+
+                [updates.desktop]
+                enabled = true
+                restart_strategy = "prompt"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let project =
+            load_release_project(&root).expect("release loader should keep full project metadata");
+
+        assert!(
+            project.updates.enabled,
+            "release loader should preserve updates"
+        );
+        assert_eq!(
+            project.updates.manifest_url.as_deref(),
+            Some("https://example.com/manifest.json"),
+            "release loader should preserve updater manifest URL"
+        );
+        assert_eq!(
+            project
+                .platforms
+                .macos
+                .as_ref()
+                .map(|macos| macos.bundle_id.as_str()),
+            Some("io.test.demo"),
+            "release loader should preserve macOS metadata"
+        );
+        assert_eq!(
+            project
+                .platforms
+                .windows
+                .as_ref()
+                .and_then(|windows| windows.company.as_deref()),
+            Some("Blinc Labs"),
+            "release loader should preserve Windows metadata"
+        );
+        assert_eq!(
+            project
+                .platforms
+                .linux
+                .as_ref()
+                .map(|linux| linux.categories.clone()),
+            Some(vec!["Utility".to_string(), "Development".to_string()]),
+            "release loader should preserve Linux metadata"
+        );
+        assert_eq!(
+            project
+                .platforms
+                .wasm
+                .as_ref()
+                .and_then(|wasm| wasm.base_url.as_deref()),
+            Some("/demo/"),
+            "release loader should preserve WASM metadata"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+}

--- a/crates/blinc_cli/src/release.rs
+++ b/crates/blinc_cli/src/release.rs
@@ -1,7 +1,10 @@
 use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
+use blinc_update::{
+    ReleaseArtifact, ReleaseChannel as UpdateReleaseChannel, ReleaseManifest,
+    RELEASE_MANIFEST_SCHEMA_VERSION,
+};
 use ed25519_dalek::{Signer, SigningKey};
-use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fmt::Write as _;
 use std::fs;
@@ -28,40 +31,18 @@ pub(crate) struct ReleaseManifestArgs {
     pub notes_url: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-struct ReleaseManifestDocument {
-    schema_version: u32,
-    product: String,
-    channel: crate::config::ReleaseChannel,
-    version: String,
-    published_at: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    notes_url: Option<String>,
-    artifacts: Vec<ReleaseManifestArtifact>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct ReleaseManifestArtifact {
-    platform: String,
-    arch: String,
-    target_id: String,
-    url: String,
-    size: u64,
-    sha256: String,
-    signature: String,
-}
-
 pub(crate) fn load_release_project(path: &Path) -> Result<BlincProject> {
     BlincProject::load_from_dir(release_project_root(path)?)
 }
 
 pub(crate) fn write_release_manifest(args: &ReleaseManifestArgs) -> Result<()> {
     validate_release_manifest_args(args)?;
+    let published_at = normalize_published_at(&args.published_at)?;
 
     let project = load_release_project(&args.source)?;
     let target_id = resolve_target_id(&project, &args.platform)?;
     let metadata = resolve_artifact_metadata(args)?;
-    let artifact = ReleaseManifestArtifact {
+    let artifact = ReleaseArtifact {
         platform: args.platform.clone(),
         arch: args.arch.clone(),
         target_id,
@@ -74,18 +55,21 @@ pub(crate) fn write_release_manifest(args: &ReleaseManifestArgs) -> Result<()> {
     let manifest = if args.output.exists() {
         let existing = fs::read_to_string(&args.output)
             .with_context(|| format!("Failed to read {}", args.output.display()))?;
-        let mut manifest: ReleaseManifestDocument =
+        let mut manifest: ReleaseManifest =
             serde_json::from_str(&existing).context("Failed to parse existing release manifest")?;
+        let existing_published_at = normalize_published_at(&manifest.published_at)
+            .context("existing release manifest published_at must be a valid RFC 3339 timestamp")?;
 
-        if manifest.schema_version != 1
+        if manifest.schema_version != RELEASE_MANIFEST_SCHEMA_VERSION
             || manifest.product != project.project.name
-            || manifest.channel != project.updates.channel
+            || manifest.channel != update_release_channel(project.updates.channel)
             || manifest.version != project.project.version
-            || manifest.published_at != args.published_at
+            || existing_published_at != published_at
         {
             bail!("Existing release manifest metadata does not match this artifact");
         }
 
+        manifest.published_at = published_at.clone();
         match (&mut manifest.notes_url, &args.notes_url) {
             (slot @ None, Some(notes_url)) => *slot = Some(notes_url.clone()),
             (Some(existing), Some(notes_url)) if existing != notes_url => {
@@ -102,12 +86,12 @@ pub(crate) fn write_release_manifest(args: &ReleaseManifestArgs) -> Result<()> {
         manifest.artifacts.push(artifact);
         manifest
     } else {
-        ReleaseManifestDocument {
-            schema_version: 1,
+        ReleaseManifest {
+            schema_version: RELEASE_MANIFEST_SCHEMA_VERSION,
             product: project.project.name.clone(),
-            channel: project.updates.channel,
+            channel: update_release_channel(project.updates.channel),
             version: project.project.version.clone(),
-            published_at: args.published_at.clone(),
+            published_at,
             notes_url: args.notes_url.clone(),
             artifacts: vec![artifact],
         }
@@ -126,8 +110,7 @@ pub(crate) fn write_release_manifest(args: &ReleaseManifestArgs) -> Result<()> {
 }
 
 fn validate_release_manifest_args(args: &ReleaseManifestArgs) -> Result<()> {
-    OffsetDateTime::parse(&args.published_at, &Rfc3339)
-        .context("published_at must be a valid RFC 3339 timestamp")?;
+    normalize_published_at(&args.published_at)?;
 
     if let Some(artifact_path) = &args.artifact_path {
         if args.size != 0 || !args.sha256.is_empty() || !args.signature.is_empty() {
@@ -156,12 +139,31 @@ fn validate_release_manifest_args(args: &ReleaseManifestArgs) -> Result<()> {
         bail!("manual manifest mode requires size, sha256, and signature, or use --artifact-path");
     }
 
+    if args
+        .private_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .is_some()
+        || args.public_key_output.is_some()
+    {
+        bail!("--private-key and --public-key-output require --artifact-path");
+    }
+
     if args.size == 0 {
         bail!("size must be greater than zero");
     }
 
     validate_sha256(&args.sha256)?;
     validate_signature(&args.signature)
+}
+
+fn normalize_published_at(published_at: &str) -> Result<String> {
+    let parsed = OffsetDateTime::parse(published_at, &Rfc3339)
+        .context("published_at must be a valid RFC 3339 timestamp")?;
+    parsed
+        .format(&Rfc3339)
+        .context("published_at must be a valid RFC 3339 timestamp")
 }
 
 fn resolve_artifact_metadata(args: &ReleaseManifestArgs) -> Result<ResolvedArtifactMetadata> {
@@ -213,15 +215,24 @@ fn load_signing_key(args: &ReleaseManifestArgs) -> Result<SigningKey> {
 }
 
 fn write_public_key(path: &Path, signing_key: &SigningKey) -> Result<()> {
+    let encoded_public_key = STANDARD.encode(signing_key.verifying_key().to_bytes());
+
+    if path.exists() {
+        let existing = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        if existing.trim() != encoded_public_key {
+            bail!(
+                "public_key_output already contains a different public key; reuse the same signing key for every artifact in this release"
+            );
+        }
+    }
+
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
 
-    fs::write(
-        path,
-        STANDARD.encode(signing_key.verifying_key().to_bytes()),
-    )
-    .with_context(|| format!("Failed to write {}", path.display()))?;
+    fs::write(path, encoded_public_key)
+        .with_context(|| format!("Failed to write {}", path.display()))?;
     Ok(())
 }
 
@@ -296,9 +307,21 @@ fn resolve_target_id(project: &BlincProject, platform: &str) -> Result<String> {
     }
 }
 
+fn update_release_channel(channel: crate::config::ReleaseChannel) -> UpdateReleaseChannel {
+    match channel {
+        crate::config::ReleaseChannel::Stable => UpdateReleaseChannel::Stable,
+        crate::config::ReleaseChannel::Beta => UpdateReleaseChannel::Beta,
+        crate::config::ReleaseChannel::Canary => UpdateReleaseChannel::Canary,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use blinc_update::{
+        verify_artifact_bytes, ReleaseManifest as UpdateReleaseManifest,
+        RELEASE_MANIFEST_SCHEMA_VERSION,
+    };
     use ed25519_dalek::{Signature, Verifier, VerifyingKey};
     use serde_json::Value;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -458,8 +481,8 @@ mod tests {
         let json: Value = serde_json::from_str(&manifest).expect("manifest should be valid JSON");
 
         assert_eq!(
-            json["schema_version"], 1,
-            "manifest should use schema version 1"
+            json["schema_version"], RELEASE_MANIFEST_SCHEMA_VERSION,
+            "manifest should use the shared updater schema version"
         );
         assert_eq!(json["product"], "Demo", "manifest should use project name");
         assert_eq!(
@@ -588,6 +611,98 @@ mod tests {
         assert_eq!(
             json["artifacts"][1]["platform"], "android",
             "second artifact should preserve its platform"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_command_accepts_equivalent_existing_published_at_formats() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("blinc_cli_release_manifest_timestamp_{nonce}"));
+        let output = root.join("dist/release-manifest.json");
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.android]
+                package = "io.test.demo"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        fs::create_dir_all(output.parent().expect("output should have a parent"))
+            .expect("manifest parent should be created");
+        fs::write(
+            &output,
+            format!(
+                r#"{{
+  "schema_version": {RELEASE_MANIFEST_SCHEMA_VERSION},
+  "product": "Demo",
+  "channel": "stable",
+  "version": "1.2.3",
+  "published_at": "2026-03-07T00:00:00+00:00",
+  "artifacts": [
+    {{
+      "platform": "macos",
+      "arch": "universal",
+      "target_id": "io.test.demo",
+      "url": "https://example.com/releases/demo-1.2.3-macos.zip",
+      "size": 12345,
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "signature": "{VALID_SIGNATURE}"
+    }}
+  ]
+}}"#
+            ),
+        )
+        .expect("existing manifest should be written");
+
+        write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "android".to_string(),
+            arch: "arm64-v8a".to_string(),
+            url: "https://example.com/releases/demo-1.2.3.apk".to_string(),
+            artifact_path: None,
+            size: 54_321,
+            sha256: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: None,
+            public_key_output: None,
+            output: output.clone(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect("equivalent RFC 3339 timestamps should append successfully");
+
+        let manifest = fs::read_to_string(&output).expect("manifest file should exist");
+        let json: Value = serde_json::from_str(&manifest).expect("manifest should be valid JSON");
+        assert_eq!(
+            json["published_at"], "2026-03-07T00:00:00Z",
+            "append flow should rewrite equivalent timestamps into the canonical manifest form"
+        );
+        assert_eq!(
+            json["artifacts"].as_array().map(Vec::len),
+            Some(2),
+            "append flow should preserve the existing artifact and add the new one"
         );
 
         let _ = fs::remove_dir_all(&root);
@@ -896,6 +1011,61 @@ mod tests {
         assert!(
             err.to_string().contains("artifact_path"),
             "mixed-mode validation should mention artifact_path"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_generation_rejects_signing_flags_in_manual_mode() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "blinc_cli_release_manifest_manual_signing_flags_{nonce}"
+        ));
+
+        fs::create_dir_all(&root).expect("temp project root should be created");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/demo-1.2.3-macos.zip".to_string(),
+            artifact_path: None,
+            size: 12_345,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+            signature: VALID_SIGNATURE.to_string(),
+            private_key: Some(STANDARD.encode([7u8; 32])),
+            public_key_output: Some(root.join("dist/public-key.txt")),
+            output: root.join("dist/release-manifest.json"),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect_err("manual mode should reject signing-only flags that it does not use");
+
+        assert!(
+            err.to_string().contains("--artifact-path"),
+            "manual mode signing flag errors should explain that --artifact-path is required"
         );
 
         let _ = fs::remove_dir_all(&root);
@@ -1337,6 +1507,189 @@ mod tests {
         assert_eq!(
             json["artifacts"][0]["target_id"], "io.test.demo",
             "source-file inputs should still resolve canonical target identity"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn generated_manifest_round_trips_into_update_domain() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("blinc_cli_release_roundtrip_{nonce}"));
+        let dist = root.join("dist");
+        let manifest_path = dist.join("release-manifest.json");
+        let public_key_path = dist.join("public-key.txt");
+        let macos_artifact_path = dist.join("Demo.zip");
+        let android_artifact_path = dist.join("Demo.apk");
+        let macos_bytes = b"macos signed release".to_vec();
+        let android_bytes = b"android signed release".to_vec();
+
+        fs::create_dir_all(&dist).expect("dist directory should be created");
+        fs::write(&macos_artifact_path, &macos_bytes).expect("macOS artifact should be written");
+        fs::write(&android_artifact_path, &android_bytes)
+            .expect("Android artifact should be written");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.android]
+                package = "io.test.demo"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/release-manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/Demo.zip".to_string(),
+            artifact_path: Some(macos_artifact_path.clone()),
+            size: 0,
+            sha256: String::new(),
+            signature: String::new(),
+            private_key: Some("BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=".to_string()),
+            public_key_output: Some(public_key_path.clone()),
+            output: manifest_path.clone(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect("macOS artifact should be added to the manifest");
+
+        write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "android".to_string(),
+            arch: "arm64-v8a".to_string(),
+            url: "https://example.com/releases/Demo.apk".to_string(),
+            artifact_path: Some(android_artifact_path.clone()),
+            size: 0,
+            sha256: String::new(),
+            signature: String::new(),
+            private_key: Some("BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=".to_string()),
+            public_key_output: Some(public_key_path.clone()),
+            output: manifest_path.clone(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect("Android artifact should be added to the manifest");
+
+        let manifest_json =
+            fs::read_to_string(&manifest_path).expect("release manifest should be written");
+        let manifest: UpdateReleaseManifest =
+            serde_json::from_str(&manifest_json).expect("manifest should parse into blinc_update");
+        manifest
+            .validate()
+            .expect("shared update domain should validate the generated manifest");
+
+        let public_key =
+            fs::read_to_string(&public_key_path).expect("public key output should be written");
+        let macos_artifact = manifest
+            .select_artifact("macos", "universal", "io.test.demo")
+            .expect("shared domain should select the macOS artifact");
+        let android_artifact = manifest
+            .select_artifact("android", "arm64-v8a", "io.test.demo")
+            .expect("shared domain should select the Android artifact");
+
+        verify_artifact_bytes(&macos_bytes, macos_artifact, public_key.trim())
+            .expect("shared verifier should accept the generated macOS artifact");
+        verify_artifact_bytes(&android_bytes, android_artifact, public_key.trim())
+            .expect("shared verifier should accept the generated Android artifact");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn release_manifest_generation_rejects_public_key_output_key_rotation() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("blinc_cli_release_manifest_key_rotation_{nonce}"));
+        let dist = root.join("dist");
+        let manifest_path = dist.join("release-manifest.json");
+        let public_key_path = dist.join("public-key.txt");
+        let macos_artifact_path = dist.join("Demo.zip");
+        let android_artifact_path = dist.join("Demo.apk");
+
+        fs::create_dir_all(&dist).expect("dist directory should be created");
+        fs::write(&macos_artifact_path, b"macos signed release")
+            .expect("macOS artifact should be written");
+        fs::write(&android_artifact_path, b"android signed release")
+            .expect("Android artifact should be written");
+        fs::write(
+            root.join(".blincproj"),
+            r#"
+                [project]
+                name = "Demo"
+                version = "1.2.3"
+
+                [platforms.android]
+                package = "io.test.demo"
+
+                [platforms.macos]
+                bundle_id = "io.test.demo"
+
+                [updates]
+                enabled = true
+                channel = "stable"
+                manifest_url = "https://example.com/releases/release-manifest.json"
+                public_key = "abc"
+            "#,
+        )
+        .expect(".blincproj should be written");
+
+        write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            url: "https://example.com/releases/Demo.zip".to_string(),
+            artifact_path: Some(macos_artifact_path),
+            size: 0,
+            sha256: String::new(),
+            signature: String::new(),
+            private_key: Some(STANDARD.encode([7u8; 32])),
+            public_key_output: Some(public_key_path.clone()),
+            output: manifest_path.clone(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect("first artifact should write the baseline public key");
+
+        let err = write_release_manifest(&ReleaseManifestArgs {
+            source: root.clone(),
+            platform: "android".to_string(),
+            arch: "arm64-v8a".to_string(),
+            url: "https://example.com/releases/Demo.apk".to_string(),
+            artifact_path: Some(android_artifact_path),
+            size: 0,
+            sha256: String::new(),
+            signature: String::new(),
+            private_key: Some(STANDARD.encode([8u8; 32])),
+            public_key_output: Some(public_key_path.clone()),
+            output: manifest_path,
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+        })
+        .expect_err("appending artifacts should reject rotating the emitted public key");
+
+        assert!(
+            err.to_string().contains("public_key_output"),
+            "key rotation errors should point at the emitted public key contract"
         );
 
         let _ = fs::remove_dir_all(&root);

--- a/crates/blinc_update/Cargo.toml
+++ b/crates/blinc_update/Cargo.toml
@@ -7,5 +7,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+base64 = "0.22"
+ed25519-dalek = "2.2"
 serde.workspace = true
+sha2 = "0.10"
 thiserror.workspace = true

--- a/crates/blinc_update/Cargo.toml
+++ b/crates/blinc_update/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "blinc_update"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true

--- a/crates/blinc_update/src/error.rs
+++ b/crates/blinc_update/src/error.rs
@@ -1,9 +1,13 @@
+use std::path::PathBuf;
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ManifestError {
     #[error("manifest artifact at index {index} is missing target_id")]
     MissingTargetId { index: usize },
+    #[error("manifest artifact at index {index} is missing {field}")]
+    MissingArtifactMetadata { index: usize, field: &'static str },
 }
 
 #[derive(Debug, Error)]
@@ -18,6 +22,26 @@ pub enum UpdateError {
     Manifest(#[from] ManifestError),
     #[error(transparent)]
     Version(#[from] VersionError),
+    #[error("failed to read artifact '{path}': {source}")]
+    ArtifactRead {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("artifact checksum mismatch")]
+    ChecksumMismatch,
+    #[error("artifact sha256 must be a 64-character hexadecimal digest")]
+    InvalidSha256,
+    #[error("artifact signature must be valid base64")]
+    InvalidSignatureEncoding,
+    #[error("artifact signature must decode to 64 bytes")]
+    InvalidSignatureLength,
+    #[error("public key must be valid base64")]
+    InvalidPublicKeyEncoding,
+    #[error("public key must decode to 32 bytes")]
+    InvalidPublicKeyLength,
+    #[error("artifact signature verification failed")]
+    SignatureMismatch,
     #[error("{0}")]
     Backend(String),
 }

--- a/crates/blinc_update/src/error.rs
+++ b/crates/blinc_update/src/error.rs
@@ -1,0 +1,23 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ManifestError {
+    #[error("manifest artifact at index {index} is missing target_id")]
+    MissingTargetId { index: usize },
+}
+
+#[derive(Debug, Error)]
+pub enum VersionError {
+    #[error("invalid version '{0}'")]
+    InvalidVersion(String),
+}
+
+#[derive(Debug, Error)]
+pub enum UpdateError {
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
+    #[error(transparent)]
+    Version(#[from] VersionError),
+    #[error("{0}")]
+    Backend(String),
+}

--- a/crates/blinc_update/src/lib.rs
+++ b/crates/blinc_update/src/lib.rs
@@ -5,7 +5,9 @@ pub mod verify;
 pub mod version;
 
 pub use error::{ManifestError, UpdateError, VersionError};
-pub use manifest::{ReleaseArtifact, ReleaseChannel, ReleaseManifest};
+pub use manifest::{
+    ReleaseArtifact, ReleaseChannel, ReleaseManifest, RELEASE_MANIFEST_SCHEMA_VERSION,
+};
 pub use service::{InstallHandoff, InstallIntent, UpdateBackend, UpdateCheckRequest, UpdateState};
 pub use verify::{verify_artifact_bytes, verify_artifact_file};
 pub use version::is_newer_release;

--- a/crates/blinc_update/src/lib.rs
+++ b/crates/blinc_update/src/lib.rs
@@ -96,4 +96,18 @@ mod tests {
             "prerelease should not be considered newer than stable release"
         );
     }
+
+    #[test]
+    fn version_check_ignores_build_metadata() {
+        assert!(
+            is_newer_release("1.2.3", "1.2.4+build.1")
+                .expect("build metadata should not invalidate candidate versions"),
+            "newer versions with build metadata should still compare correctly"
+        );
+        assert!(
+            !is_newer_release("1.2.3+build.1", "1.2.3")
+                .expect("build metadata should be ignored during precedence checks"),
+            "build metadata alone should not make a version newer"
+        );
+    }
 }

--- a/crates/blinc_update/src/lib.rs
+++ b/crates/blinc_update/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod error;
 pub mod manifest;
 pub mod service;
+pub mod verify;
 pub mod version;
 
 pub use error::{ManifestError, UpdateError, VersionError};
 pub use manifest::{ReleaseArtifact, ReleaseChannel, ReleaseManifest};
 pub use service::{InstallIntent, UpdateBackend, UpdateCheckRequest, UpdateState};
+pub use verify::{verify_artifact_bytes, verify_artifact_file};
 pub use version::is_newer_release;
 
 #[cfg(test)]
@@ -73,6 +75,70 @@ mod tests {
             .validate()
             .expect_err("manifest validation should reject missing target_id");
         assert!(matches!(err, ManifestError::MissingTargetId { .. }));
+    }
+
+    #[test]
+    fn rejects_manifest_with_missing_signature_metadata() {
+        let manifest = ReleaseManifest {
+            schema_version: 1,
+            product: "Demo".to_string(),
+            channel: ReleaseChannel::Stable,
+            version: "1.2.3".to_string(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+            artifacts: vec![ReleaseArtifact {
+                platform: "android".to_string(),
+                arch: "arm64-v8a".to_string(),
+                target_id: "io.test.demo".to_string(),
+                url: "https://example.com/demo.apk".to_string(),
+                size: 20,
+                sha256: "beadfeed".to_string(),
+                signature: String::new(),
+            }],
+        };
+
+        let err = manifest
+            .validate()
+            .expect_err("manifest validation should reject missing signature metadata");
+        assert!(matches!(
+            err,
+            ManifestError::MissingArtifactMetadata {
+                field: "signature",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_manifest_with_missing_sha256_metadata() {
+        let manifest = ReleaseManifest {
+            schema_version: 1,
+            product: "Demo".to_string(),
+            channel: ReleaseChannel::Stable,
+            version: "1.2.3".to_string(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+            artifacts: vec![ReleaseArtifact {
+                platform: "android".to_string(),
+                arch: "arm64-v8a".to_string(),
+                target_id: "io.test.demo".to_string(),
+                url: "https://example.com/demo.apk".to_string(),
+                size: 20,
+                sha256: String::new(),
+                signature: "c2ln".to_string(),
+            }],
+        };
+
+        let err = manifest
+            .validate()
+            .expect_err("manifest validation should reject missing sha256 metadata");
+        assert!(matches!(
+            err,
+            ManifestError::MissingArtifactMetadata {
+                field: "sha256",
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/blinc_update/src/lib.rs
+++ b/crates/blinc_update/src/lib.rs
@@ -6,7 +6,7 @@ pub mod version;
 
 pub use error::{ManifestError, UpdateError, VersionError};
 pub use manifest::{ReleaseArtifact, ReleaseChannel, ReleaseManifest};
-pub use service::{InstallIntent, UpdateBackend, UpdateCheckRequest, UpdateState};
+pub use service::{InstallHandoff, InstallIntent, UpdateBackend, UpdateCheckRequest, UpdateState};
 pub use verify::{verify_artifact_bytes, verify_artifact_file};
 pub use version::is_newer_release;
 

--- a/crates/blinc_update/src/lib.rs
+++ b/crates/blinc_update/src/lib.rs
@@ -1,0 +1,99 @@
+pub mod error;
+pub mod manifest;
+pub mod service;
+pub mod version;
+
+pub use error::{ManifestError, UpdateError, VersionError};
+pub use manifest::{ReleaseArtifact, ReleaseChannel, ReleaseManifest};
+pub use service::{InstallIntent, UpdateBackend, UpdateCheckRequest, UpdateState};
+pub use version::is_newer_release;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_matching_artifact_for_platform_and_arch() {
+        let manifest = ReleaseManifest {
+            schema_version: 1,
+            product: "Demo".to_string(),
+            channel: ReleaseChannel::Stable,
+            version: "1.2.3".to_string(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+            artifacts: vec![
+                ReleaseArtifact {
+                    platform: "macos".to_string(),
+                    arch: "universal".to_string(),
+                    target_id: "io.test.demo".to_string(),
+                    url: "https://example.com/demo-macos.zip".to_string(),
+                    size: 10,
+                    sha256: "deadbeef".to_string(),
+                    signature: "c2ln".to_string(),
+                },
+                ReleaseArtifact {
+                    platform: "android".to_string(),
+                    arch: "arm64-v8a".to_string(),
+                    target_id: "io.test.demo".to_string(),
+                    url: "https://example.com/demo.apk".to_string(),
+                    size: 20,
+                    sha256: "beadfeed".to_string(),
+                    signature: "YWJj".to_string(),
+                },
+            ],
+        };
+
+        let artifact = manifest
+            .select_artifact("android", "arm64-v8a", "io.test.demo")
+            .expect("matching artifact should be selected");
+        assert_eq!(artifact.url, "https://example.com/demo.apk");
+    }
+
+    #[test]
+    fn rejects_manifest_with_missing_target_id() {
+        let manifest = ReleaseManifest {
+            schema_version: 1,
+            product: "Demo".to_string(),
+            channel: ReleaseChannel::Stable,
+            version: "1.2.3".to_string(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+            artifacts: vec![ReleaseArtifact {
+                platform: "android".to_string(),
+                arch: "arm64-v8a".to_string(),
+                target_id: String::new(),
+                url: "https://example.com/demo.apk".to_string(),
+                size: 20,
+                sha256: "beadfeed".to_string(),
+                signature: "YWJj".to_string(),
+            }],
+        };
+
+        let err = manifest
+            .validate()
+            .expect_err("manifest validation should reject missing target_id");
+        assert!(matches!(err, ManifestError::MissingTargetId { .. }));
+    }
+
+    #[test]
+    fn version_check_detects_newer_release() {
+        assert!(
+            is_newer_release("1.2.3", "1.3.0").expect("version comparison should succeed"),
+            "newer release should be detected"
+        );
+        assert!(
+            !is_newer_release("1.2.3", "1.2.3").expect("version comparison should succeed"),
+            "equal versions should not be treated as newer"
+        );
+        assert!(
+            is_newer_release("1.2.3-beta.1", "1.2.3")
+                .expect("stable release should outrank its prerelease"),
+            "stable release should be considered newer than prerelease"
+        );
+        assert!(
+            !is_newer_release("1.2.3", "1.2.3-beta.1")
+                .expect("prerelease should not outrank stable release"),
+            "prerelease should not be considered newer than stable release"
+        );
+    }
+}

--- a/crates/blinc_update/src/manifest.rs
+++ b/crates/blinc_update/src/manifest.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::ManifestError;
 
+pub const RELEASE_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
 #[derive(Debug, Clone, Copy, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReleaseChannel {

--- a/crates/blinc_update/src/manifest.rs
+++ b/crates/blinc_update/src/manifest.rs
@@ -39,6 +39,18 @@ impl ReleaseManifest {
             if artifact.target_id.trim().is_empty() {
                 return Err(ManifestError::MissingTargetId { index });
             }
+            if artifact.sha256.trim().is_empty() {
+                return Err(ManifestError::MissingArtifactMetadata {
+                    index,
+                    field: "sha256",
+                });
+            }
+            if artifact.signature.trim().is_empty() {
+                return Err(ManifestError::MissingArtifactMetadata {
+                    index,
+                    field: "signature",
+                });
+            }
         }
 
         Ok(())

--- a/crates/blinc_update/src/manifest.rs
+++ b/crates/blinc_update/src/manifest.rs
@@ -1,0 +1,59 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::ManifestError;
+
+#[derive(Debug, Clone, Copy, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReleaseChannel {
+    Stable,
+    Beta,
+    Canary,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ReleaseManifest {
+    pub schema_version: u32,
+    pub product: String,
+    pub channel: ReleaseChannel,
+    pub version: String,
+    pub published_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes_url: Option<String>,
+    pub artifacts: Vec<ReleaseArtifact>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ReleaseArtifact {
+    pub platform: String,
+    pub arch: String,
+    pub target_id: String,
+    pub url: String,
+    pub size: u64,
+    pub sha256: String,
+    pub signature: String,
+}
+
+impl ReleaseManifest {
+    pub fn validate(&self) -> Result<(), ManifestError> {
+        for (index, artifact) in self.artifacts.iter().enumerate() {
+            if artifact.target_id.trim().is_empty() {
+                return Err(ManifestError::MissingTargetId { index });
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn select_artifact(
+        &self,
+        platform: &str,
+        arch: &str,
+        target_id: &str,
+    ) -> Option<&ReleaseArtifact> {
+        self.artifacts.iter().find(|artifact| {
+            artifact.platform == platform
+                && artifact.arch == arch
+                && artifact.target_id == target_id
+        })
+    }
+}

--- a/crates/blinc_update/src/service.rs
+++ b/crates/blinc_update/src/service.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+
+use crate::error::UpdateError;
+use crate::manifest::{ReleaseArtifact, ReleaseManifest};
+
+#[derive(Debug, Clone)]
+pub struct UpdateCheckRequest {
+    pub platform: String,
+    pub arch: String,
+    pub target_id: String,
+    pub current_version: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct InstallIntent {
+    pub artifact: ReleaseArtifact,
+    pub downloaded_file: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub enum UpdateState {
+    Idle,
+    Checking,
+    Available(ReleaseArtifact),
+    Downloading { downloaded: u64, total: Option<u64> },
+    ReadyToInstall(InstallIntent),
+    Installing,
+    Complete,
+    Failed(String),
+}
+
+pub trait UpdateBackend {
+    fn check_for_update(
+        &self,
+        manifest: &ReleaseManifest,
+        request: &UpdateCheckRequest,
+    ) -> Result<Option<ReleaseArtifact>, UpdateError>;
+
+    fn download_artifact(&self, artifact: &ReleaseArtifact) -> Result<InstallIntent, UpdateError>;
+
+    fn install_update(&self, intent: &InstallIntent) -> Result<(), UpdateError>;
+}

--- a/crates/blinc_update/src/service.rs
+++ b/crates/blinc_update/src/service.rs
@@ -11,10 +11,26 @@ pub struct UpdateCheckRequest {
     pub current_version: String,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum InstallHandoff {
+    AndroidPackageInstaller {
+        package_name: String,
+        allow_unknown_sources_prompt: bool,
+    },
+    MacOsBundleReplace {
+        bundle_id: String,
+    },
+    Unsupported {
+        platform: String,
+        reason: String,
+    },
+}
+
 #[derive(Debug, Clone)]
 pub struct InstallIntent {
     pub artifact: ReleaseArtifact,
     pub downloaded_file: PathBuf,
+    pub handoff: InstallHandoff,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/blinc_update/src/verify.rs
+++ b/crates/blinc_update/src/verify.rs
@@ -1,0 +1,190 @@
+use std::path::Path;
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+use crate::error::UpdateError;
+use crate::manifest::ReleaseArtifact;
+
+pub fn verify_artifact_file(
+    path: &Path,
+    artifact: &ReleaseArtifact,
+    public_key: &str,
+) -> Result<(), UpdateError> {
+    let bytes = std::fs::read(path).map_err(|source| UpdateError::ArtifactRead {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    verify_artifact_bytes(&bytes, artifact, public_key)
+}
+
+pub fn verify_artifact_bytes(
+    bytes: &[u8],
+    artifact: &ReleaseArtifact,
+    public_key: &str,
+) -> Result<(), UpdateError> {
+    verify_sha256(bytes, &artifact.sha256)?;
+    verify_signature(bytes, &artifact.signature, public_key)
+}
+
+fn verify_sha256(bytes: &[u8], expected: &str) -> Result<(), UpdateError> {
+    if expected.len() != 64 || !expected.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return Err(UpdateError::InvalidSha256);
+    }
+
+    let actual = Sha256::digest(bytes);
+    let mut actual_hex = String::with_capacity(actual.len() * 2);
+    for byte in actual {
+        actual_hex.push_str(&format!("{byte:02x}"));
+    }
+
+    if actual_hex != expected.to_ascii_lowercase() {
+        return Err(UpdateError::ChecksumMismatch);
+    }
+
+    Ok(())
+}
+
+fn verify_signature(bytes: &[u8], signature: &str, public_key: &str) -> Result<(), UpdateError> {
+    let signature_bytes = STANDARD
+        .decode(signature)
+        .map_err(|_| UpdateError::InvalidSignatureEncoding)?;
+    let signature = Signature::from_bytes(
+        &signature_bytes
+            .try_into()
+            .map_err(|_| UpdateError::InvalidSignatureLength)?,
+    );
+    let public_key_bytes = STANDARD
+        .decode(public_key)
+        .map_err(|_| UpdateError::InvalidPublicKeyEncoding)?;
+    let verifying_key = VerifyingKey::from_bytes(
+        &public_key_bytes
+            .try_into()
+            .map_err(|_| UpdateError::InvalidPublicKeyLength)?,
+    )
+    .map_err(|_| UpdateError::InvalidPublicKeyLength)?;
+
+    verifying_key
+        .verify(bytes, &signature)
+        .map_err(|_| UpdateError::SignatureMismatch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::STANDARD;
+    use ed25519_dalek::{Signer, SigningKey};
+    use sha2::{Digest, Sha256};
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const PRIVATE_KEY: &str = "BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=";
+
+    #[test]
+    fn accepts_matching_sha256_and_signature() {
+        let (bytes, artifact, public_key) = signed_fixture();
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("blinc_update_verify_ok_{nonce}.bin"));
+        fs::write(&path, &bytes).expect("artifact fixture should be written");
+
+        verify_artifact_file(&path, &artifact, &public_key)
+            .expect("matching artifacts should verify successfully");
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn rejects_artifact_when_checksum_differs() {
+        let (bytes, mut artifact, public_key) = signed_fixture();
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("blinc_update_verify_bad_sha_{nonce}.bin"));
+        fs::write(&path, &bytes).expect("artifact fixture should be written");
+        artifact.sha256 =
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_string();
+
+        let err = verify_artifact_file(&path, &artifact, &public_key)
+            .expect_err("checksum mismatches must be rejected");
+        assert!(
+            matches!(err, UpdateError::ChecksumMismatch),
+            "checksum mismatches should return a typed checksum error"
+        );
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn accepts_uppercase_sha256_digest() {
+        let (bytes, mut artifact, public_key) = signed_fixture();
+        artifact.sha256 = artifact.sha256.to_uppercase();
+
+        verify_artifact_bytes(&bytes, &artifact, &public_key)
+            .expect("uppercase hex digests should verify successfully");
+    }
+
+    #[test]
+    fn rejects_artifact_when_signature_differs() {
+        let (bytes, mut artifact, public_key) = signed_fixture();
+        artifact.signature = STANDARD.encode([0_u8; 64]);
+
+        let err = verify_artifact_bytes(&bytes, &artifact, &public_key)
+            .expect_err("signature mismatches must be rejected");
+        assert!(
+            matches!(err, UpdateError::SignatureMismatch),
+            "signature mismatches should return a typed signature error"
+        );
+    }
+
+    #[test]
+    fn rejects_artifact_when_sha256_format_is_invalid() {
+        let (bytes, mut artifact, public_key) = signed_fixture();
+        artifact.sha256 = "not-hex".to_string();
+
+        let err = verify_artifact_bytes(&bytes, &artifact, &public_key)
+            .expect_err("invalid sha256 metadata must be rejected");
+        assert!(
+            matches!(err, UpdateError::InvalidSha256),
+            "invalid digests should return a typed sha256 error"
+        );
+    }
+
+    fn signed_fixture() -> (Vec<u8>, ReleaseArtifact, String) {
+        let bytes = b"hello signed release".to_vec();
+        let secret_bytes = STANDARD
+            .decode(PRIVATE_KEY)
+            .expect("fixture private key should decode");
+        let signing_key = SigningKey::from_bytes(
+            &secret_bytes
+                .try_into()
+                .expect("fixture private key should be 32 bytes"),
+        );
+        let signature = signing_key.sign(&bytes);
+        let public_key = STANDARD.encode(signing_key.verifying_key().to_bytes());
+        let digest = Sha256::digest(&bytes);
+        let sha256 = digest
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+
+        (
+            bytes.clone(),
+            ReleaseArtifact {
+                platform: "macos".to_string(),
+                arch: "universal".to_string(),
+                target_id: "io.test.demo".to_string(),
+                url: "https://example.com/releases/demo.zip".to_string(),
+                size: bytes.len() as u64,
+                sha256,
+                signature: STANDARD.encode(signature.to_bytes()),
+            },
+            public_key,
+        )
+    }
+}

--- a/crates/blinc_update/src/version.rs
+++ b/crates/blinc_update/src/version.rs
@@ -1,0 +1,122 @@
+use std::cmp::Ordering;
+
+use crate::error::VersionError;
+
+#[derive(Debug, Eq, PartialEq)]
+struct ParsedVersion {
+    core: Vec<u64>,
+    pre_release: Option<Vec<PreReleaseIdentifier>>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum PreReleaseIdentifier {
+    Numeric(u64),
+    AlphaNumeric(String),
+}
+
+pub fn is_newer_release(current: &str, candidate: &str) -> Result<bool, VersionError> {
+    let current = parse_version(current)?;
+    let candidate = parse_version(candidate)?;
+
+    Ok(compare_versions(&candidate, &current).is_gt())
+}
+
+fn parse_version(input: &str) -> Result<ParsedVersion, VersionError> {
+    let normalized = input.trim().trim_start_matches('v');
+    let (core, pre_release) = normalized
+        .split_once('-')
+        .map_or((normalized, None), |(core, pre)| (core, Some(pre)));
+
+    let core = core
+        .split('.')
+        .map(|segment| {
+            segment
+                .parse::<u64>()
+                .map_err(|_| VersionError::InvalidVersion(input.to_string()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if core.is_empty() {
+        return Err(VersionError::InvalidVersion(input.to_string()));
+    }
+
+    let pre_release = pre_release
+        .map(|value| {
+            value
+                .split('.')
+                .map(|segment| {
+                    if segment.is_empty() {
+                        return Err(VersionError::InvalidVersion(input.to_string()));
+                    }
+
+                    match segment.parse::<u64>() {
+                        Ok(number) => Ok(PreReleaseIdentifier::Numeric(number)),
+                        Err(_) => Ok(PreReleaseIdentifier::AlphaNumeric(segment.to_string())),
+                    }
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?;
+
+    Ok(ParsedVersion { core, pre_release })
+}
+
+fn compare_versions(left: &ParsedVersion, right: &ParsedVersion) -> Ordering {
+    let core_len = left.core.len().max(right.core.len());
+    for index in 0..core_len {
+        let ordering = left
+            .core
+            .get(index)
+            .unwrap_or(&0)
+            .cmp(right.core.get(index).unwrap_or(&0));
+        if !ordering.is_eq() {
+            return ordering;
+        }
+    }
+
+    compare_pre_release(left.pre_release.as_deref(), right.pre_release.as_deref())
+}
+
+fn compare_pre_release(
+    left: Option<&[PreReleaseIdentifier]>,
+    right: Option<&[PreReleaseIdentifier]>,
+) -> Ordering {
+    match (left, right) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(_), None) => Ordering::Less,
+        (Some(left), Some(right)) => {
+            let len = left.len().max(right.len());
+            for index in 0..len {
+                match (left.get(index), right.get(index)) {
+                    (Some(left), Some(right)) => {
+                        let ordering = compare_identifier(left, right);
+                        if !ordering.is_eq() {
+                            return ordering;
+                        }
+                    }
+                    (Some(_), None) => return Ordering::Greater,
+                    (None, Some(_)) => return Ordering::Less,
+                    (None, None) => return Ordering::Equal,
+                }
+            }
+
+            Ordering::Equal
+        }
+    }
+}
+
+fn compare_identifier(left: &PreReleaseIdentifier, right: &PreReleaseIdentifier) -> Ordering {
+    match (left, right) {
+        (PreReleaseIdentifier::Numeric(left), PreReleaseIdentifier::Numeric(right)) => {
+            left.cmp(right)
+        }
+        (PreReleaseIdentifier::Numeric(_), PreReleaseIdentifier::AlphaNumeric(_)) => Ordering::Less,
+        (PreReleaseIdentifier::AlphaNumeric(_), PreReleaseIdentifier::Numeric(_)) => {
+            Ordering::Greater
+        }
+        (PreReleaseIdentifier::AlphaNumeric(left), PreReleaseIdentifier::AlphaNumeric(right)) => {
+            left.cmp(right)
+        }
+    }
+}

--- a/crates/blinc_update/src/version.rs
+++ b/crates/blinc_update/src/version.rs
@@ -23,6 +23,9 @@ pub fn is_newer_release(current: &str, candidate: &str) -> Result<bool, VersionE
 
 fn parse_version(input: &str) -> Result<ParsedVersion, VersionError> {
     let normalized = input.trim().trim_start_matches('v');
+    let normalized = normalized
+        .split_once('+')
+        .map_or(normalized, |(without_build, _)| without_build);
     let (core, pre_release) = normalized
         .split_once('-')
         .map_or((normalized, None), |(core, pre)| (core, Some(pre)));

--- a/docs/plans/2026-03-07-updater-design.md
+++ b/docs/plans/2026-03-07-updater-design.md
@@ -1,0 +1,327 @@
+# Updater Architecture Design (Blinc)
+
+## Problem
+
+Blinc currently has desktop runtime crates and platform scaffolding, but it does not have a real packaging or release pipeline for application updates. The current desktop extension is responsible for windowing and input only, while `blinc build` does not yet produce installable artifacts. That means update support cannot be treated as a small add-on inside `blinc_platform_desktop`; it needs a dedicated domain model plus packaging and release metadata support.
+
+There is also a correctness gap in project scaffolding: `.blincproj` records organization-aware package and bundle identifiers, but the non-Rust project templates still emit `com.example.*` identifiers into generated Android/iOS/macOS files. Any updater design built on top of unstable app identifiers will fail later when signatures, manifests, and installation handoff rely on those IDs.
+
+## Scope
+
+- Desktop self-update support
+- Android private/development distribution update support
+- Shared updater interfaces, state, manifest schema, and verification rules
+- CLI support for package/release metadata generation
+
+## Explicit Non-Goals
+
+- iOS in-app self-update
+- Background auto-download in v1
+- Full Windows/Linux installer implementation in v1
+- Replacing the existing `blinc_platform::Platform` trait with an update-aware trait
+
+## Options Considered
+
+### Option A: Add updater code directly to platform crates
+
+- Put desktop update code in `extensions/blinc_platform_desktop`
+- Put Android update code in `extensions/blinc_platform_android`
+
+**Pros**
+- Fastest path to a spike
+- Fewer new packages
+
+**Cons**
+- Mixes runtime platform APIs with release/distribution concerns
+- Hard to test and reason about separately
+- Makes future signing/release policies leak into low-level windowing/native bridge code
+
+### Option B: Create a shared updater domain crate plus platform backends (Chosen)
+
+- Add a new shared crate for updater types and orchestration
+- Implement platform-specific backends in separate extension crates
+- Extend `blinc_cli` to emit manifests and release metadata
+
+**Pros**
+- Keeps clear package boundaries
+- Matches the current `crates/` plus `extensions/` architecture
+- Allows desktop and Android to share state, verification, and manifest parsing
+- Lets Windows/Linux remain stubs while macOS and Android become reference implementations
+
+**Cons**
+- More initial package scaffolding
+- Requires CLI and config work before the runtime feature feels complete
+
+### Option C: External-only updater helper
+
+- App only exposes UI
+- All update work is delegated to an external CLI/helper
+
+**Pros**
+- Simpler app runtime
+- Strong separation from installer logic
+
+**Cons**
+- Weak in-app state tracking
+- Poor Android UX for private APK distribution
+- Pushes too much product behavior out of the framework
+
+## Decision
+
+Choose **Option B**.
+
+Blinc should introduce a dedicated updater domain package, keep platform-specific installation logic in separate extension packages, and let `blinc_cli` own artifact packaging plus release manifest generation. The updater should be interface-first, with platform-specific installation behavior hidden behind backends.
+
+## Architectural Boundaries
+
+### 1. Shared updater domain
+
+Add a new crate:
+
+- `crates/blinc_update`
+
+Responsibilities:
+
+- version comparison policy
+- release channels
+- manifest parsing and validation
+- download lifecycle state machine
+- signature and checksum verification
+- public API traits for check/download/install orchestration
+
+Representative types:
+
+- `UpdateService`
+- `UpdateBackend`
+- `UpdateCheckRequest`
+- `UpdateManifest`
+- `ReleaseChannel`
+- `UpdateState`
+- `UpdateError`
+- `InstallIntent`
+
+This crate should not know about `winit`, Android intents, AppKit, MSI/MSIX, or package installers.
+
+### 2. Platform backends
+
+Add extension crates:
+
+- `extensions/blinc_update_desktop`
+- `extensions/blinc_update_android`
+
+Responsibilities:
+
+- platform-specific capability checks
+- installer handoff
+- relaunch/restart hooks
+- storage path decisions for downloaded artifacts
+
+`extensions/blinc_update_desktop` should expose separate modules for:
+
+- `macos`
+- `windows`
+- `linux`
+
+V1 expectation:
+
+- `macos`: real implementation
+- `windows`: explicit stub or capability-limited implementation
+- `linux`: explicit stub or capability-limited implementation
+
+`extensions/blinc_update_android` should implement APK-based private/development distribution update handoff and validation rules.
+
+### 3. Existing platform abstraction stays unchanged
+
+Do **not** extend `crates/blinc_platform::Platform` for v1.
+
+Reason:
+
+- `Platform` is currently about window/event-loop lifecycle
+- updater responsibilities are product distribution concerns
+- adding updater APIs there would force unrelated platform crates to implement a surface they do not own
+
+The updater should be created and injected separately by application code or helper APIs in `blinc_app` later if needed.
+
+### 4. CLI owns package/release metadata
+
+`crates/blinc_cli` must become the source of truth for:
+
+- package artifact generation
+- release manifest generation
+- release signing metadata
+- channel-aware output layout
+
+This implies `blinc build` alone is not sufficient. The CLI should evolve toward:
+
+- `build`
+- `package`
+- `release`
+
+with `release` producing both artifacts and update metadata.
+
+## Configuration Model
+
+Extend `.blincproj` with a dedicated updater section.
+
+Example shape:
+
+```toml
+[updates]
+enabled = true
+channel = "stable"
+manifest_url = "https://example.com/releases/manifest.json"
+public_key = "base64-ed25519-public-key"
+
+[updates.desktop]
+enabled = true
+restart_strategy = "prompt"
+
+[updates.android]
+enabled = true
+allow_unknown_sources_prompt = true
+expected_package = "com.example.myapp"
+```
+
+Rules:
+
+- global fields live under `[updates]`
+- only desktop and Android platform overrides are supported in v1
+- iOS has no updater section beyond possible future release metadata
+- `manifest_url` and `public_key` are required when updates are enabled
+
+## Release Manifest
+
+Use a shared JSON manifest for runtime consumption.
+
+Example:
+
+```json
+{
+  "schema_version": 1,
+  "app_id": "com.example.myapp",
+  "channel": "stable",
+  "version": "1.2.3",
+  "published_at": "2026-03-07T00:00:00Z",
+  "notes_url": "https://example.com/releases/1.2.3",
+  "artifacts": [
+    {
+      "platform": "macos",
+      "arch": "universal",
+      "url": "https://example.com/releases/myapp-1.2.3-macos.zip",
+      "size": 12345678,
+      "sha256": "hex",
+      "signature": "base64"
+    },
+    {
+      "platform": "android",
+      "arch": "arm64-v8a",
+      "url": "https://example.com/releases/myapp-1.2.3.apk",
+      "size": 9876543,
+      "sha256": "hex",
+      "signature": "base64"
+    }
+  ]
+}
+```
+
+Rules:
+
+- signatures are per artifact, not only per manifest
+- the runtime must verify both checksum and signature before handoff
+- `app_id` must match the package/bundle identifier expected by the target platform
+
+## Runtime Flow
+
+V1 uses an explicit user-driven flow:
+
+1. Check for updates
+2. Show availability and release notes
+3. Ask for explicit approval
+4. Download artifact
+5. Verify checksum and signature
+6. Hand off to platform installer path
+7. Prompt to restart or continue with a deferred restart
+
+No background auto-download in v1.
+
+## Platform-Specific Behavior
+
+### Desktop
+
+Desktop should never rely on “overwrite the currently running executable in place” as a generic strategy.
+
+Instead:
+
+- `macos`: install via app bundle replacement or helper handoff
+- `windows`: eventually install via MSI/MSIX/external installer strategy
+- `linux`: eventually install via AppImage/package-manager/packaged artifact strategy
+
+The shared updater service only emits an install intent; the platform backend decides how to perform or delegate installation.
+
+### Android
+
+Android private/development distribution should use APK-based update handoff:
+
+- verify downloaded APK metadata
+- confirm package identifier matches expected app
+- hand off to Android package installer intent
+- report install handoff success/failure, not “update finished inside the app”
+
+The framework should treat Android install as a controlled handoff, not a self-managed binary replacement.
+
+### iOS
+
+iOS is excluded from the in-app updater scope.
+
+## Required Precondition Fixes
+
+Before updater implementation starts, fix the project scaffolding mismatch:
+
+- `.blincproj` already stores organization-aware IDs
+- generated non-Rust Android/iOS/macOS files must stop hardcoding `com.example.*`
+
+Without this fix, any release manifest keyed by app ID will drift from generated projects.
+
+## Rollout Strategy
+
+1. Fix identifier propagation in CLI scaffolding and config serialization
+2. Introduce `blinc_update` with tests and no platform side effects
+3. Add CLI release manifest generation and signing placeholders
+4. Implement Android private-distribution updater backend
+5. Implement desktop shared backend surface
+6. Implement macOS reference backend
+7. Add Windows/Linux stubs with explicit unsupported or not-yet-implemented responses
+
+## Testing Strategy
+
+### Unit tests
+
+- version comparison
+- manifest parsing
+- signature/checksum validation
+- config serialization/deserialization
+- scaffolded project identifier propagation
+
+### Integration tests
+
+- CLI release manifest generation
+- Android handoff request construction
+- macOS install intent construction
+- unsupported backend behavior for Windows/Linux stubs
+
+### Manual verification
+
+- generate a sample app with non-default org/package IDs
+- produce package/release artifacts
+- validate manifest contents
+- exercise explicit update flow on Android private build and macOS sample app
+
+## Acceptance Criteria
+
+- Blinc has a dedicated updater domain crate with a stable public interface
+- `.blincproj` can describe updater settings for desktop and Android
+- non-Rust project scaffolding emits correct org-aware package/bundle identifiers
+- CLI can generate signed release metadata for updater consumption
+- Android private/development distribution update flow works through explicit install handoff
+- macOS has a reference desktop backend
+- Windows/Linux expose explicit unsupported or stubbed behavior rather than pretending to support updates

--- a/docs/plans/2026-03-07-updater-design.md
+++ b/docs/plans/2026-03-07-updater-design.md
@@ -159,6 +159,15 @@ This implies `blinc build` alone is not sufficient. The CLI should evolve toward
 
 with `release` producing both artifacts and update metadata.
 
+Release-related code must not rely on the current `BlincConfig::from_project()` projection as-is, because that path only preserves legacy `desktop/android/ios` target data today. V1 release work should either:
+
+- load `BlincProject` directly for release/package commands, or
+- extend `BlincConfig` so it preserves `updates`, `macos`, `windows`, `linux`, and `wasm` fields without lossy conversion
+
+V1 also needs at least one user-callable release surface, even before the full packaging pipeline is done. A minimal `blinc release manifest` command is sufficient; an internal helper alone is not.
+
+The long-term CLI direction is still `build` / `package` / `release`, but `package` is not a v1 blocker for this updater milestone while `build` remains a stub. V1 only requires a documented `release manifest` command and the internal hooks needed for future packaging integration.
+
 ## Configuration Model
 
 Extend `.blincproj` with a dedicated updater section.
@@ -179,7 +188,6 @@ restart_strategy = "prompt"
 [updates.android]
 enabled = true
 allow_unknown_sources_prompt = true
-expected_package = "com.example.myapp"
 ```
 
 Rules:
@@ -188,6 +196,12 @@ Rules:
 - only desktop and Android platform overrides are supported in v1
 - iOS has no updater section beyond possible future release metadata
 - `manifest_url` and `public_key` are required when updates are enabled
+- updater config must not redefine package or bundle identifiers
+- canonical target identity comes from existing platform config:
+  - `platforms.android.package`
+  - `platforms.macos.bundle_id`
+  - desktop packaging metadata for any future Windows/Linux implementation
+- release generation must fail if a target artifact cannot resolve a canonical platform identity
 
 ## Release Manifest
 
@@ -198,7 +212,7 @@ Example:
 ```json
 {
   "schema_version": 1,
-  "app_id": "com.example.myapp",
+  "product": "myapp",
   "channel": "stable",
   "version": "1.2.3",
   "published_at": "2026-03-07T00:00:00Z",
@@ -207,6 +221,7 @@ Example:
     {
       "platform": "macos",
       "arch": "universal",
+      "target_id": "com.example.myapp",
       "url": "https://example.com/releases/myapp-1.2.3-macos.zip",
       "size": 12345678,
       "sha256": "hex",
@@ -215,6 +230,7 @@ Example:
     {
       "platform": "android",
       "arch": "arm64-v8a",
+      "target_id": "com.example.myapp",
       "url": "https://example.com/releases/myapp-1.2.3.apk",
       "size": 9876543,
       "sha256": "hex",
@@ -228,7 +244,20 @@ Rules:
 
 - signatures are per artifact, not only per manifest
 - the runtime must verify both checksum and signature before handoff
-- `app_id` must match the package/bundle identifier expected by the target platform
+- each artifact carries its own canonical `target_id`
+- runtime validation compares `target_id` with the platform's canonical configured identity instead of a second updater-only identity field
+
+## Signing Inputs
+
+Signed release metadata requires both verification and generation.
+
+V1 release tooling therefore needs:
+
+- a documented private-key input for signing artifacts during release generation
+- a public-key output path for application configuration
+- deterministic tests using fixture keys so signing and verification can be validated in CI
+
+Verification-only support is not enough to satisfy the signed-release goal.
 
 ## Runtime Flow
 
@@ -263,7 +292,7 @@ The shared updater service only emits an install intent; the platform backend de
 Android private/development distribution should use APK-based update handoff:
 
 - verify downloaded APK metadata
-- confirm package identifier matches expected app
+- confirm artifact `target_id` matches `platforms.android.package`
 - hand off to Android package installer intent
 - report install handoff success/failure, not “update finished inside the app”
 
@@ -278,19 +307,23 @@ iOS is excluded from the in-app updater scope.
 Before updater implementation starts, fix the project scaffolding mismatch:
 
 - `.blincproj` already stores organization-aware IDs
-- generated non-Rust Android/iOS/macOS files must stop hardcoding `com.example.*`
+- generated non-Rust Android/iOS/macOS/Linux files must stop hardcoding `com.example.*`
+- non-Rust `blinc new` and `blinc init` paths must validate `--org` with the same rules used by the Rust-first scaffold path
 
-Without this fix, any release manifest keyed by app ID will drift from generated projects.
+Without this fix, release metadata keyed by canonical target identity will drift from generated projects.
 
 ## Rollout Strategy
 
-1. Fix identifier propagation in CLI scaffolding and config serialization
-2. Introduce `blinc_update` with tests and no platform side effects
-3. Add CLI release manifest generation and signing placeholders
-4. Implement Android private-distribution updater backend
-5. Implement desktop shared backend surface
-6. Implement macOS reference backend
-7. Add Windows/Linux stubs with explicit unsupported or not-yet-implemented responses
+1. Fix identifier propagation and `org` validation in CLI scaffolding, including Linux metadata
+2. Add updater config using canonical platform identities only
+3. Define a user-callable CLI release contract and a non-lossy project loading path
+4. Introduce `blinc_update` with tests and no platform side effects
+5. Add CLI manifest generation plus artifact signing
+6. Add runtime checksum and signature verification helpers
+7. Implement Android private-distribution updater backend
+8. Implement desktop shared backend surface
+9. Implement macOS reference backend
+10. Add Windows/Linux stubs with explicit unsupported or not-yet-implemented responses
 
 ## Testing Strategy
 
@@ -301,10 +334,12 @@ Without this fix, any release manifest keyed by app ID will drift from generated
 - signature/checksum validation
 - config serialization/deserialization
 - scaffolded project identifier propagation
+- non-Rust `org` validation
+- signing with fixture keys
 
 ### Integration tests
 
-- CLI release manifest generation
+- black-box CLI release manifest generation
 - Android handoff request construction
 - macOS install intent construction
 - unsupported backend behavior for Windows/Linux stubs
@@ -320,7 +355,10 @@ Without this fix, any release manifest keyed by app ID will drift from generated
 
 - Blinc has a dedicated updater domain crate with a stable public interface
 - `.blincproj` can describe updater settings for desktop and Android
-- non-Rust project scaffolding emits correct org-aware package/bundle identifiers
+- non-Rust project scaffolding emits correct org-aware Android, Apple, and Linux identifiers
+- non-Rust project scaffolding rejects unsafe `org` values
+- release metadata derives target identity from canonical platform config, not updater-only duplicate fields
+- CLI exposes a user-callable release-manifest path
 - CLI can generate signed release metadata for updater consumption
 - Android private/development distribution update flow works through explicit install handoff
 - macOS has a reference desktop backend

--- a/docs/plans/2026-03-07-updater-impl-plan.md
+++ b/docs/plans/2026-03-07-updater-impl-plan.md
@@ -2,11 +2,11 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Add an interface-first updater architecture to Blinc, with shared updater domain types, desktop and Android backend boundaries, updater-aware project configuration, and CLI release metadata generation.
+**Goal:** Add an interface-first updater architecture to Blinc, with canonical platform-derived release identity, user-callable CLI release metadata generation, artifact signing and verification, and Android plus macOS updater backends.
 
-**Architecture:** Keep update orchestration in a new shared crate and push platform-specific install behavior into dedicated extension crates. Treat `blinc_cli` as the owner of package/release metadata while keeping `crates/blinc_platform` unchanged. Implement real behavior for Android and macOS first, with explicit stubs for Windows and Linux.
+**Architecture:** Keep update orchestration in a new shared crate and push platform-specific install behavior into dedicated extension crates. Treat `blinc_cli` as the owner of package/release metadata, load `BlincProject` without lossy conversion for release paths, and keep `crates/blinc_platform` unchanged. Implement real behavior for Android and macOS first, with explicit stubs for Windows and Linux.
 
-**Tech Stack:** Rust 2021, Cargo workspace crates, `serde`/`serde_json`, `thiserror`, `anyhow`, Blinc CLI/config scaffolding, platform extension crates.
+**Tech Stack:** Rust 2021, Cargo workspace crates, `serde`/`serde_json`, `thiserror`, `anyhow`, `sha2`, `ed25519-dalek` or `ring`, Blinc CLI/config scaffolding, platform extension crates.
 
 ---
 
@@ -14,15 +14,15 @@
 
 - Follow TDD for every new behavior: write a failing test first, confirm the failure, then add the minimum code to pass.
 - Keep `crates/blinc_platform::Platform` unchanged in this plan.
-- Do not claim desktop support generically unless the backend is explicitly implemented.
+- Do not add updater-only duplicate identity fields such as Android `expected_package`.
+- Canonical release identity must come from existing platform config or platform packaging metadata.
+- Expose at least one user-callable CLI release entry point in v1.
 - Treat Windows/Linux as capability-limited stubs in v1.
-- Fix project identifier propagation before building updater metadata on top of it.
 
-### Task 1: Fix scaffolded app identifiers before updater work
+### Task 1: Fix non-Rust scaffolding identity drift and validate `org`
 
 **Files:**
 - Modify: `crates/blinc_cli/src/project.rs`
-- Modify: `crates/blinc_cli/src/config.rs`
 - Test: `crates/blinc_cli/src/project.rs`
 
 **Step 1: Write the failing tests**
@@ -31,50 +31,74 @@ Add tests beside the existing `#[cfg(test)]` module in `crates/blinc_cli/src/pro
 
 ```rust
 #[test]
-fn non_rust_project_uses_org_for_android_and_apple_ids() {
+fn non_rust_project_uses_org_for_android_apple_and_linux_ids() {
     // create_project(&root, "Demo App", "default", "io.test") ...
-    // assert generated Android and plist files contain io.test.demo_app
+    // assert Android, plist, and Linux metainfo files contain io.test.demo_app
+}
+
+#[test]
+fn non_rust_project_rejects_unsafe_org_chars() {
+    // create_project(..., r#"io.test"; rm -rf /"#) should fail
 }
 ```
 
-**Step 2: Run test to verify it fails**
+**Step 2: Run tests to verify failure**
 
-Run: `cargo test -p blinc_cli non_rust_project_uses_org_for_android_and_apple_ids -- --nocapture`
-Expected: FAIL because generated files still contain `com.example`.
+Run:
+
+```bash
+cargo test -p blinc_cli non_rust_project_uses_org_for_android_apple_and_linux_ids -- --nocapture
+cargo test -p blinc_cli non_rust_project_rejects_unsafe_org_chars -- --nocapture
+```
+
+Expected: FAIL because non-Rust scaffolding still emits `com.example.*` and does not validate `org`.
 
 **Step 3: Write minimal implementation**
 
-Update `create_platform_files`, `create_android_files`, `create_ios_files`, and `create_macos_files` so they accept and use `org`, not a hardcoded prefix. Keep generated identifiers consistent with `BlincProject::with_all_platforms`.
+Update `create_project()` and its helpers to:
 
-**Step 4: Run targeted tests to verify they pass**
+- reuse `validate_org_name()`
+- propagate `org` into Android files
+- propagate `org` into iOS/macOS bundle IDs
+- propagate `org` into Linux AppStream metadata
+
+Keep generated identifiers aligned with `BlincProject::with_all_platforms()`.
+
+**Step 4: Run targeted tests**
 
 Run: `cargo test -p blinc_cli project::tests -- --nocapture`
-Expected: PASS with existing scaffold tests plus the new org propagation test.
+Expected: PASS with existing scaffold tests plus the new identity and validation tests.
 
 **Step 5: Commit**
 
 ```bash
-git add crates/blinc_cli/src/project.rs crates/blinc_cli/src/config.rs
-git commit -m "fix: align scaffolded app identifiers with project config"
+git add crates/blinc_cli/src/project.rs
+git commit -m "fix: align non-rust scaffold identities and validate org"
 ```
 
-### Task 2: Add updater configuration to `.blincproj`
+### Task 2: Add updater config without duplicating platform identity
 
 **Files:**
 - Modify: `crates/blinc_cli/src/config.rs`
-- Test: `crates/blinc_cli/src/config.rs` or `crates/blinc_cli/src/project.rs`
+- Test: `crates/blinc_cli/src/config.rs`
 
 **Step 1: Write the failing tests**
 
-Add round-trip tests for config serialization:
+Add config tests such as:
 
 ```rust
 #[test]
-fn updater_config_round_trips_with_desktop_and_android_overrides() {
+fn updater_config_round_trips_without_identity_overrides() {
     let toml = r#"
         [project]
         name = "Demo"
         version = "0.1.0"
+
+        [platforms.android]
+        package = "io.test.demo"
+
+        [platforms.macos]
+        bundle_id = "io.test.demo"
 
         [updates]
         enabled = true
@@ -87,15 +111,15 @@ fn updater_config_round_trips_with_desktop_and_android_overrides() {
 
         [updates.android]
         enabled = true
-        expected_package = "io.test.demo"
+        allow_unknown_sources_prompt = true
     "#;
     // parse + serialize + parse again
 }
 ```
 
-**Step 2: Run test to verify it fails**
+**Step 2: Run test to verify failure**
 
-Run: `cargo test -p blinc_cli updater_config_round_trips_with_desktop_and_android_overrides -- --nocapture`
+Run: `cargo test -p blinc_cli updater_config_round_trips_without_identity_overrides -- --nocapture`
 Expected: FAIL because `BlincProject` has no updater schema.
 
 **Step 3: Write minimal implementation**
@@ -107,21 +131,107 @@ Add new config structs:
 - `AndroidUpdateConfig`
 - `ReleaseChannel` string representation for config
 
-Extend `BlincProject` with `#[serde(default)] pub updates: UpdatesConfig`.
+Do not add any updater-owned package or bundle ID field. Extend `BlincProject` with `#[serde(default)] pub updates: UpdatesConfig`.
 
 **Step 4: Run focused tests**
 
-Run: `cargo test -p blinc_cli updater_config_round_trips_with_desktop_and_android_overrides -- --nocapture`
+Run: `cargo test -p blinc_cli updater_config_round_trips_without_identity_overrides -- --nocapture`
 Expected: PASS.
 
 **Step 5: Commit**
 
 ```bash
 git add crates/blinc_cli/src/config.rs
-git commit -m "feat: add updater settings to blinc project config"
+git commit -m "feat: add updater config without duplicate app identity"
 ```
 
-### Task 3: Create the shared updater domain crate
+### Task 3: Preserve full project metadata for release commands
+
+**Files:**
+- Modify: `crates/blinc_cli/src/config.rs`
+- Modify: `crates/blinc_cli/src/main.rs`
+- Create: `crates/blinc_cli/src/release.rs`
+- Test: `crates/blinc_cli/src/release.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove release code sees fields missing from the legacy `BlincConfig` projection:
+
+```rust
+#[test]
+fn release_loader_preserves_updates_and_non_legacy_platforms() {}
+```
+
+**Step 2: Run test to verify failure**
+
+Run: `cargo test -p blinc_cli release_loader_preserves_updates_and_non_legacy_platforms -- --nocapture`
+Expected: FAIL because current release paths would be forced through lossy `BlincConfig`.
+
+**Step 3: Write minimal implementation**
+
+Add a release-focused loading path that either:
+
+- loads `BlincProject` directly, or
+- extends `BlincConfig` and `from_project()` so release commands can access `updates`, `macos`, `windows`, `linux`, and `wasm`
+
+Make the choice explicit in code and tests.
+
+**Step 4: Run focused tests**
+
+Run: `cargo test -p blinc_cli release_loader_preserves_updates_and_non_legacy_platforms -- --nocapture`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/blinc_cli/src/config.rs crates/blinc_cli/src/main.rs crates/blinc_cli/src/release.rs
+git commit -m "refactor: preserve full project metadata for release commands"
+```
+
+### Task 4: Define and expose a user-callable CLI release contract
+
+**Files:**
+- Modify: `crates/blinc_cli/src/main.rs`
+- Modify: `crates/blinc_cli/src/release.rs`
+- Test: `crates/blinc_cli/src/release.rs`
+
+**Step 1: Write the failing black-box test**
+
+Add a CLI-level test such as:
+
+```rust
+#[test]
+fn release_manifest_command_writes_manifest_json() {
+    // invoke CLI with a temp project and assert manifest file is created
+}
+```
+
+**Step 2: Run test to verify failure**
+
+Run: `cargo test -p blinc_cli release_manifest_command_writes_manifest_json -- --nocapture`
+Expected: FAIL because the CLI exposes no release command yet.
+
+**Step 3: Write minimal implementation**
+
+Add a user-callable release surface. The minimum acceptable contract is:
+
+- `blinc release manifest`
+
+with explicit input and output arguments. Document that this is the v1 public interface even if packaging is still incomplete.
+
+**Step 4: Run focused tests**
+
+Run: `cargo test -p blinc_cli release_manifest_command_writes_manifest_json -- --nocapture`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/blinc_cli/src/main.rs crates/blinc_cli/src/release.rs
+git commit -m "feat: add user-callable release manifest command"
+```
+
+### Task 5: Create the shared updater domain crate
 
 **Files:**
 - Modify: `Cargo.toml`
@@ -131,7 +241,7 @@ git commit -m "feat: add updater settings to blinc project config"
 - Create: `crates/blinc_update/src/manifest.rs`
 - Create: `crates/blinc_update/src/service.rs`
 - Create: `crates/blinc_update/src/version.rs`
-- Test: `crates/blinc_update/src/lib.rs` or dedicated unit test modules
+- Test: `crates/blinc_update/src/lib.rs`
 
 **Step 1: Write the failing tests**
 
@@ -142,13 +252,13 @@ Start with unit tests for:
 fn selects_matching_artifact_for_platform_and_arch() {}
 
 #[test]
-fn rejects_manifest_with_missing_signature() {}
+fn rejects_manifest_with_missing_target_id() {}
 
 #[test]
 fn version_check_detects_newer_release() {}
 ```
 
-**Step 2: Run test to verify it fails**
+**Step 2: Run test to verify failure**
 
 Run: `cargo test -p blinc_update`
 Expected: FAIL because crate does not exist yet.
@@ -157,7 +267,7 @@ Expected: FAIL because crate does not exist yet.
 
 Create the crate and implement:
 
-- manifest structs
+- manifest structs using per-artifact `target_id`
 - artifact selector helper
 - update state enum
 - backend trait with install/check/download shape
@@ -177,55 +287,62 @@ git add Cargo.toml crates/blinc_update
 git commit -m "feat: add shared updater domain crate"
 ```
 
-### Task 4: Add release manifest generation to the CLI
+### Task 6: Add artifact signing to release generation
 
 **Files:**
-- Modify: `crates/blinc_cli/src/main.rs`
-- Create: `crates/blinc_cli/src/release.rs`
 - Modify: `crates/blinc_cli/Cargo.toml`
+- Modify: `crates/blinc_cli/src/release.rs`
+- Modify: `crates/blinc_update/src/manifest.rs`
 - Test: `crates/blinc_cli/src/release.rs`
 
 **Step 1: Write the failing tests**
 
-Add tests for release manifest generation:
+Add tests such as:
 
 ```rust
 #[test]
-fn generates_manifest_with_expected_app_id_channel_and_artifacts() {}
+fn release_manifest_populates_artifact_signatures() {}
 
 #[test]
-fn rejects_release_when_updates_enabled_but_public_key_is_missing() {}
+fn release_manifest_generation_requires_private_key_input() {}
 ```
 
-**Step 2: Run tests to verify failure**
+**Step 2: Run test to verify failure**
 
-Run: `cargo test -p blinc_cli generates_manifest_with_expected_app_id_channel_and_artifacts -- --nocapture`
-Expected: FAIL because release manifest logic is missing.
+Run:
+
+```bash
+cargo test -p blinc_cli release_manifest_populates_artifact_signatures -- --nocapture
+cargo test -p blinc_cli release_manifest_generation_requires_private_key_input -- --nocapture
+```
+
+Expected: FAIL because release generation does not sign artifacts yet.
 
 **Step 3: Write minimal implementation**
 
-Add a new module that:
+Add release signing support that:
 
-- reads `BlincProject`
-- builds `blinc_update::UpdateManifest`
-- serializes JSON
-- validates required updater fields when updates are enabled
+- accepts signing key material from a documented CLI argument or environment variable
+- computes artifact signatures during manifest generation
+- writes `artifact.signature`
+- exposes the matching public key for application configuration
+- picks one concrete crypto stack and uses it consistently across release generation and runtime verification
 
-Expose the smallest possible CLI entry point first, even if it is an internal command helper used by future `package`/`release` commands.
+Use fixture keys in tests rather than real release keys.
 
-**Step 4: Run tests**
+**Step 4: Run focused tests**
 
 Run: `cargo test -p blinc_cli release -- --nocapture`
-Expected: PASS for manifest generation tests.
+Expected: PASS for signing-related tests.
 
 **Step 5: Commit**
 
 ```bash
-git add crates/blinc_cli/src/main.rs crates/blinc_cli/src/release.rs crates/blinc_cli/Cargo.toml
-git commit -m "feat: generate updater release manifests from the CLI"
+git add crates/blinc_cli/Cargo.toml crates/blinc_cli/src/release.rs crates/blinc_update/src/manifest.rs
+git commit -m "feat: sign release artifacts during manifest generation"
 ```
 
-### Task 5: Add artifact checksum and signature verification helpers
+### Task 7: Add runtime checksum and signature verification helpers
 
 **Files:**
 - Modify: `crates/blinc_update/Cargo.toml`
@@ -255,7 +372,9 @@ Expected: FAIL because verification helpers are missing.
 Add pure helpers to verify:
 
 - SHA-256 checksum
-- detached signature using the chosen public-key scheme
+- detached signature using the same public-key scheme produced by release generation
+
+Use the same concrete crypto crates chosen in Task 6 rather than a second parallel implementation.
 
 Return typed `UpdateError` values. Keep this layer file-based and deterministic.
 
@@ -271,7 +390,7 @@ git add crates/blinc_update/Cargo.toml crates/blinc_update/src/lib.rs crates/bli
 git commit -m "feat: add updater artifact verification helpers"
 ```
 
-### Task 6: Add Android updater backend crate
+### Task 8: Add Android updater backend crate
 
 **Files:**
 - Modify: `Cargo.toml`
@@ -286,7 +405,7 @@ Start with backend-level tests that avoid real Android runtime dependencies:
 
 ```rust
 #[test]
-fn android_backend_rejects_manifest_artifact_with_wrong_package_id() {}
+fn android_backend_rejects_artifact_with_wrong_target_id() {}
 
 #[test]
 fn android_backend_builds_install_intent_for_matching_apk() {}
@@ -302,7 +421,7 @@ Expected: FAIL because crate and backend do not exist.
 Implement a backend that:
 
 - chooses Android APK artifacts
-- validates expected package name from config
+- validates `artifact.target_id` against `platforms.android.package`
 - returns an `InstallIntent` representing Android package installer handoff
 
 Do not attempt real install execution in unit tests.
@@ -319,7 +438,7 @@ git add Cargo.toml extensions/blinc_update_android
 git commit -m "feat: add android updater backend"
 ```
 
-### Task 7: Add desktop updater backend crate with macOS reference backend
+### Task 9: Add desktop updater backend crate with macOS reference backend
 
 **Files:**
 - Modify: `Cargo.toml`
@@ -356,7 +475,7 @@ Expected: FAIL because crate and backends do not exist.
 Implement:
 
 - shared desktop backend dispatch
-- macOS install intent builder
+- macOS install intent builder using canonical bundle identity
 - explicit unsupported/stub responses for Windows/Linux
 
 Avoid real installer side effects in tests. Model installation as a handoff plan, not an in-process overwrite.
@@ -373,7 +492,7 @@ git add Cargo.toml extensions/blinc_update_desktop
 git commit -m "feat: add desktop updater backend with macos reference path"
 ```
 
-### Task 8: Thread updater config through generated projects and templates
+### Task 10: Surface updater config and release contract in generated docs
 
 **Files:**
 - Modify: `crates/blinc_cli/src/project.rs`
@@ -386,12 +505,12 @@ Add a scaffolding test that asserts generated projects include updater configura
 
 ```rust
 #[test]
-fn generated_project_includes_updater_config_placeholders() {}
+fn generated_project_includes_updater_config_and_release_manifest_guidance() {}
 ```
 
 **Step 2: Run the test**
 
-Run: `cargo test -p blinc_cli generated_project_includes_updater_config_placeholders -- --nocapture`
+Run: `cargo test -p blinc_cli generated_project_includes_updater_config_and_release_manifest_guidance -- --nocapture`
 Expected: FAIL because templates do not include updater guidance.
 
 **Step 3: Write minimal implementation**
@@ -401,22 +520,23 @@ Update generated README and config examples to describe:
 - updater config location
 - desktop and Android support
 - iOS exclusion
+- the user-callable `blinc release manifest` entry point
 
 Keep templates simple; do not add fake implementation code.
 
 **Step 4: Run tests**
 
-Run: `cargo test -p blinc_cli generated_project_includes_updater_config_placeholders -- --nocapture`
+Run: `cargo test -p blinc_cli generated_project_includes_updater_config_and_release_manifest_guidance -- --nocapture`
 Expected: PASS.
 
 **Step 5: Commit**
 
 ```bash
 git add crates/blinc_cli/src/project.rs crates/blinc_cli/README.md
-git commit -m "docs: surface updater configuration in generated projects"
+git commit -m "docs: surface updater config and release contract"
 ```
 
-### Task 9: Add end-to-end CLI plus crate verification
+### Task 11: Add end-to-end release and runtime verification
 
 **Files:**
 - Modify: `crates/blinc_cli/src/main.rs`
@@ -426,19 +546,19 @@ git commit -m "docs: surface updater configuration in generated projects"
 - Test: `extensions/blinc_update_android/src/lib.rs`
 - Test: `extensions/blinc_update_desktop/src/lib.rs`
 
-**Step 1: Write the failing integration-style test**
+**Step 1: Write the failing integration-style tests**
 
-Add a temporary-dir test that:
+Add tests that:
 
-- creates a sample project config
-- generates a manifest
-- parses it through `blinc_update`
-- selects the correct platform artifact
+- invoke `blinc release manifest` on a temp project
+- parse the resulting manifest through `blinc_update`
+- assert signatures and `target_id` fields are present
+- assert Android and macOS selectors choose the correct artifacts
 
 **Step 2: Run test to verify failure**
 
 Run: `cargo test -p blinc_cli generated_manifest_round_trips_into_update_domain -- --nocapture`
-Expected: FAIL until the pieces connect cleanly.
+Expected: FAIL until the CLI contract, manifest schema, and runtime domain align.
 
 **Step 3: Write minimal integration glue**
 
@@ -464,7 +584,7 @@ git add crates/blinc_cli/src/main.rs crates/blinc_cli/src/release.rs crates/blin
 git commit -m "test: verify updater manifest flow across CLI and backends"
 ```
 
-### Task 10: Final verification, formatting, and documentation pass
+### Task 12: Final verification, formatting, and documentation pass
 
 **Files:**
 - Modify: `docs/plans/2026-03-07-updater-design.md` if implementation changed scope

--- a/docs/plans/2026-03-07-updater-impl-plan.md
+++ b/docs/plans/2026-03-07-updater-impl-plan.md
@@ -1,0 +1,510 @@
+# Updater Architecture Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an interface-first updater architecture to Blinc, with shared updater domain types, desktop and Android backend boundaries, updater-aware project configuration, and CLI release metadata generation.
+
+**Architecture:** Keep update orchestration in a new shared crate and push platform-specific install behavior into dedicated extension crates. Treat `blinc_cli` as the owner of package/release metadata while keeping `crates/blinc_platform` unchanged. Implement real behavior for Android and macOS first, with explicit stubs for Windows and Linux.
+
+**Tech Stack:** Rust 2021, Cargo workspace crates, `serde`/`serde_json`, `thiserror`, `anyhow`, Blinc CLI/config scaffolding, platform extension crates.
+
+---
+
+## Global Constraints / Guardrails
+
+- Follow TDD for every new behavior: write a failing test first, confirm the failure, then add the minimum code to pass.
+- Keep `crates/blinc_platform::Platform` unchanged in this plan.
+- Do not claim desktop support generically unless the backend is explicitly implemented.
+- Treat Windows/Linux as capability-limited stubs in v1.
+- Fix project identifier propagation before building updater metadata on top of it.
+
+### Task 1: Fix scaffolded app identifiers before updater work
+
+**Files:**
+- Modify: `crates/blinc_cli/src/project.rs`
+- Modify: `crates/blinc_cli/src/config.rs`
+- Test: `crates/blinc_cli/src/project.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests beside the existing `#[cfg(test)]` module in `crates/blinc_cli/src/project.rs`:
+
+```rust
+#[test]
+fn non_rust_project_uses_org_for_android_and_apple_ids() {
+    // create_project(&root, "Demo App", "default", "io.test") ...
+    // assert generated Android and plist files contain io.test.demo_app
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p blinc_cli non_rust_project_uses_org_for_android_and_apple_ids -- --nocapture`
+Expected: FAIL because generated files still contain `com.example`.
+
+**Step 3: Write minimal implementation**
+
+Update `create_platform_files`, `create_android_files`, `create_ios_files`, and `create_macos_files` so they accept and use `org`, not a hardcoded prefix. Keep generated identifiers consistent with `BlincProject::with_all_platforms`.
+
+**Step 4: Run targeted tests to verify they pass**
+
+Run: `cargo test -p blinc_cli project::tests -- --nocapture`
+Expected: PASS with existing scaffold tests plus the new org propagation test.
+
+**Step 5: Commit**
+
+```bash
+git add crates/blinc_cli/src/project.rs crates/blinc_cli/src/config.rs
+git commit -m "fix: align scaffolded app identifiers with project config"
+```
+
+### Task 2: Add updater configuration to `.blincproj`
+
+**Files:**
+- Modify: `crates/blinc_cli/src/config.rs`
+- Test: `crates/blinc_cli/src/config.rs` or `crates/blinc_cli/src/project.rs`
+
+**Step 1: Write the failing tests**
+
+Add round-trip tests for config serialization:
+
+```rust
+#[test]
+fn updater_config_round_trips_with_desktop_and_android_overrides() {
+    let toml = r#"
+        [project]
+        name = "Demo"
+        version = "0.1.0"
+
+        [updates]
+        enabled = true
+        channel = "stable"
+        manifest_url = "https://example.com/manifest.json"
+        public_key = "abc"
+
+        [updates.desktop]
+        enabled = true
+
+        [updates.android]
+        enabled = true
+        expected_package = "io.test.demo"
+    "#;
+    // parse + serialize + parse again
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p blinc_cli updater_config_round_trips_with_desktop_and_android_overrides -- --nocapture`
+Expected: FAIL because `BlincProject` has no updater schema.
+
+**Step 3: Write minimal implementation**
+
+Add new config structs:
+
+- `UpdatesConfig`
+- `DesktopUpdateConfig`
+- `AndroidUpdateConfig`
+- `ReleaseChannel` string representation for config
+
+Extend `BlincProject` with `#[serde(default)] pub updates: UpdatesConfig`.
+
+**Step 4: Run focused tests**
+
+Run: `cargo test -p blinc_cli updater_config_round_trips_with_desktop_and_android_overrides -- --nocapture`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/blinc_cli/src/config.rs
+git commit -m "feat: add updater settings to blinc project config"
+```
+
+### Task 3: Create the shared updater domain crate
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `crates/blinc_update/Cargo.toml`
+- Create: `crates/blinc_update/src/lib.rs`
+- Create: `crates/blinc_update/src/error.rs`
+- Create: `crates/blinc_update/src/manifest.rs`
+- Create: `crates/blinc_update/src/service.rs`
+- Create: `crates/blinc_update/src/version.rs`
+- Test: `crates/blinc_update/src/lib.rs` or dedicated unit test modules
+
+**Step 1: Write the failing tests**
+
+Start with unit tests for:
+
+```rust
+#[test]
+fn selects_matching_artifact_for_platform_and_arch() {}
+
+#[test]
+fn rejects_manifest_with_missing_signature() {}
+
+#[test]
+fn version_check_detects_newer_release() {}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p blinc_update`
+Expected: FAIL because crate does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create the crate and implement:
+
+- manifest structs
+- artifact selector helper
+- update state enum
+- backend trait with install/check/download shape
+- version comparison helper
+
+Keep networking out of scope for now; test pure domain behavior first.
+
+**Step 4: Run tests**
+
+Run: `cargo test -p blinc_update`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Cargo.toml crates/blinc_update
+git commit -m "feat: add shared updater domain crate"
+```
+
+### Task 4: Add release manifest generation to the CLI
+
+**Files:**
+- Modify: `crates/blinc_cli/src/main.rs`
+- Create: `crates/blinc_cli/src/release.rs`
+- Modify: `crates/blinc_cli/Cargo.toml`
+- Test: `crates/blinc_cli/src/release.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests for release manifest generation:
+
+```rust
+#[test]
+fn generates_manifest_with_expected_app_id_channel_and_artifacts() {}
+
+#[test]
+fn rejects_release_when_updates_enabled_but_public_key_is_missing() {}
+```
+
+**Step 2: Run tests to verify failure**
+
+Run: `cargo test -p blinc_cli generates_manifest_with_expected_app_id_channel_and_artifacts -- --nocapture`
+Expected: FAIL because release manifest logic is missing.
+
+**Step 3: Write minimal implementation**
+
+Add a new module that:
+
+- reads `BlincProject`
+- builds `blinc_update::UpdateManifest`
+- serializes JSON
+- validates required updater fields when updates are enabled
+
+Expose the smallest possible CLI entry point first, even if it is an internal command helper used by future `package`/`release` commands.
+
+**Step 4: Run tests**
+
+Run: `cargo test -p blinc_cli release -- --nocapture`
+Expected: PASS for manifest generation tests.
+
+**Step 5: Commit**
+
+```bash
+git add crates/blinc_cli/src/main.rs crates/blinc_cli/src/release.rs crates/blinc_cli/Cargo.toml
+git commit -m "feat: generate updater release manifests from the CLI"
+```
+
+### Task 5: Add artifact checksum and signature verification helpers
+
+**Files:**
+- Modify: `crates/blinc_update/Cargo.toml`
+- Modify: `crates/blinc_update/src/lib.rs`
+- Create: `crates/blinc_update/src/verify.rs`
+- Test: `crates/blinc_update/src/verify.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests like:
+
+```rust
+#[test]
+fn accepts_matching_sha256_and_signature() {}
+
+#[test]
+fn rejects_artifact_when_checksum_differs() {}
+```
+
+**Step 2: Run the tests**
+
+Run: `cargo test -p blinc_update verify -- --nocapture`
+Expected: FAIL because verification helpers are missing.
+
+**Step 3: Write minimal implementation**
+
+Add pure helpers to verify:
+
+- SHA-256 checksum
+- detached signature using the chosen public-key scheme
+
+Return typed `UpdateError` values. Keep this layer file-based and deterministic.
+
+**Step 4: Run tests**
+
+Run: `cargo test -p blinc_update verify -- --nocapture`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/blinc_update/Cargo.toml crates/blinc_update/src/lib.rs crates/blinc_update/src/verify.rs
+git commit -m "feat: add updater artifact verification helpers"
+```
+
+### Task 6: Add Android updater backend crate
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `extensions/blinc_update_android/Cargo.toml`
+- Create: `extensions/blinc_update_android/src/lib.rs`
+- Create: `extensions/blinc_update_android/src/backend.rs`
+- Test: `extensions/blinc_update_android/src/lib.rs`
+
+**Step 1: Write the failing tests**
+
+Start with backend-level tests that avoid real Android runtime dependencies:
+
+```rust
+#[test]
+fn android_backend_rejects_manifest_artifact_with_wrong_package_id() {}
+
+#[test]
+fn android_backend_builds_install_intent_for_matching_apk() {}
+```
+
+**Step 2: Run tests to verify failure**
+
+Run: `cargo test -p blinc_update_android`
+Expected: FAIL because crate and backend do not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement a backend that:
+
+- chooses Android APK artifacts
+- validates expected package name from config
+- returns an `InstallIntent` representing Android package installer handoff
+
+Do not attempt real install execution in unit tests.
+
+**Step 4: Run tests**
+
+Run: `cargo test -p blinc_update_android`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Cargo.toml extensions/blinc_update_android
+git commit -m "feat: add android updater backend"
+```
+
+### Task 7: Add desktop updater backend crate with macOS reference backend
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `extensions/blinc_update_desktop/Cargo.toml`
+- Create: `extensions/blinc_update_desktop/src/lib.rs`
+- Create: `extensions/blinc_update_desktop/src/backend.rs`
+- Create: `extensions/blinc_update_desktop/src/macos.rs`
+- Create: `extensions/blinc_update_desktop/src/windows.rs`
+- Create: `extensions/blinc_update_desktop/src/linux.rs`
+- Test: `extensions/blinc_update_desktop/src/lib.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests such as:
+
+```rust
+#[test]
+fn macos_backend_emits_bundle_replace_install_intent() {}
+
+#[test]
+fn windows_backend_reports_unsupported_for_now() {}
+
+#[test]
+fn linux_backend_reports_unsupported_for_now() {}
+```
+
+**Step 2: Run the tests**
+
+Run: `cargo test -p blinc_update_desktop`
+Expected: FAIL because crate and backends do not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- shared desktop backend dispatch
+- macOS install intent builder
+- explicit unsupported/stub responses for Windows/Linux
+
+Avoid real installer side effects in tests. Model installation as a handoff plan, not an in-process overwrite.
+
+**Step 4: Run tests**
+
+Run: `cargo test -p blinc_update_desktop`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Cargo.toml extensions/blinc_update_desktop
+git commit -m "feat: add desktop updater backend with macos reference path"
+```
+
+### Task 8: Thread updater config through generated projects and templates
+
+**Files:**
+- Modify: `crates/blinc_cli/src/project.rs`
+- Modify: `crates/blinc_cli/README.md`
+- Test: `crates/blinc_cli/src/project.rs`
+
+**Step 1: Write the failing tests**
+
+Add a scaffolding test that asserts generated projects include updater configuration examples or placeholders:
+
+```rust
+#[test]
+fn generated_project_includes_updater_config_placeholders() {}
+```
+
+**Step 2: Run the test**
+
+Run: `cargo test -p blinc_cli generated_project_includes_updater_config_placeholders -- --nocapture`
+Expected: FAIL because templates do not include updater guidance.
+
+**Step 3: Write minimal implementation**
+
+Update generated README and config examples to describe:
+
+- updater config location
+- desktop and Android support
+- iOS exclusion
+
+Keep templates simple; do not add fake implementation code.
+
+**Step 4: Run tests**
+
+Run: `cargo test -p blinc_cli generated_project_includes_updater_config_placeholders -- --nocapture`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/blinc_cli/src/project.rs crates/blinc_cli/README.md
+git commit -m "docs: surface updater configuration in generated projects"
+```
+
+### Task 9: Add end-to-end CLI plus crate verification
+
+**Files:**
+- Modify: `crates/blinc_cli/src/main.rs`
+- Modify: `crates/blinc_cli/src/release.rs`
+- Test: `crates/blinc_cli/src/release.rs`
+- Test: `crates/blinc_update/src/lib.rs`
+- Test: `extensions/blinc_update_android/src/lib.rs`
+- Test: `extensions/blinc_update_desktop/src/lib.rs`
+
+**Step 1: Write the failing integration-style test**
+
+Add a temporary-dir test that:
+
+- creates a sample project config
+- generates a manifest
+- parses it through `blinc_update`
+- selects the correct platform artifact
+
+**Step 2: Run test to verify failure**
+
+Run: `cargo test -p blinc_cli generated_manifest_round_trips_into_update_domain -- --nocapture`
+Expected: FAIL until the pieces connect cleanly.
+
+**Step 3: Write minimal integration glue**
+
+Wire the CLI generator and shared domain so manifest output matches runtime expectations exactly. Remove any duplicate schema definitions.
+
+**Step 4: Run full targeted verification**
+
+Run:
+
+```bash
+cargo test -p blinc_cli
+cargo test -p blinc_update
+cargo test -p blinc_update_android
+cargo test -p blinc_update_desktop
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/blinc_cli/src/main.rs crates/blinc_cli/src/release.rs crates/blinc_update extensions/blinc_update_android extensions/blinc_update_desktop Cargo.toml
+git commit -m "test: verify updater manifest flow across CLI and backends"
+```
+
+### Task 10: Final verification, formatting, and documentation pass
+
+**Files:**
+- Modify: `docs/plans/2026-03-07-updater-design.md` if implementation changed scope
+- Modify: `docs/plans/2026-03-07-updater-impl-plan.md` if task ordering changed
+
+**Step 1: Run formatting**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+```
+
+Expected: second command exits successfully.
+
+**Step 2: Run workspace verification for touched packages**
+
+Run:
+
+```bash
+cargo test -p blinc_cli
+cargo test -p blinc_update
+cargo test -p blinc_update_android
+cargo test -p blinc_update_desktop
+```
+
+Expected: PASS.
+
+**Step 3: Review unsupported behavior explicitly**
+
+Verify Windows/Linux return explicit unsupported or stub results and that no docs imply full support.
+
+**Step 4: Update docs if implementation diverged**
+
+Make only the minimal documentation changes needed to reflect the shipped behavior.
+
+**Step 5: Commit**
+
+```bash
+git add docs/plans/2026-03-07-updater-design.md docs/plans/2026-03-07-updater-impl-plan.md
+git commit -m "docs: finalize updater implementation notes"
+```

--- a/extensions/blinc_update_android/Cargo.toml
+++ b/extensions/blinc_update_android/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "blinc_update_android"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+blinc_update = { path = "../../crates/blinc_update", version = "0.1.14" }

--- a/extensions/blinc_update_android/src/backend.rs
+++ b/extensions/blinc_update_android/src/backend.rs
@@ -103,6 +103,7 @@ impl UpdateBackend for AndroidUpdateBackend {
             .url
             .rsplit('/')
             .next()
+            .and_then(|name| name.split(['?', '#']).next())
             .filter(|name| !name.is_empty())
             .unwrap_or("update.apk");
         let downloaded_file = self.download_dir.join(file_name);

--- a/extensions/blinc_update_android/src/backend.rs
+++ b/extensions/blinc_update_android/src/backend.rs
@@ -1,0 +1,126 @@
+use std::path::{Path, PathBuf};
+
+use blinc_update::{
+    is_newer_release, InstallHandoff, InstallIntent, ReleaseArtifact, ReleaseManifest,
+    UpdateBackend, UpdateCheckRequest, UpdateError,
+};
+
+#[derive(Debug, Clone)]
+pub struct AndroidUpdateBackend {
+    package_name: String,
+    allow_unknown_sources_prompt: bool,
+    download_dir: PathBuf,
+}
+
+impl AndroidUpdateBackend {
+    pub fn new(
+        package_name: impl Into<String>,
+        allow_unknown_sources_prompt: bool,
+        download_dir: impl AsRef<Path>,
+    ) -> Self {
+        Self {
+            package_name: package_name.into(),
+            allow_unknown_sources_prompt,
+            download_dir: download_dir.as_ref().to_path_buf(),
+        }
+    }
+
+    pub fn build_install_intent(
+        &self,
+        artifact: &ReleaseArtifact,
+        downloaded_file: PathBuf,
+    ) -> Result<InstallIntent, UpdateError> {
+        if artifact.platform != "android" {
+            return Err(UpdateError::Backend(
+                "android backend only accepts android artifacts".to_string(),
+            ));
+        }
+
+        if artifact.target_id != self.package_name {
+            return Err(UpdateError::Backend(format!(
+                "android artifact target_id '{}' does not match expected target_id '{}'",
+                artifact.target_id, self.package_name
+            )));
+        }
+
+        let is_apk = downloaded_file
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.eq_ignore_ascii_case("apk"))
+            .unwrap_or(false);
+        if !is_apk {
+            return Err(UpdateError::Backend(
+                "android backend requires an .apk downloaded file".to_string(),
+            ));
+        }
+
+        Ok(InstallIntent {
+            artifact: artifact.clone(),
+            downloaded_file,
+            handoff: InstallHandoff::AndroidPackageInstaller {
+                package_name: self.package_name.clone(),
+                allow_unknown_sources_prompt: self.allow_unknown_sources_prompt,
+            },
+        })
+    }
+}
+
+impl UpdateBackend for AndroidUpdateBackend {
+    fn check_for_update(
+        &self,
+        manifest: &ReleaseManifest,
+        request: &UpdateCheckRequest,
+    ) -> Result<Option<ReleaseArtifact>, UpdateError> {
+        if request.platform != "android" {
+            return Err(UpdateError::Backend(
+                "android backend only supports android update checks".to_string(),
+            ));
+        }
+        if request.target_id != self.package_name {
+            return Err(UpdateError::Backend(format!(
+                "android request target_id '{}' does not match backend target_id '{}'",
+                request.target_id, self.package_name
+            )));
+        }
+
+        let Some(artifact) = manifest
+            .select_artifact("android", &request.arch, &self.package_name)
+            .cloned()
+        else {
+            return Ok(None);
+        };
+
+        let is_newer = is_newer_release(&request.current_version, &manifest.version)?;
+        if !is_newer {
+            return Ok(None);
+        }
+
+        Ok(Some(artifact))
+    }
+
+    fn download_artifact(&self, artifact: &ReleaseArtifact) -> Result<InstallIntent, UpdateError> {
+        let file_name = artifact
+            .url
+            .rsplit('/')
+            .next()
+            .filter(|name| !name.is_empty())
+            .unwrap_or("update.apk");
+        let downloaded_file = self.download_dir.join(file_name);
+
+        self.build_install_intent(artifact, downloaded_file)
+    }
+
+    fn install_update(&self, intent: &InstallIntent) -> Result<(), UpdateError> {
+        match &intent.handoff {
+            InstallHandoff::AndroidPackageInstaller { package_name, .. }
+                if package_name == &self.package_name
+                    && intent.artifact.target_id == self.package_name =>
+            {
+                Ok(())
+            }
+            _ => Err(UpdateError::Backend(
+                "android install intent does not match the backend package".to_string(),
+            )),
+        }
+    }
+}

--- a/extensions/blinc_update_android/src/lib.rs
+++ b/extensions/blinc_update_android/src/lib.rs
@@ -119,4 +119,31 @@ mod tests {
             "android backend should return the matching android artifact"
         );
     }
+
+    #[test]
+    fn android_backend_strips_query_from_downloaded_apk_name() {
+        let backend = AndroidUpdateBackend::new("io.test.demo", true, "/tmp/downloads");
+        let artifact = ReleaseArtifact {
+            platform: "android".to_string(),
+            arch: "arm64-v8a".to_string(),
+            target_id: "io.test.demo".to_string(),
+            url: "https://example.com/releases/demo.apk?X-Amz-Signature=abc123".to_string(),
+            size: 42,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+            signature:
+                "CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQ=="
+                    .to_string(),
+        };
+
+        let intent = backend
+            .download_artifact(&artifact)
+            .expect("android backend should sanitize presigned URLs into apk file paths");
+
+        assert_eq!(
+            intent.downloaded_file,
+            PathBuf::from("/tmp/downloads/demo.apk"),
+            "download path should strip query parameters before deriving the local apk file name"
+        );
+    }
 }

--- a/extensions/blinc_update_android/src/lib.rs
+++ b/extensions/blinc_update_android/src/lib.rs
@@ -1,0 +1,122 @@
+mod backend;
+
+pub use backend::AndroidUpdateBackend;
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use blinc_update::{
+        InstallHandoff, ReleaseArtifact, ReleaseChannel, ReleaseManifest, UpdateBackend,
+        UpdateCheckRequest, UpdateError,
+    };
+
+    use crate::AndroidUpdateBackend;
+
+    #[test]
+    fn android_backend_rejects_artifact_with_wrong_target_id() {
+        let backend = AndroidUpdateBackend::new("io.test.demo", true, "/tmp/downloads");
+        let artifact = ReleaseArtifact {
+            platform: "android".to_string(),
+            arch: "arm64-v8a".to_string(),
+            target_id: "io.test.other".to_string(),
+            url: "https://example.com/releases/demo.apk".to_string(),
+            size: 42,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+            signature:
+                "CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQ=="
+                    .to_string(),
+        };
+        let apk_path = PathBuf::from("/tmp/downloads/demo.apk");
+
+        let err = backend
+            .build_install_intent(&artifact, apk_path)
+            .expect_err("android backend should reject artifacts for a different package");
+        assert!(
+            matches!(err, UpdateError::Backend(message) if message.contains("target_id")),
+            "target mismatches should return a backend error mentioning target_id"
+        );
+    }
+
+    #[test]
+    fn android_backend_builds_install_intent_for_matching_apk() {
+        let backend = AndroidUpdateBackend::new("io.test.demo", true, "/tmp/downloads");
+        let artifact = ReleaseArtifact {
+            platform: "android".to_string(),
+            arch: "arm64-v8a".to_string(),
+            target_id: "io.test.demo".to_string(),
+            url: "https://example.com/releases/demo.apk".to_string(),
+            size: 42,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+            signature:
+                "CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQ=="
+                    .to_string(),
+        };
+        let apk_path = PathBuf::from("/tmp/downloads/demo.apk");
+
+        let intent = backend
+            .build_install_intent(&artifact, apk_path.clone())
+            .expect("android backend should build a package-installer handoff intent");
+
+        assert_eq!(
+            intent.downloaded_file, apk_path,
+            "install intent should point at the downloaded apk path"
+        );
+        assert_eq!(
+            intent.artifact.target_id, "io.test.demo",
+            "install intent should preserve the release artifact metadata"
+        );
+        assert_eq!(
+            intent.handoff,
+            InstallHandoff::AndroidPackageInstaller {
+                package_name: "io.test.demo".to_string(),
+                allow_unknown_sources_prompt: true,
+            },
+            "android backend should request package installer handoff"
+        );
+    }
+
+    #[test]
+    fn android_backend_selects_newer_matching_release() {
+        let backend = AndroidUpdateBackend::new("io.test.demo", true, "/tmp/downloads");
+        let artifact = ReleaseArtifact {
+            platform: "android".to_string(),
+            arch: "arm64-v8a".to_string(),
+            target_id: "io.test.demo".to_string(),
+            url: "https://example.com/releases/demo.apk".to_string(),
+            size: 42,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+            signature:
+                "CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQ=="
+                    .to_string(),
+        };
+        let manifest = ReleaseManifest {
+            schema_version: 1,
+            product: "Demo".to_string(),
+            channel: ReleaseChannel::Stable,
+            version: "1.2.4".to_string(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+            artifacts: vec![artifact.clone()],
+        };
+        let request = UpdateCheckRequest {
+            platform: "android".to_string(),
+            arch: "arm64-v8a".to_string(),
+            target_id: "io.test.demo".to_string(),
+            current_version: "1.2.3".to_string(),
+        };
+
+        let selected = backend
+            .check_for_update(&manifest, &request)
+            .expect("android backend should compare versions and select matching artifacts")
+            .expect("android backend should return the newer matching artifact");
+
+        assert_eq!(
+            selected.url, artifact.url,
+            "android backend should return the matching android artifact"
+        );
+    }
+}

--- a/extensions/blinc_update_desktop/Cargo.toml
+++ b/extensions/blinc_update_desktop/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "blinc_update_desktop"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+blinc_update = { path = "../../crates/blinc_update", version = "0.1.14" }

--- a/extensions/blinc_update_desktop/src/backend.rs
+++ b/extensions/blinc_update_desktop/src/backend.rs
@@ -1,0 +1,125 @@
+use std::path::{Path, PathBuf};
+
+use blinc_update::{
+    is_newer_release, InstallHandoff, InstallIntent, ReleaseArtifact, ReleaseManifest,
+    UpdateBackend, UpdateCheckRequest, UpdateError,
+};
+
+use crate::{linux, macos, windows};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum DesktopPlatform {
+    MacOs { bundle_id: String },
+    Windows,
+    Linux,
+}
+
+#[derive(Debug, Clone)]
+pub struct DesktopUpdateBackend {
+    platform: DesktopPlatform,
+    download_dir: PathBuf,
+}
+
+impl DesktopUpdateBackend {
+    pub fn new(platform: DesktopPlatform, download_dir: impl AsRef<Path>) -> Self {
+        Self {
+            platform,
+            download_dir: download_dir.as_ref().to_path_buf(),
+        }
+    }
+
+    pub fn build_install_intent(
+        &self,
+        artifact: &ReleaseArtifact,
+        downloaded_file: PathBuf,
+    ) -> Result<InstallIntent, UpdateError> {
+        match &self.platform {
+            DesktopPlatform::MacOs { bundle_id } => {
+                macos::build_install_intent(bundle_id, artifact, downloaded_file)
+            }
+            DesktopPlatform::Windows => windows::build_install_intent(artifact, downloaded_file),
+            DesktopPlatform::Linux => linux::build_install_intent(artifact, downloaded_file),
+        }
+    }
+}
+
+impl UpdateBackend for DesktopUpdateBackend {
+    fn check_for_update(
+        &self,
+        manifest: &ReleaseManifest,
+        request: &UpdateCheckRequest,
+    ) -> Result<Option<ReleaseArtifact>, UpdateError> {
+        let (platform_name, expected_target_id) = match &self.platform {
+            DesktopPlatform::MacOs { bundle_id } => ("macos", bundle_id.as_str()),
+            DesktopPlatform::Windows => {
+                return Err(UpdateError::Backend(
+                    "windows desktop updater backend is unsupported in v1".to_string(),
+                ))
+            }
+            DesktopPlatform::Linux => {
+                return Err(UpdateError::Backend(
+                    "linux desktop updater backend is unsupported in v1".to_string(),
+                ))
+            }
+        };
+
+        if request.platform != platform_name {
+            return Err(UpdateError::Backend(format!(
+                "desktop backend for '{}' cannot handle platform '{}'",
+                platform_name, request.platform
+            )));
+        }
+        if request.target_id != expected_target_id {
+            return Err(UpdateError::Backend(format!(
+                "desktop request target_id '{}' does not match backend target_id '{}'",
+                request.target_id, expected_target_id
+            )));
+        }
+
+        let Some(artifact) = manifest
+            .select_artifact(platform_name, &request.arch, expected_target_id)
+            .cloned()
+        else {
+            return Ok(None);
+        };
+
+        let is_newer = is_newer_release(&request.current_version, &manifest.version)?;
+        if !is_newer {
+            return Ok(None);
+        }
+
+        Ok(Some(artifact))
+    }
+
+    fn download_artifact(&self, artifact: &ReleaseArtifact) -> Result<InstallIntent, UpdateError> {
+        let file_name = artifact
+            .url
+            .rsplit('/')
+            .next()
+            .filter(|name| !name.is_empty())
+            .unwrap_or("update.bin");
+        let downloaded_file = self.download_dir.join(file_name);
+
+        self.build_install_intent(artifact, downloaded_file)
+    }
+
+    fn install_update(&self, intent: &InstallIntent) -> Result<(), UpdateError> {
+        match (&self.platform, &intent.handoff) {
+            (
+                DesktopPlatform::MacOs { bundle_id },
+                InstallHandoff::MacOsBundleReplace {
+                    bundle_id: intent_bundle_id,
+                },
+            ) if bundle_id == intent_bundle_id && intent.artifact.target_id == *bundle_id => Ok(()),
+            (DesktopPlatform::Windows, _) => Err(UpdateError::Backend(
+                "windows desktop updater backend is unsupported in v1".to_string(),
+            )),
+            (DesktopPlatform::Linux, _) => Err(UpdateError::Backend(
+                "linux desktop updater backend is unsupported in v1".to_string(),
+            )),
+            _ => Err(UpdateError::Backend(
+                "desktop install intent does not match the backend platform".to_string(),
+            )),
+        }
+    }
+}

--- a/extensions/blinc_update_desktop/src/backend.rs
+++ b/extensions/blinc_update_desktop/src/backend.rs
@@ -96,9 +96,19 @@ impl UpdateBackend for DesktopUpdateBackend {
             .url
             .rsplit('/')
             .next()
-            .filter(|name| !name.is_empty())
-            .unwrap_or("update.bin");
-        let downloaded_file = self.download_dir.join(file_name);
+            .and_then(|name| name.split(['?', '#']).next())
+            .unwrap_or("");
+        if file_name == "." || file_name == ".." || file_name.contains(['/', '\\']) {
+            return Err(UpdateError::Backend(
+                "desktop backend derived an unsafe download file name from artifact url"
+                    .to_string(),
+            ));
+        }
+        let downloaded_file = self.download_dir.join(if file_name.is_empty() {
+            "update.bin"
+        } else {
+            file_name
+        });
 
         self.build_install_intent(artifact, downloaded_file)
     }

--- a/extensions/blinc_update_desktop/src/lib.rs
+++ b/extensions/blinc_update_desktop/src/lib.rs
@@ -184,4 +184,34 @@ mod tests {
             .install_update(&intent)
             .expect("macOS backend should accept matching bundle-replace handoffs");
     }
+
+    #[test]
+    fn macos_backend_rejects_dot_segment_download_names() {
+        let backend = DesktopUpdateBackend::new(
+            DesktopPlatform::MacOs {
+                bundle_id: "io.test.demo".to_string(),
+            },
+            "/tmp/downloads",
+        );
+        let artifact = ReleaseArtifact {
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            target_id: "io.test.demo".to_string(),
+            url: "https://example.com/releases/..".to_string(),
+            size: 42,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+            signature:
+                "CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQ=="
+                    .to_string(),
+        };
+
+        let err = backend
+            .download_artifact(&artifact)
+            .expect_err("desktop backends should reject dot-segment file names derived from URLs");
+        assert!(
+            matches!(err, UpdateError::Backend(message) if message.contains("unsafe")),
+            "unsafe file names should be rejected before joining them into the download directory"
+        );
+    }
 }

--- a/extensions/blinc_update_desktop/src/lib.rs
+++ b/extensions/blinc_update_desktop/src/lib.rs
@@ -1,0 +1,187 @@
+mod backend;
+mod linux;
+mod macos;
+mod windows;
+
+pub use backend::{DesktopPlatform, DesktopUpdateBackend};
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use blinc_update::{
+        InstallHandoff, InstallIntent, ReleaseArtifact, ReleaseChannel, ReleaseManifest,
+        UpdateBackend, UpdateCheckRequest, UpdateError,
+    };
+
+    use crate::{DesktopPlatform, DesktopUpdateBackend};
+
+    #[test]
+    fn macos_backend_emits_bundle_replace_install_intent() {
+        let backend = DesktopUpdateBackend::new(
+            DesktopPlatform::MacOs {
+                bundle_id: "io.test.demo".to_string(),
+            },
+            "/tmp/downloads",
+        );
+        let artifact = ReleaseArtifact {
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            target_id: "io.test.demo".to_string(),
+            url: "https://example.com/releases/Demo.zip".to_string(),
+            size: 42,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+            signature:
+                "CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQ=="
+                    .to_string(),
+        };
+        let bundle_path = PathBuf::from("/tmp/downloads/Demo.app");
+
+        let intent = backend
+            .build_install_intent(&artifact, bundle_path.clone())
+            .expect("macOS backend should build a bundle replacement handoff intent");
+
+        assert_eq!(
+            intent.downloaded_file, bundle_path,
+            "install intent should point at the downloaded macOS artifact"
+        );
+        assert_eq!(
+            intent.handoff,
+            InstallHandoff::MacOsBundleReplace {
+                bundle_id: "io.test.demo".to_string(),
+            },
+            "macOS backend should request bundle replacement handoff"
+        );
+    }
+
+    #[test]
+    fn windows_backend_reports_unsupported_for_now() {
+        let backend = DesktopUpdateBackend::new(DesktopPlatform::Windows, "/tmp/downloads");
+        let artifact = ReleaseArtifact {
+            platform: "windows".to_string(),
+            arch: "x86_64".to_string(),
+            target_id: "Demo".to_string(),
+            url: "https://example.com/releases/Demo.msi".to_string(),
+            size: 42,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+            signature:
+                "CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQ=="
+                    .to_string(),
+        };
+
+        let err = backend
+            .build_install_intent(&artifact, PathBuf::from("/tmp/downloads/Demo.msi"))
+            .expect_err("windows backend should stay unsupported in v1");
+        assert!(
+            matches!(err, UpdateError::Backend(message) if message.contains("unsupported")),
+            "windows backend should report an explicit unsupported error"
+        );
+    }
+
+    #[test]
+    fn linux_backend_reports_unsupported_for_now() {
+        let backend = DesktopUpdateBackend::new(DesktopPlatform::Linux, "/tmp/downloads");
+        let artifact = ReleaseArtifact {
+            platform: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            target_id: "demo.desktop".to_string(),
+            url: "https://example.com/releases/Demo.AppImage".to_string(),
+            size: 42,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+            signature:
+                "CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQ=="
+                    .to_string(),
+        };
+
+        let err = backend
+            .build_install_intent(&artifact, PathBuf::from("/tmp/downloads/Demo.AppImage"))
+            .expect_err("linux backend should stay unsupported in v1");
+        assert!(
+            matches!(err, UpdateError::Backend(message) if message.contains("unsupported")),
+            "linux backend should report an explicit unsupported error"
+        );
+    }
+
+    #[test]
+    fn macos_backend_selects_newer_matching_release() {
+        let backend = DesktopUpdateBackend::new(
+            DesktopPlatform::MacOs {
+                bundle_id: "io.test.demo".to_string(),
+            },
+            "/tmp/downloads",
+        );
+        let artifact = ReleaseArtifact {
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            target_id: "io.test.demo".to_string(),
+            url: "https://example.com/releases/Demo.zip".to_string(),
+            size: 42,
+            sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+            signature:
+                "CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQ=="
+                    .to_string(),
+        };
+        let manifest = ReleaseManifest {
+            schema_version: 1,
+            product: "Demo".to_string(),
+            channel: ReleaseChannel::Stable,
+            version: "1.2.4".to_string(),
+            published_at: "2026-03-07T00:00:00Z".to_string(),
+            notes_url: None,
+            artifacts: vec![artifact.clone()],
+        };
+        let request = UpdateCheckRequest {
+            platform: "macos".to_string(),
+            arch: "universal".to_string(),
+            target_id: "io.test.demo".to_string(),
+            current_version: "1.2.3".to_string(),
+        };
+
+        let selected = backend
+            .check_for_update(&manifest, &request)
+            .expect("macOS backend should compare versions and select matching artifacts")
+            .expect("macOS backend should return the newer matching artifact");
+
+        assert_eq!(
+            selected.url, artifact.url,
+            "macOS backend should return the matching desktop artifact"
+        );
+    }
+
+    #[test]
+    fn macos_backend_accepts_matching_install_handoff() {
+        let backend = DesktopUpdateBackend::new(
+            DesktopPlatform::MacOs {
+                bundle_id: "io.test.demo".to_string(),
+            },
+            "/tmp/downloads",
+        );
+        let intent = InstallIntent {
+            artifact: ReleaseArtifact {
+                platform: "macos".to_string(),
+                arch: "universal".to_string(),
+                target_id: "io.test.demo".to_string(),
+                url: "https://example.com/releases/Demo.zip".to_string(),
+                size: 42,
+                sha256:
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                        .to_string(),
+                signature:
+                    "CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQ=="
+                        .to_string(),
+            },
+            downloaded_file: PathBuf::from("/tmp/downloads/Demo.app"),
+            handoff: InstallHandoff::MacOsBundleReplace {
+                bundle_id: "io.test.demo".to_string(),
+            },
+        };
+
+        backend
+            .install_update(&intent)
+            .expect("macOS backend should accept matching bundle-replace handoffs");
+    }
+}

--- a/extensions/blinc_update_desktop/src/linux.rs
+++ b/extensions/blinc_update_desktop/src/linux.rs
@@ -1,0 +1,11 @@
+use blinc_update::{InstallIntent, ReleaseArtifact, UpdateError};
+use std::path::PathBuf;
+
+pub(crate) fn build_install_intent(
+    _artifact: &ReleaseArtifact,
+    _downloaded_file: PathBuf,
+) -> Result<InstallIntent, UpdateError> {
+    Err(UpdateError::Backend(
+        "linux desktop updater backend is unsupported in v1".to_string(),
+    ))
+}

--- a/extensions/blinc_update_desktop/src/macos.rs
+++ b/extensions/blinc_update_desktop/src/macos.rs
@@ -1,0 +1,28 @@
+use blinc_update::{InstallHandoff, InstallIntent, ReleaseArtifact, UpdateError};
+use std::path::PathBuf;
+
+pub(crate) fn build_install_intent(
+    bundle_id: &str,
+    artifact: &ReleaseArtifact,
+    downloaded_file: PathBuf,
+) -> Result<InstallIntent, UpdateError> {
+    if artifact.platform != "macos" {
+        return Err(UpdateError::Backend(
+            "macOS backend only accepts macOS artifacts".to_string(),
+        ));
+    }
+    if artifact.target_id != bundle_id {
+        return Err(UpdateError::Backend(format!(
+            "macOS artifact target_id '{}' does not match expected target_id '{}'",
+            artifact.target_id, bundle_id
+        )));
+    }
+
+    Ok(InstallIntent {
+        artifact: artifact.clone(),
+        downloaded_file,
+        handoff: InstallHandoff::MacOsBundleReplace {
+            bundle_id: bundle_id.to_string(),
+        },
+    })
+}

--- a/extensions/blinc_update_desktop/src/windows.rs
+++ b/extensions/blinc_update_desktop/src/windows.rs
@@ -1,0 +1,11 @@
+use blinc_update::{InstallIntent, ReleaseArtifact, UpdateError};
+use std::path::PathBuf;
+
+pub(crate) fn build_install_intent(
+    _artifact: &ReleaseArtifact,
+    _downloaded_file: PathBuf,
+) -> Result<InstallIntent, UpdateError> {
+    Err(UpdateError::Backend(
+        "windows desktop updater backend is unsupported in v1".to_string(),
+    ))
+}


### PR DESCRIPTION
## Summary
- add the shared updater domain, signing and verification helpers, and user-callable release manifest generation
- add Android private-distribution and desktop updater backends, with macOS as the current desktop reference path
- align project scaffolding and release docs/contracts with .blincproj-based updater workflows and manifest safety checks

## Test Plan
- cargo test -p blinc_cli
- cargo test -p blinc_update
- cargo test -p blinc_update_android
- cargo test -p blinc_update_desktop
- cargo fmt --all
- cargo fmt --all -- --check
