### PR TITLE
app: expose headless windowed context helpers

### DIFF
--- a/crates/blinc_animation/src/scheduler.rs
+++ b/crates/blinc_animation/src/scheduler.rs
@@ -202,6 +202,16 @@ impl AnimationScheduler {
         self.wake_callback = Some(Arc::new(callback));
     }
 
+    /// Set the wake callback from an existing shared callback value.
+    pub fn set_wake_callback_arc(&mut self, callback: WakeCallback) {
+        self.wake_callback = Some(callback);
+    }
+
+    /// Remove any previously configured wake callback.
+    pub fn clear_wake_callback(&mut self) {
+        self.wake_callback = None;
+    }
+
     /// Start the scheduler on a background thread
     ///
     /// This ensures animations continue even when the window loses focus.
@@ -325,6 +335,25 @@ impl AnimationScheduler {
             let _ = handle.join();
         }
         self.stop_flag.store(false, Ordering::Relaxed);
+    }
+
+    /// Reset scheduler state before reusing it for a new runtime session.
+    ///
+    /// This stops any existing background loop, clears registered animations and
+    /// tick callbacks, and drops wake/redraw state so a later runtime can bind a
+    /// fresh event loop callback without inheriting stale session state.
+    pub fn reset_runtime_state(&mut self) {
+        self.stop_background();
+        self.clear_wake_callback();
+        self.needs_redraw.store(false, Ordering::Release);
+        self.continuous_redraw.store(false, Ordering::Release);
+
+        let mut inner = self.inner.lock().unwrap();
+        inner.springs.clear();
+        inner.keyframes.clear();
+        inner.timelines.clear();
+        inner.tick_callbacks.clear();
+        inner.last_frame = Instant::now();
     }
 
     /// Check if the background thread is running

--- a/crates/blinc_app/src/android.rs
+++ b/crates/blinc_app/src/android.rs
@@ -259,7 +259,9 @@ impl AndroidApp {
         // Set global scheduler handle
         {
             let scheduler_handle = animations.lock().unwrap().handle();
-            blinc_animation::set_global_scheduler(scheduler_handle);
+            if !blinc_animation::is_scheduler_initialized() {
+                blinc_animation::set_global_scheduler(scheduler_handle);
+            }
         }
 
         // Element registry for query API

--- a/crates/blinc_app/src/android.rs
+++ b/crates/blinc_app/src/android.rs
@@ -28,7 +28,6 @@ use android_activity::input::{InputEvent as AndroidInputEvent, MotionAction};
 use android_activity::{AndroidApp as NdkAndroidApp, InputStatus, MainEvent, PollEvent};
 use ndk::native_window::NativeWindow;
 
-use blinc_animation::AnimationScheduler;
 use blinc_core::context_state::{BlincContextState, HookState, SharedHookState};
 use blinc_core::reactive::{ReactiveGraph, SignalId};
 use blinc_layout::event_router::MouseButton;
@@ -47,8 +46,8 @@ use blinc_platform_android::AndroidAssetLoader;
 use crate::app::BlincApp;
 use crate::error::{BlincError, Result};
 use crate::windowed::{
-    RefDirtyFlag, SharedAnimationScheduler, SharedElementRegistry, SharedReactiveGraph,
-    SharedReadyCallbacks, WindowedContext,
+    shared_runtime_scheduler, RefDirtyFlag, SharedAnimationScheduler, SharedElementRegistry,
+    SharedReactiveGraph, SharedReadyCallbacks, WindowedContext,
 };
 
 /// Android application runner
@@ -253,8 +252,7 @@ impl AndroidApp {
         // Animation scheduler - single-threaded for mobile efficiency
         // Unlike desktop, we tick animations on main thread to avoid mutex contention
         // and high CPU usage from background thread + main thread fighting
-        let scheduler = AnimationScheduler::new();
-        let animations: SharedAnimationScheduler = Arc::new(Mutex::new(scheduler));
+        let animations: SharedAnimationScheduler = shared_runtime_scheduler();
 
         // Set global scheduler handle
         {

--- a/crates/blinc_app/src/android.rs
+++ b/crates/blinc_app/src/android.rs
@@ -46,7 +46,7 @@ use blinc_platform_android::AndroidAssetLoader;
 use crate::app::BlincApp;
 use crate::error::{BlincError, Result};
 use crate::windowed::{
-    shared_runtime_scheduler, RefDirtyFlag, SharedAnimationScheduler, SharedElementRegistry,
+    prepare_runtime_scheduler, RefDirtyFlag, SharedAnimationScheduler, SharedElementRegistry,
     SharedReactiveGraph, SharedReadyCallbacks, WindowedContext,
 };
 
@@ -252,7 +252,7 @@ impl AndroidApp {
         // Animation scheduler - single-threaded for mobile efficiency
         // Unlike desktop, we tick animations on main thread to avoid mutex contention
         // and high CPU usage from background thread + main thread fighting
-        let animations: SharedAnimationScheduler = shared_runtime_scheduler();
+        let animations: SharedAnimationScheduler = prepare_runtime_scheduler(None, false);
 
         // Set global scheduler handle
         {

--- a/crates/blinc_app/src/automation_session/mod.rs
+++ b/crates/blinc_app/src/automation_session/mod.rs
@@ -144,7 +144,7 @@ where
             Arc::new(Mutex::new(Vec::new()));
         let pending_focus_changes: PendingFocusChanges = Arc::new(Mutex::new(Vec::new()));
         let pending_scroll_requests: PendingScrollRequests = Arc::new(Mutex::new(Vec::new()));
-        let mut ctx = WindowedContext::new_headless(
+        let mut ctx = WindowedContext::new_headless_runtime(
             runtime_cfg.width as f32,
             runtime_cfg.height as f32,
             animations,

--- a/crates/blinc_app/src/ios.rs
+++ b/crates/blinc_app/src/ios.rs
@@ -32,6 +32,7 @@ use std::sync::{
     Arc, Mutex,
 };
 
+use blinc_animation::scheduler::WakeCallback;
 use blinc_core::context_state::{BlincContextState, HookState, SharedHookState};
 use blinc_core::reactive::{ReactiveGraph, SignalId};
 use blinc_layout::event_router::MouseButton;
@@ -199,7 +200,8 @@ impl IOSApp {
         // Animation scheduler with wake proxy
         // Set up wake proxy for iOS
         let wake_proxy = IOSWakeProxy::new();
-        let wake_callback: blinc_animation::WakeCallback = Arc::new(move || wake_proxy.wake());
+        let wake_proxy_for_callback = wake_proxy.clone();
+        let wake_callback: WakeCallback = Arc::new(move || wake_proxy_for_callback.wake());
         let animations: SharedAnimationScheduler =
             prepare_runtime_scheduler(Some(wake_callback), true);
 

--- a/crates/blinc_app/src/ios.rs
+++ b/crates/blinc_app/src/ios.rs
@@ -49,7 +49,7 @@ use blinc_platform_ios::{Gesture, GestureDetector, IOSAssetLoader, IOSWakeProxy,
 use crate::app::BlincApp;
 use crate::error::{BlincError, Result};
 use crate::windowed::{
-    shared_runtime_scheduler, RefDirtyFlag, SharedAnimationScheduler, SharedElementRegistry,
+    prepare_runtime_scheduler, RefDirtyFlag, SharedAnimationScheduler, SharedElementRegistry,
     SharedReactiveGraph, SharedReadyCallbacks, WindowedContext,
 };
 
@@ -197,16 +197,11 @@ impl IOSApp {
         }
 
         // Animation scheduler with wake proxy
-        let animations: SharedAnimationScheduler = shared_runtime_scheduler();
-
         // Set up wake proxy for iOS
         let wake_proxy = IOSWakeProxy::new();
-        let wake_proxy_clone = wake_proxy.clone();
-        {
-            let mut scheduler = animations.lock().unwrap();
-            scheduler.set_wake_callback(move || wake_proxy_clone.wake());
-            scheduler.start_background();
-        }
+        let wake_callback: blinc_animation::WakeCallback = Arc::new(move || wake_proxy.wake());
+        let animations: SharedAnimationScheduler =
+            prepare_runtime_scheduler(Some(wake_callback), true);
 
         // Set global scheduler handle
         {

--- a/crates/blinc_app/src/ios.rs
+++ b/crates/blinc_app/src/ios.rs
@@ -32,7 +32,6 @@ use std::sync::{
     Arc, Mutex,
 };
 
-use blinc_animation::AnimationScheduler;
 use blinc_core::context_state::{BlincContextState, HookState, SharedHookState};
 use blinc_core::reactive::{ReactiveGraph, SignalId};
 use blinc_layout::event_router::MouseButton;
@@ -50,8 +49,8 @@ use blinc_platform_ios::{Gesture, GestureDetector, IOSAssetLoader, IOSWakeProxy,
 use crate::app::BlincApp;
 use crate::error::{BlincError, Result};
 use crate::windowed::{
-    RefDirtyFlag, SharedAnimationScheduler, SharedElementRegistry, SharedReactiveGraph,
-    SharedReadyCallbacks, WindowedContext,
+    shared_runtime_scheduler, RefDirtyFlag, SharedAnimationScheduler, SharedElementRegistry,
+    SharedReactiveGraph, SharedReadyCallbacks, WindowedContext,
 };
 
 /// iOS application runner
@@ -198,15 +197,16 @@ impl IOSApp {
         }
 
         // Animation scheduler with wake proxy
-        let mut scheduler = AnimationScheduler::new();
+        let animations: SharedAnimationScheduler = shared_runtime_scheduler();
 
         // Set up wake proxy for iOS
         let wake_proxy = IOSWakeProxy::new();
         let wake_proxy_clone = wake_proxy.clone();
-        scheduler.set_wake_callback(move || wake_proxy_clone.wake());
-
-        scheduler.start_background();
-        let animations: SharedAnimationScheduler = Arc::new(Mutex::new(scheduler));
+        {
+            let mut scheduler = animations.lock().unwrap();
+            scheduler.set_wake_callback(move || wake_proxy_clone.wake());
+            scheduler.start_background();
+        }
 
         // Set global scheduler handle
         {

--- a/crates/blinc_app/src/ios.rs
+++ b/crates/blinc_app/src/ios.rs
@@ -211,7 +211,9 @@ impl IOSApp {
         // Set global scheduler handle
         {
             let scheduler_handle = animations.lock().unwrap().handle();
-            blinc_animation::set_global_scheduler(scheduler_handle);
+            if !blinc_animation::is_scheduler_initialized() {
+                blinc_animation::set_global_scheduler(scheduler_handle);
+            }
         }
 
         // Element registry for query API

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -663,7 +663,8 @@ impl WindowedContext {
 
         let global = BlincContextState::get();
         global.set_viewport_size(logical_width, logical_height);
-        global.set_element_registry(Arc::clone(&element_registry) as blinc_core::AnyElementRegistry);
+        global
+            .set_element_registry(Arc::clone(&element_registry) as blinc_core::AnyElementRegistry);
 
         ctx
     }
@@ -882,7 +883,9 @@ impl WindowedContext {
 
         let global = BlincContextState::get();
         global.set_viewport_size(logical_width, logical_height);
-        global.set_element_registry(Arc::clone(&self.element_registry) as blinc_core::AnyElementRegistry);
+        global.set_element_registry(
+            Arc::clone(&self.element_registry) as blinc_core::AnyElementRegistry
+        );
     }
 
     /// Update context from window (preserving event router, dirty flag, and reactive graph)

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -575,9 +575,9 @@ pub type ReadyCallback = Box<dyn FnOnce() + Send + Sync>;
 /// Shared storage for ready callbacks
 pub type SharedReadyCallbacks = Arc<Mutex<Vec<ReadyCallback>>>;
 
-fn shared_headless_scheduler() -> SharedAnimationScheduler {
-    static HEADLESS_SCHEDULER: OnceLock<SharedAnimationScheduler> = OnceLock::new();
-    HEADLESS_SCHEDULER
+pub(crate) fn shared_runtime_scheduler() -> SharedAnimationScheduler {
+    static RUNTIME_SCHEDULER: OnceLock<SharedAnimationScheduler> = OnceLock::new();
+    RUNTIME_SCHEDULER
         .get_or_init(|| Arc::new(Mutex::new(AnimationScheduler::new())))
         .clone()
 }
@@ -648,16 +648,8 @@ impl WindowedContext {
         let _init_guard = headless_context_init_lock()
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        let animations = shared_headless_scheduler();
-        let (global, reactive, hooks, ref_dirty_flag) = if BlincContextState::is_initialized() {
-            let global = BlincContextState::get();
-            (
-                global,
-                global.active_reactive(),
-                global.active_hooks(),
-                global.active_dirty_flag(),
-            )
-        } else {
+        let animations = shared_runtime_scheduler();
+        if !BlincContextState::is_initialized() {
             let reactive: SharedReactiveGraph = Arc::new(Mutex::new(ReactiveGraph::new()));
             let hooks: SharedHookState = Arc::new(Mutex::new(HookState::new()));
             let ref_dirty_flag: RefDirtyFlag = Arc::new(AtomicBool::new(false));
@@ -670,8 +662,12 @@ impl WindowedContext {
                 Arc::clone(&ref_dirty_flag),
                 stateful_callback,
             );
-            (BlincContextState::get(), reactive, hooks, ref_dirty_flag)
-        };
+        }
+
+        let global = BlincContextState::get();
+        let reactive = global.active_reactive();
+        let hooks = global.active_hooks();
+        let ref_dirty_flag = global.active_dirty_flag();
         let element_registry: SharedElementRegistry = if let Some(existing) =
             global.element_registry::<blinc_layout::selector::ElementRegistry>()
         {
@@ -688,10 +684,10 @@ impl WindowedContext {
             logical_width,
             logical_height,
             animations,
-            Arc::clone(&ref_dirty_flag),
-            Arc::clone(&reactive),
-            Arc::clone(&hooks),
-            Arc::clone(&element_registry),
+            ref_dirty_flag,
+            reactive,
+            hooks,
+            element_registry,
             ready_callbacks,
         );
 
@@ -2476,11 +2472,13 @@ impl WindowedApp {
 
         // Shared animation scheduler for spring/keyframe animations
         // Runs on background thread so animations continue even when window loses focus
-        let mut scheduler = AnimationScheduler::new();
-        // Set up wake callback so animation thread can wake the event loop
-        scheduler.set_wake_callback(move || wake_proxy.wake());
-        scheduler.start_background();
-        let animations: SharedAnimationScheduler = Arc::new(Mutex::new(scheduler));
+        let animations = shared_runtime_scheduler();
+        {
+            let mut scheduler = animations.lock().unwrap();
+            // Set up wake callback so animation thread can wake the event loop
+            scheduler.set_wake_callback(move || wake_proxy.wake());
+            scheduler.start_background();
+        }
 
         // Set global scheduler handle for StateContext and component access
         {

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -28,6 +28,7 @@ use std::sync::{
     Arc, Mutex, OnceLock,
 };
 
+use blinc_animation::scheduler::WakeCallback;
 use blinc_animation::{
     AnimatedTimeline, AnimatedValue, AnimationContext, AnimationScheduler, SchedulerHandle,
     SharedAnimatedTimeline, SharedAnimatedValue, SpringConfig,
@@ -582,6 +583,24 @@ pub(crate) fn shared_runtime_scheduler() -> SharedAnimationScheduler {
         .clone()
 }
 
+pub(crate) fn prepare_runtime_scheduler(
+    wake_callback: Option<WakeCallback>,
+    run_background: bool,
+) -> SharedAnimationScheduler {
+    let scheduler = shared_runtime_scheduler();
+    {
+        let mut guard = scheduler.lock().unwrap();
+        guard.reset_runtime_state();
+        if let Some(callback) = wake_callback {
+            guard.set_wake_callback_arc(callback);
+        }
+        if run_background {
+            guard.start_background();
+        }
+    }
+    scheduler
+}
+
 fn headless_context_init_lock() -> &'static Mutex<()> {
     static HEADLESS_CONTEXT_INIT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     HEADLESS_CONTEXT_INIT_LOCK.get_or_init(|| Mutex::new(()))
@@ -639,6 +658,48 @@ pub struct WindowedContext {
 }
 
 impl WindowedContext {
+    fn ensure_global_context_state() -> (
+        &'static BlincContextState,
+        SharedReactiveGraph,
+        SharedHookState,
+        RefDirtyFlag,
+    ) {
+        if !BlincContextState::is_initialized() {
+            let reactive: SharedReactiveGraph = Arc::new(Mutex::new(ReactiveGraph::new()));
+            let hooks: SharedHookState = Arc::new(Mutex::new(HookState::new()));
+            let ref_dirty_flag: RefDirtyFlag = Arc::new(AtomicBool::new(false));
+            let stateful_callback: StatefulCallback = Arc::new(|signal_ids| {
+                blinc_layout::check_stateful_deps(signal_ids);
+            });
+            BlincContextState::init_with_callback(
+                reactive,
+                hooks,
+                ref_dirty_flag,
+                stateful_callback,
+            );
+        }
+
+        let global = BlincContextState::get();
+        (
+            global,
+            global.active_reactive(),
+            global.active_hooks(),
+            global.active_dirty_flag(),
+        )
+    }
+
+    fn ensure_element_registry(global: &'static BlincContextState) -> SharedElementRegistry {
+        if let Some(existing) = global.element_registry::<blinc_layout::selector::ElementRegistry>()
+        {
+            existing
+        } else {
+            let registry: SharedElementRegistry =
+                Arc::new(blinc_layout::selector::ElementRegistry::new());
+            global.set_element_registry(Arc::clone(&registry) as blinc_core::AnyElementRegistry);
+            registry
+        }
+    }
+
     /// Create a deterministic headless context for offscreen rendering and screenshot tests.
     ///
     /// Unlike the internal runtime constructor, this convenience API initializes the
@@ -649,35 +710,8 @@ impl WindowedContext {
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         let animations = shared_runtime_scheduler();
-        if !BlincContextState::is_initialized() {
-            let reactive: SharedReactiveGraph = Arc::new(Mutex::new(ReactiveGraph::new()));
-            let hooks: SharedHookState = Arc::new(Mutex::new(HookState::new()));
-            let ref_dirty_flag: RefDirtyFlag = Arc::new(AtomicBool::new(false));
-            let stateful_callback: StatefulCallback = Arc::new(|signal_ids| {
-                blinc_layout::check_stateful_deps(signal_ids);
-            });
-            BlincContextState::init_with_callback(
-                Arc::clone(&reactive),
-                Arc::clone(&hooks),
-                Arc::clone(&ref_dirty_flag),
-                stateful_callback,
-            );
-        }
-
-        let global = BlincContextState::get();
-        let reactive = global.active_reactive();
-        let hooks = global.active_hooks();
-        let ref_dirty_flag = global.active_dirty_flag();
-        let element_registry: SharedElementRegistry = if let Some(existing) =
-            global.element_registry::<blinc_layout::selector::ElementRegistry>()
-        {
-            existing
-        } else {
-            let registry: SharedElementRegistry =
-                Arc::new(blinc_layout::selector::ElementRegistry::new());
-            global.set_element_registry(Arc::clone(&registry) as blinc_core::AnyElementRegistry);
-            registry
-        };
+        let (global, reactive, hooks, ref_dirty_flag) = Self::ensure_global_context_state();
+        let element_registry = Self::ensure_element_registry(global);
         let ready_callbacks: SharedReadyCallbacks = Arc::new(Mutex::new(Vec::new()));
 
         let ctx = Self::new_headless_runtime(
@@ -2114,7 +2148,8 @@ impl WindowedContext {
 
 #[cfg(test)]
 mod windowed_context_tests {
-    use super::WindowedContext;
+    use super::{prepare_runtime_scheduler, shared_runtime_scheduler, WindowedContext};
+    use blinc_animation::scheduler::WakeCallback;
     use blinc_core::BlincContextState;
     use std::sync::{Arc, Mutex, OnceLock};
 
@@ -2175,6 +2210,27 @@ mod windowed_context_tests {
             first.element_registry(),
             second.element_registry()
         ));
+    }
+
+    #[test]
+    fn prepare_runtime_scheduler_resets_shared_state_between_runs() {
+        let _guard = test_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let scheduler = shared_runtime_scheduler();
+        {
+            let mut guard = scheduler.lock().unwrap();
+            guard.add_tick_callback(|_| {});
+            let wake_callback: WakeCallback = Arc::new(|| {});
+            guard.set_wake_callback_arc(wake_callback);
+            guard.start_background();
+        }
+
+        let prepared = prepare_runtime_scheduler(None, false);
+
+        assert!(Arc::ptr_eq(&scheduler, &prepared));
+        let guard = prepared.lock().unwrap();
+        assert_eq!(guard.tick_callback_count(), 0);
+        assert!(!guard.is_background_running());
+        assert!(!guard.is_continuous_redraw());
     }
 }
 
@@ -2472,13 +2528,8 @@ impl WindowedApp {
 
         // Shared animation scheduler for spring/keyframe animations
         // Runs on background thread so animations continue even when window loses focus
-        let animations = shared_runtime_scheduler();
-        {
-            let mut scheduler = animations.lock().unwrap();
-            // Set up wake callback so animation thread can wake the event loop
-            scheduler.set_wake_callback(move || wake_proxy.wake());
-            scheduler.start_background();
-        }
+        let wake_callback: WakeCallback = Arc::new(move || wake_proxy.wake());
+        let animations = prepare_runtime_scheduler(Some(wake_callback), true);
 
         // Set global scheduler handle for StateContext and component access
         {

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -25,7 +25,7 @@
 use std::hash::Hash;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
+    Arc, Mutex, OnceLock,
 };
 
 use blinc_animation::{
@@ -575,6 +575,13 @@ pub type ReadyCallback = Box<dyn FnOnce() + Send + Sync>;
 /// Shared storage for ready callbacks
 pub type SharedReadyCallbacks = Arc<Mutex<Vec<ReadyCallback>>>;
 
+fn shared_headless_scheduler() -> SharedAnimationScheduler {
+    static HEADLESS_SCHEDULER: OnceLock<SharedAnimationScheduler> = OnceLock::new();
+    HEADLESS_SCHEDULER
+        .get_or_init(|| Arc::new(Mutex::new(AnimationScheduler::new())))
+        .clone()
+}
+
 /// Context passed to the UI builder function
 pub struct WindowedContext {
     /// Current window width in logical pixels (for UI layout)
@@ -633,10 +640,25 @@ impl WindowedContext {
     /// shared animation/context globals when they are not yet available so tests can
     /// build a `WindowedContext` without recreating the full windowed runtime setup.
     pub fn new_headless(logical_width: f32, logical_height: f32) -> Self {
-        let animations: SharedAnimationScheduler = Arc::new(Mutex::new(AnimationScheduler::new()));
-        let reactive: SharedReactiveGraph = Arc::new(Mutex::new(ReactiveGraph::new()));
-        let hooks: SharedHookState = Arc::new(Mutex::new(HookState::new()));
-        let ref_dirty_flag: RefDirtyFlag = Arc::new(AtomicBool::new(false));
+        let animations = shared_headless_scheduler();
+        let (reactive, hooks, ref_dirty_flag) = if BlincContextState::is_initialized() {
+            let global = BlincContextState::get();
+            (
+                global.active_reactive(),
+                global.active_hooks(),
+                global.active_dirty_flag(),
+            )
+        } else {
+            let reactive: SharedReactiveGraph = Arc::new(Mutex::new(ReactiveGraph::new()));
+            let hooks: SharedHookState = Arc::new(Mutex::new(HookState::new()));
+            let ref_dirty_flag: RefDirtyFlag = Arc::new(AtomicBool::new(false));
+            BlincContextState::init(
+                Arc::clone(&reactive),
+                Arc::clone(&hooks),
+                Arc::clone(&ref_dirty_flag),
+            );
+            (reactive, hooks, ref_dirty_flag)
+        };
         let element_registry: SharedElementRegistry =
             Arc::new(blinc_layout::selector::ElementRegistry::new());
         let ready_callbacks: SharedReadyCallbacks = Arc::new(Mutex::new(Vec::new()));
@@ -651,10 +673,6 @@ impl WindowedContext {
             Arc::clone(&element_registry),
             ready_callbacks,
         );
-
-        if !BlincContextState::is_initialized() {
-            BlincContextState::init(reactive, hooks, ref_dirty_flag);
-        }
 
         if !blinc_animation::is_scheduler_initialized() {
             let scheduler_handle = ctx.animations.lock().unwrap().handle();

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -627,6 +627,47 @@ pub struct WindowedContext {
 }
 
 impl WindowedContext {
+    /// Create a deterministic headless context for offscreen rendering and screenshot tests.
+    ///
+    /// Unlike the internal runtime constructor, this convenience API initializes the
+    /// shared animation/context globals when they are not yet available so tests can
+    /// build a `WindowedContext` without recreating the full windowed runtime setup.
+    pub fn new_headless(logical_width: f32, logical_height: f32) -> Self {
+        let animations: SharedAnimationScheduler = Arc::new(Mutex::new(AnimationScheduler::new()));
+        let reactive: SharedReactiveGraph = Arc::new(Mutex::new(ReactiveGraph::new()));
+        let hooks: SharedHookState = Arc::new(Mutex::new(HookState::new()));
+        let ref_dirty_flag: RefDirtyFlag = Arc::new(AtomicBool::new(false));
+        let element_registry: SharedElementRegistry =
+            Arc::new(blinc_layout::selector::ElementRegistry::new());
+        let ready_callbacks: SharedReadyCallbacks = Arc::new(Mutex::new(Vec::new()));
+
+        let ctx = Self::new_headless_runtime(
+            logical_width,
+            logical_height,
+            animations,
+            Arc::clone(&ref_dirty_flag),
+            Arc::clone(&reactive),
+            Arc::clone(&hooks),
+            Arc::clone(&element_registry),
+            ready_callbacks,
+        );
+
+        if !BlincContextState::is_initialized() {
+            BlincContextState::init(reactive, hooks, ref_dirty_flag);
+        }
+
+        if !blinc_animation::is_scheduler_initialized() {
+            let scheduler_handle = ctx.animations.lock().unwrap().handle();
+            blinc_animation::set_global_scheduler(scheduler_handle);
+        }
+
+        let global = BlincContextState::get();
+        global.set_viewport_size(logical_width, logical_height);
+        global.set_element_registry(Arc::clone(&element_registry) as blinc_core::AnyElementRegistry);
+
+        ctx
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn from_window<W: Window>(
         window: &W,
@@ -799,7 +840,7 @@ impl WindowedContext {
     }
 
     /// Create a deterministic windowless context for headless automation/testing.
-    pub(crate) fn new_headless(
+    pub(crate) fn new_headless_runtime(
         logical_width: f32,
         logical_height: f32,
         animations: SharedAnimationScheduler,
@@ -830,6 +871,18 @@ impl WindowedContext {
             stylesheet: None,
             css_sources: Vec::new(),
         }
+    }
+
+    /// Update the logical and physical size for a headless context.
+    pub fn set_headless_size(&mut self, logical_width: f32, logical_height: f32) {
+        self.width = logical_width;
+        self.height = logical_height;
+        self.physical_width = logical_width;
+        self.physical_height = logical_height;
+
+        let global = BlincContextState::get();
+        global.set_viewport_size(logical_width, logical_height);
+        global.set_element_registry(Arc::clone(&self.element_registry) as blinc_core::AnyElementRegistry);
     }
 
     /// Update context from window (preserving event router, dirty flag, and reactive graph)
@@ -2024,6 +2077,43 @@ impl WindowedContext {
                 self.stylesheet = Some(Arc::new(sheet));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod windowed_context_tests {
+    use super::WindowedContext;
+    use std::sync::{Mutex, OnceLock};
+
+    fn test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn headless_context_initializes_expected_defaults() {
+        let _guard = test_lock().lock().unwrap();
+        let ctx = WindowedContext::new_headless(640.0, 360.0);
+
+        assert_eq!(ctx.width, 640.0);
+        assert_eq!(ctx.height, 360.0);
+        assert_eq!(ctx.physical_width(), 640.0);
+        assert_eq!(ctx.physical_height(), 360.0);
+        assert_eq!(ctx.scale_factor, 1.0);
+        assert!(ctx.focused);
+    }
+
+    #[test]
+    fn headless_context_resize_updates_logical_and_physical_size() {
+        let _guard = test_lock().lock().unwrap();
+        let mut ctx = WindowedContext::new_headless(640.0, 360.0);
+
+        ctx.set_headless_size(1024.0, 768.0);
+
+        assert_eq!(ctx.width, 1024.0);
+        assert_eq!(ctx.height, 768.0);
+        assert_eq!(ctx.physical_width(), 1024.0);
+        assert_eq!(ctx.physical_height(), 768.0);
     }
 }
 

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -582,6 +582,11 @@ fn shared_headless_scheduler() -> SharedAnimationScheduler {
         .clone()
 }
 
+fn headless_context_init_lock() -> &'static Mutex<()> {
+    static HEADLESS_CONTEXT_INIT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    HEADLESS_CONTEXT_INIT_LOCK.get_or_init(|| Mutex::new(()))
+}
+
 /// Context passed to the UI builder function
 pub struct WindowedContext {
     /// Current window width in logical pixels (for UI layout)
@@ -640,6 +645,7 @@ impl WindowedContext {
     /// shared animation/context globals when they are not yet available so tests can
     /// build a `WindowedContext` without recreating the full windowed runtime setup.
     pub fn new_headless(logical_width: f32, logical_height: f32) -> Self {
+        let _init_guard = headless_context_init_lock().lock().unwrap();
         let animations = shared_headless_scheduler();
         let (reactive, hooks, ref_dirty_flag) = if BlincContextState::is_initialized() {
             let global = BlincContextState::get();

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -907,9 +907,6 @@ impl WindowedContext {
 
         let global = BlincContextState::get();
         global.set_viewport_size(logical_width, logical_height);
-        global.set_element_registry(
-            Arc::clone(&self.element_registry) as blinc_core::AnyElementRegistry
-        );
     }
 
     /// Update context from window (preserving event router, dirty flag, and reactive graph)
@@ -2110,7 +2107,8 @@ impl WindowedContext {
 #[cfg(test)]
 mod windowed_context_tests {
     use super::WindowedContext;
-    use std::sync::{Mutex, OnceLock};
+    use blinc_core::BlincContextState;
+    use std::sync::{Arc, Mutex, OnceLock};
 
     fn test_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -2141,6 +2139,22 @@ mod windowed_context_tests {
         assert_eq!(ctx.height, 768.0);
         assert_eq!(ctx.physical_width(), 1024.0);
         assert_eq!(ctx.physical_height(), 768.0);
+    }
+
+    #[test]
+    fn headless_context_resize_keeps_existing_global_registry() {
+        let _guard = test_lock().lock().unwrap();
+        let mut ctx = WindowedContext::new_headless(640.0, 360.0);
+        let before = BlincContextState::get()
+            .element_registry_any()
+            .expect("headless context installs a global element registry");
+
+        ctx.set_headless_size(1024.0, 768.0);
+
+        let after = BlincContextState::get()
+            .element_registry_any()
+            .expect("headless resize preserves a global element registry");
+        assert!(Arc::ptr_eq(&before, &after));
     }
 }
 

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -34,7 +34,7 @@ use blinc_animation::{
 };
 use blinc_core::context_state::{
     BlincContextState, ContextBindingOverride, ContextResourceOverride, HookState, SharedHookState,
-    StateKey,
+    StateKey, StatefulCallback,
 };
 use blinc_core::reactive::{Derived, ReactiveGraph, Signal, SignalId, State, StatefulDepsCallback};
 use blinc_layout::overlay_state::{get_overlay_manager, OverlayContext};
@@ -645,11 +645,14 @@ impl WindowedContext {
     /// shared animation/context globals when they are not yet available so tests can
     /// build a `WindowedContext` without recreating the full windowed runtime setup.
     pub fn new_headless(logical_width: f32, logical_height: f32) -> Self {
-        let _init_guard = headless_context_init_lock().lock().unwrap();
+        let _init_guard = headless_context_init_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let animations = shared_headless_scheduler();
-        let (reactive, hooks, ref_dirty_flag) = if BlincContextState::is_initialized() {
+        let (global, reactive, hooks, ref_dirty_flag) = if BlincContextState::is_initialized() {
             let global = BlincContextState::get();
             (
+                global,
                 global.active_reactive(),
                 global.active_hooks(),
                 global.active_dirty_flag(),
@@ -658,15 +661,27 @@ impl WindowedContext {
             let reactive: SharedReactiveGraph = Arc::new(Mutex::new(ReactiveGraph::new()));
             let hooks: SharedHookState = Arc::new(Mutex::new(HookState::new()));
             let ref_dirty_flag: RefDirtyFlag = Arc::new(AtomicBool::new(false));
-            BlincContextState::init(
+            let stateful_callback: StatefulCallback = Arc::new(|signal_ids| {
+                blinc_layout::check_stateful_deps(signal_ids);
+            });
+            BlincContextState::init_with_callback(
                 Arc::clone(&reactive),
                 Arc::clone(&hooks),
                 Arc::clone(&ref_dirty_flag),
+                stateful_callback,
             );
-            (reactive, hooks, ref_dirty_flag)
+            (BlincContextState::get(), reactive, hooks, ref_dirty_flag)
         };
-        let element_registry: SharedElementRegistry =
-            Arc::new(blinc_layout::selector::ElementRegistry::new());
+        let element_registry: SharedElementRegistry = if let Some(existing) =
+            global.element_registry::<blinc_layout::selector::ElementRegistry>()
+        {
+            existing
+        } else {
+            let registry: SharedElementRegistry =
+                Arc::new(blinc_layout::selector::ElementRegistry::new());
+            global.set_element_registry(Arc::clone(&registry) as blinc_core::AnyElementRegistry);
+            registry
+        };
         let ready_callbacks: SharedReadyCallbacks = Arc::new(Mutex::new(Vec::new()));
 
         let ctx = Self::new_headless_runtime(
@@ -685,10 +700,7 @@ impl WindowedContext {
             blinc_animation::set_global_scheduler(scheduler_handle);
         }
 
-        let global = BlincContextState::get();
         global.set_viewport_size(logical_width, logical_height);
-        global
-            .set_element_registry(Arc::clone(&element_registry) as blinc_core::AnyElementRegistry);
 
         ctx
     }
@@ -2117,7 +2129,7 @@ mod windowed_context_tests {
 
     #[test]
     fn headless_context_initializes_expected_defaults() {
-        let _guard = test_lock().lock().unwrap();
+        let _guard = test_lock().lock().unwrap_or_else(|e| e.into_inner());
         let ctx = WindowedContext::new_headless(640.0, 360.0);
 
         assert_eq!(ctx.width, 640.0);
@@ -2130,7 +2142,7 @@ mod windowed_context_tests {
 
     #[test]
     fn headless_context_resize_updates_logical_and_physical_size() {
-        let _guard = test_lock().lock().unwrap();
+        let _guard = test_lock().lock().unwrap_or_else(|e| e.into_inner());
         let mut ctx = WindowedContext::new_headless(640.0, 360.0);
 
         ctx.set_headless_size(1024.0, 768.0);
@@ -2143,7 +2155,7 @@ mod windowed_context_tests {
 
     #[test]
     fn headless_context_resize_keeps_existing_global_registry() {
-        let _guard = test_lock().lock().unwrap();
+        let _guard = test_lock().lock().unwrap_or_else(|e| e.into_inner());
         let mut ctx = WindowedContext::new_headless(640.0, 360.0);
         let before = BlincContextState::get()
             .element_registry_any()
@@ -2155,6 +2167,18 @@ mod windowed_context_tests {
             .element_registry_any()
             .expect("headless resize preserves a global element registry");
         assert!(Arc::ptr_eq(&before, &after));
+    }
+
+    #[test]
+    fn repeated_headless_context_reuses_existing_global_registry() {
+        let _guard = test_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let first = WindowedContext::new_headless(640.0, 360.0);
+        let second = WindowedContext::new_headless(800.0, 600.0);
+
+        assert!(Arc::ptr_eq(
+            first.element_registry(),
+            second.element_registry()
+        ));
     }
 }
 
@@ -2461,7 +2485,9 @@ impl WindowedApp {
         // Set global scheduler handle for StateContext and component access
         {
             let scheduler_handle = animations.lock().unwrap().handle();
-            blinc_animation::set_global_scheduler(scheduler_handle);
+            if !blinc_animation::is_scheduler_initialized() {
+                blinc_animation::set_global_scheduler(scheduler_handle);
+            }
         }
 
         // Shared CSS animation/transition store


### PR DESCRIPTION
## Summary
- add a public `WindowedContext::new_headless(width, height)` convenience constructor
- add `WindowedContext::set_headless_size(width, height)` for offscreen resize flows
- keep the existing runtime-specific constructor internal as `new_headless_runtime`

## Why
Headless renderers and screenshot harnesses often need a real `WindowedContext` without constructing the full windowed runtime stack by hand.

This change makes that use case explicit and reusable:
- test harnesses can create a context with one call
- offscreen flows can update viewport size without reaching into internal fields
- the existing automation/runtime path keeps its lower-level constructor and behavior

## Verification
- `cargo test -p blinc_app headless_context_ -- --nocapture`
- `cargo check -p blinc_app`
