### PR TITLE
Add desktop IME text input support

### DIFF
--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -38,8 +38,8 @@ use blinc_layout::overlay_state::{get_overlay_manager, OverlayContext};
 use blinc_layout::prelude::*;
 use blinc_layout::widgets::overlay::{overlay_manager, OverlayManager, OverlayManagerExt};
 use blinc_platform::{
-    ControlFlow, Event, EventLoop, InputEvent, Key, KeyState, LifecycleEvent, MouseEvent, Platform,
-    TouchEvent, Window, WindowConfig, WindowEvent,
+    ControlFlow, Event, EventLoop, ImeCursorArea, ImeState, InputEvent, Key, KeyState,
+    LifecycleEvent, MouseEvent, Platform, TouchEvent, Window, WindowConfig, WindowEvent,
 };
 
 use crate::app::BlincApp;
@@ -76,6 +76,78 @@ fn e2e_exit_after() -> bool {
         return !(v.is_empty() || v == "0" || v == "false" || v == "no");
     }
     e2e_is_enabled()
+}
+
+fn sync_platform_ime_state() {
+    let cursor_area = blinc_layout::widgets::focused_text_widget_ime_area()
+        .map(|bounds| ImeCursorArea::new(bounds.x, bounds.y, bounds.width, bounds.height));
+    let enabled = blinc_layout::widgets::text_input::has_live_focused_text_widget();
+    blinc_platform::set_ime_state(ImeState {
+        enabled,
+        cursor_area,
+    });
+}
+
+fn keyboard_text_chars(event: &blinc_platform::KeyboardEvent) -> Vec<char> {
+    if let Some(text) = event.text.as_deref() {
+        return text.chars().filter(|ch| !ch.is_control()).collect();
+    }
+
+    let mods = &event.modifiers;
+    let fallback = match &event.key {
+        Key::Char(c) => Some(*c),
+        Key::Space => Some(' '),
+        Key::A => Some(if mods.shift { 'A' } else { 'a' }),
+        Key::B => Some(if mods.shift { 'B' } else { 'b' }),
+        Key::C => Some(if mods.shift { 'C' } else { 'c' }),
+        Key::D => Some(if mods.shift { 'D' } else { 'd' }),
+        Key::E => Some(if mods.shift { 'E' } else { 'e' }),
+        Key::F => Some(if mods.shift { 'F' } else { 'f' }),
+        Key::G => Some(if mods.shift { 'G' } else { 'g' }),
+        Key::H => Some(if mods.shift { 'H' } else { 'h' }),
+        Key::I => Some(if mods.shift { 'I' } else { 'i' }),
+        Key::J => Some(if mods.shift { 'J' } else { 'j' }),
+        Key::K => Some(if mods.shift { 'K' } else { 'k' }),
+        Key::L => Some(if mods.shift { 'L' } else { 'l' }),
+        Key::M => Some(if mods.shift { 'M' } else { 'm' }),
+        Key::N => Some(if mods.shift { 'N' } else { 'n' }),
+        Key::O => Some(if mods.shift { 'O' } else { 'o' }),
+        Key::P => Some(if mods.shift { 'P' } else { 'p' }),
+        Key::Q => Some(if mods.shift { 'Q' } else { 'q' }),
+        Key::R => Some(if mods.shift { 'R' } else { 'r' }),
+        Key::S => Some(if mods.shift { 'S' } else { 's' }),
+        Key::T => Some(if mods.shift { 'T' } else { 't' }),
+        Key::U => Some(if mods.shift { 'U' } else { 'u' }),
+        Key::V => Some(if mods.shift { 'V' } else { 'v' }),
+        Key::W => Some(if mods.shift { 'W' } else { 'w' }),
+        Key::X => Some(if mods.shift { 'X' } else { 'x' }),
+        Key::Y => Some(if mods.shift { 'Y' } else { 'y' }),
+        Key::Z => Some(if mods.shift { 'Z' } else { 'z' }),
+        Key::Num0 => Some(if mods.shift { ')' } else { '0' }),
+        Key::Num1 => Some(if mods.shift { '!' } else { '1' }),
+        Key::Num2 => Some(if mods.shift { '@' } else { '2' }),
+        Key::Num3 => Some(if mods.shift { '#' } else { '3' }),
+        Key::Num4 => Some(if mods.shift { '$' } else { '4' }),
+        Key::Num5 => Some(if mods.shift { '%' } else { '5' }),
+        Key::Num6 => Some(if mods.shift { '^' } else { '6' }),
+        Key::Num7 => Some(if mods.shift { '&' } else { '7' }),
+        Key::Num8 => Some(if mods.shift { '*' } else { '8' }),
+        Key::Num9 => Some(if mods.shift { '(' } else { '9' }),
+        Key::Minus => Some(if mods.shift { '_' } else { '-' }),
+        Key::Equals => Some(if mods.shift { '+' } else { '=' }),
+        Key::LeftBracket => Some(if mods.shift { '{' } else { '[' }),
+        Key::RightBracket => Some(if mods.shift { '}' } else { ']' }),
+        Key::Backslash => Some(if mods.shift { '|' } else { '\\' }),
+        Key::Semicolon => Some(if mods.shift { ':' } else { ';' }),
+        Key::Quote => Some(if mods.shift { '"' } else { '\'' }),
+        Key::Comma => Some(if mods.shift { '<' } else { ',' }),
+        Key::Period => Some(if mods.shift { '>' } else { '.' }),
+        Key::Slash => Some(if mods.shift { '?' } else { '/' }),
+        Key::Grave => Some(if mods.shift { '~' } else { '`' }),
+        _ => None,
+    };
+
+    fallback.into_iter().collect()
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2406,6 +2478,8 @@ impl WindowedApp {
                             if !focused {
                                 blinc_layout::widgets::blur_all_text_inputs();
                             }
+
+                            sync_platform_ime_state();
                         }
                     }
 
@@ -2684,60 +2758,7 @@ impl WindowedApp {
                                 },
                                 InputEvent::Keyboard(kb_event) => {
                                     let mods = &kb_event.modifiers;
-
-                                    // Extract character from key if applicable
-                                    let key_char = match &kb_event.key {
-                                        Key::Char(c) => Some(*c),
-                                        Key::Space => Some(' '),
-                                        Key::A => Some(if mods.shift { 'A' } else { 'a' }),
-                                        Key::B => Some(if mods.shift { 'B' } else { 'b' }),
-                                        Key::C => Some(if mods.shift { 'C' } else { 'c' }),
-                                        Key::D => Some(if mods.shift { 'D' } else { 'd' }),
-                                        Key::E => Some(if mods.shift { 'E' } else { 'e' }),
-                                        Key::F => Some(if mods.shift { 'F' } else { 'f' }),
-                                        Key::G => Some(if mods.shift { 'G' } else { 'g' }),
-                                        Key::H => Some(if mods.shift { 'H' } else { 'h' }),
-                                        Key::I => Some(if mods.shift { 'I' } else { 'i' }),
-                                        Key::J => Some(if mods.shift { 'J' } else { 'j' }),
-                                        Key::K => Some(if mods.shift { 'K' } else { 'k' }),
-                                        Key::L => Some(if mods.shift { 'L' } else { 'l' }),
-                                        Key::M => Some(if mods.shift { 'M' } else { 'm' }),
-                                        Key::N => Some(if mods.shift { 'N' } else { 'n' }),
-                                        Key::O => Some(if mods.shift { 'O' } else { 'o' }),
-                                        Key::P => Some(if mods.shift { 'P' } else { 'p' }),
-                                        Key::Q => Some(if mods.shift { 'Q' } else { 'q' }),
-                                        Key::R => Some(if mods.shift { 'R' } else { 'r' }),
-                                        Key::S => Some(if mods.shift { 'S' } else { 's' }),
-                                        Key::T => Some(if mods.shift { 'T' } else { 't' }),
-                                        Key::U => Some(if mods.shift { 'U' } else { 'u' }),
-                                        Key::V => Some(if mods.shift { 'V' } else { 'v' }),
-                                        Key::W => Some(if mods.shift { 'W' } else { 'w' }),
-                                        Key::X => Some(if mods.shift { 'X' } else { 'x' }),
-                                        Key::Y => Some(if mods.shift { 'Y' } else { 'y' }),
-                                        Key::Z => Some(if mods.shift { 'Z' } else { 'z' }),
-                                        Key::Num0 => Some(if mods.shift { ')' } else { '0' }),
-                                        Key::Num1 => Some(if mods.shift { '!' } else { '1' }),
-                                        Key::Num2 => Some(if mods.shift { '@' } else { '2' }),
-                                        Key::Num3 => Some(if mods.shift { '#' } else { '3' }),
-                                        Key::Num4 => Some(if mods.shift { '$' } else { '4' }),
-                                        Key::Num5 => Some(if mods.shift { '%' } else { '5' }),
-                                        Key::Num6 => Some(if mods.shift { '^' } else { '6' }),
-                                        Key::Num7 => Some(if mods.shift { '&' } else { '7' }),
-                                        Key::Num8 => Some(if mods.shift { '*' } else { '8' }),
-                                        Key::Num9 => Some(if mods.shift { '(' } else { '9' }),
-                                        Key::Minus => Some(if mods.shift { '_' } else { '-' }),
-                                        Key::Equals => Some(if mods.shift { '+' } else { '=' }),
-                                        Key::LeftBracket => Some(if mods.shift { '{' } else { '[' }),
-                                        Key::RightBracket => Some(if mods.shift { '}' } else { ']' }),
-                                        Key::Backslash => Some(if mods.shift { '|' } else { '\\' }),
-                                        Key::Semicolon => Some(if mods.shift { ':' } else { ';' }),
-                                        Key::Quote => Some(if mods.shift { '"' } else { '\'' }),
-                                        Key::Comma => Some(if mods.shift { '<' } else { ',' }),
-                                        Key::Period => Some(if mods.shift { '>' } else { '.' }),
-                                        Key::Slash => Some(if mods.shift { '?' } else { '/' }),
-                                        Key::Grave => Some(if mods.shift { '~' } else { '`' }),
-                                        _ => None,
-                                    };
+                                    let text_chars = keyboard_text_chars(&kb_event);
 
                                     // Key code for special key handling (backspace, arrows, etc)
                                     let key_code = match &kb_event.key {
@@ -2777,9 +2798,8 @@ impl WindowedApp {
 
                                             // For character-producing keys, dispatch TEXT_INPUT
                                             // We use broadcast dispatch so any focused text input can receive it
-                                            if let Some(c) = key_char {
-                                                // Don't send text input if ctrl/cmd is held (shortcuts)
-                                                if !mods.ctrl && !mods.meta {
+                                            if !mods.ctrl && !mods.meta {
+                                                for c in text_chars {
                                                     keyboard_events.push(PendingEvent {
                                                         event_type: blinc_core::events::event_types::TEXT_INPUT,
                                                         key_char: Some(c),
@@ -3071,6 +3091,8 @@ impl WindowedApp {
                                     );
                                 }
                             }
+
+                            sync_platform_ime_state();
 
                             // If scroll momentum ended, notify scroll physics
                             if scroll_ended {
@@ -3708,6 +3730,8 @@ impl WindowedApp {
                                 }
                             }
 
+                            sync_platform_ime_state();
+
                             // Apply CSS state styles (:hover, :active, :focus) from stylesheet
                             // This also detects property changes and starts new transitions
                             if let Some(ref mut tree) = render_tree {
@@ -4092,6 +4116,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use blinc_platform::{Key, KeyState, KeyboardEvent, Modifiers};
 
     fn make_test_ctx() -> WindowedContext {
         let animations: SharedAnimationScheduler = Arc::new(Mutex::new(AnimationScheduler::new()));
@@ -4147,5 +4172,46 @@ mod tests {
         });
 
         assert_eq!(ctx.get(sig), Some(14));
+    }
+
+    #[test]
+    fn keyboard_text_chars_prefers_committed_text() {
+        let event = KeyboardEvent {
+            key: Key::Unknown,
+            text: Some("초".to_string()),
+            state: KeyState::Pressed,
+            modifiers: Modifiers::default(),
+        };
+
+        assert_eq!(keyboard_text_chars(&event), vec!['초']);
+    }
+
+    #[test]
+    fn keyboard_text_chars_filters_control_characters() {
+        let event = KeyboardEvent {
+            key: Key::Enter,
+            text: Some("\r".to_string()),
+            state: KeyState::Pressed,
+            modifiers: Modifiers::default(),
+        };
+
+        assert!(keyboard_text_chars(&event).is_empty());
+    }
+
+    #[test]
+    fn keyboard_text_chars_falls_back_to_legacy_key_mapping() {
+        let event = KeyboardEvent {
+            key: Key::A,
+            text: None,
+            state: KeyState::Pressed,
+            modifiers: Modifiers {
+                shift: true,
+                ctrl: false,
+                alt: false,
+                meta: false,
+            },
+        };
+
+        assert_eq!(keyboard_text_chars(&event), vec!['A']);
     }
 }

--- a/crates/blinc_layout/src/widgets/mod.rs
+++ b/crates/blinc_layout/src/widgets/mod.rs
@@ -61,6 +61,8 @@ pub use text_input::{
     blur_all_text_inputs,
     // Cursor blink timing utilities
     elapsed_ms,
+    focus_text_input,
+    focused_text_widget_ime_area,
     has_focused_text_input,
     request_css_reparse,
     // Rebuild/relayout request functions

--- a/crates/blinc_layout/src/widgets/text_input.rs
+++ b/crates/blinc_layout/src/widgets/text_input.rs
@@ -88,6 +88,48 @@ pub fn has_focused_text_input() -> bool {
     GLOBAL_FOCUS_COUNT.load(Ordering::Relaxed) > 0
 }
 
+fn focused_text_input_is_live() -> bool {
+    let focused = match FOCUSED_TEXT_INPUT.lock() {
+        Ok(focused) => focused,
+        Err(_) => return false,
+    };
+    let weak = match focused.as_ref() {
+        Some(weak) => weak,
+        None => return false,
+    };
+    let data = match weak.upgrade() {
+        Some(data) => data,
+        None => return false,
+    };
+    data.lock()
+        .ok()
+        .map(|guard| guard.visual.is_focused())
+        .unwrap_or(false)
+}
+
+fn focused_text_area_is_live() -> bool {
+    let focused = match FOCUSED_TEXT_AREA.lock() {
+        Ok(focused) => focused,
+        Err(_) => return false,
+    };
+    let weak = match focused.as_ref() {
+        Some(weak) => weak,
+        None => return false,
+    };
+    let data = match weak.upgrade() {
+        Some(data) => data,
+        None => return false,
+    };
+    data.lock()
+        .ok()
+        .map(|guard| guard.visual.is_focused())
+        .unwrap_or(false)
+}
+
+pub fn has_live_focused_text_widget() -> bool {
+    focused_text_input_is_live() || focused_text_area_is_live()
+}
+
 pub fn take_needs_continuous_redraw() -> bool {
     NEEDS_CONTINUOUS_REDRAW.swap(false, Ordering::SeqCst)
 }
@@ -324,6 +366,95 @@ pub fn blur_all_text_inputs() {
             }
         }
     }
+}
+
+/// Programmatically focus a text input.
+///
+/// This mirrors the focus path used by pointer interaction so keyboard-driven
+/// navigation can move focus between inputs without synthesizing a mouse click.
+pub fn focus_text_input(state: &SharedTextInputData) {
+    use crate::stateful::refresh_stateful;
+    use blinc_core::events::event_types;
+
+    let (already_focused, disabled) = state
+        .lock()
+        .ok()
+        .map(|guard| (guard.visual.is_focused(), guard.disabled))
+        .unwrap_or((false, true));
+
+    if disabled {
+        return;
+    }
+
+    if !already_focused {
+        blur_all_text_inputs();
+    }
+
+    let stateful_ref = {
+        let mut data = match state.lock() {
+            Ok(data) => data,
+            Err(_) => return,
+        };
+
+        if !data.visual.is_focused() {
+            data.visual = data
+                .visual
+                .on_event(event_types::FOCUS)
+                .unwrap_or(TextFieldState::Focused);
+            data.focus_time_ms = elapsed_ms();
+            increment_focus_count();
+        }
+
+        if data.masked {
+            data.cursor = data.value.chars().count();
+        }
+        data.selection_start = None;
+        data.reset_cursor_blink();
+        data.sync_global_selection();
+        data.stateful_state.clone()
+    };
+
+    if let Some(ref stateful) = stateful_ref {
+        if let Ok(mut shared) = stateful.lock() {
+            if !shared.state.is_focused() {
+                if let Some(new_state) = shared.state.on_event(event_types::FOCUS) {
+                    shared.state = new_state;
+                } else {
+                    shared.state = TextFieldState::Focused;
+                }
+            }
+            shared.needs_visual_update = true;
+        }
+    }
+
+    set_focused_text_input(state);
+    request_continuous_redraw();
+
+    if let Some(ref stateful) = stateful_ref {
+        refresh_stateful(stateful);
+    }
+}
+
+fn focused_text_input_bounds() -> Option<crate::element::ElementBounds> {
+    let focused = FOCUSED_TEXT_INPUT.lock().ok()?;
+    let weak = focused.as_ref()?;
+    let data = weak.upgrade()?;
+    let guard = data.lock().ok()?;
+    let bounds = guard.layout_bounds_storage.lock().ok()?;
+    *bounds
+}
+
+fn focused_text_area_bounds() -> Option<crate::element::ElementBounds> {
+    let focused = FOCUSED_TEXT_AREA.lock().ok()?;
+    let weak = focused.as_ref()?;
+    let data = weak.upgrade()?;
+    let guard = data.lock().ok()?;
+    let bounds = guard.layout_bounds_storage.lock().ok()?;
+    *bounds
+}
+
+pub fn focused_text_widget_ime_area() -> Option<crate::element::ElementBounds> {
+    focused_text_input_bounds().or_else(focused_text_area_bounds)
 }
 
 /// Get the layout node ID of the currently focused TextInput, if any.
@@ -772,6 +903,10 @@ impl TextInputData {
         }
 
         best_pos
+    }
+
+    pub fn cursor_position_from_pointer_x(&self, x: f32, font_size: f32) -> usize {
+        self.cursor_position_from_x(x, font_size)
     }
 
     /// Ensure the cursor is visible by adjusting horizontal scroll offset.
@@ -1389,7 +1524,7 @@ impl TextInput {
                     // local_x is already in text-relative coordinates - use it directly.
                     // cursor_position_from_x handles scroll offset internally.
                     let text_x = ctx.local_x.max(0.0);
-                    let cursor_pos = d.cursor_position_from_x(text_x, font_size);
+                    let cursor_pos = d.cursor_position_from_pointer_x(text_x, font_size);
                     d.cursor = cursor_pos;
                     d.selection_start = None;
                     d.reset_cursor_blink();
@@ -2054,6 +2189,13 @@ impl ElementBuilder for TextInput {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::element::ElementBounds;
+    use std::sync::{Mutex, OnceLock};
+
+    fn focus_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn test_text_input_data_insert() {
@@ -2096,5 +2238,139 @@ mod tests {
         data.cursor = 0;
         data.insert("abc123");
         assert_eq!(data.value, "123");
+    }
+
+    #[test]
+    fn test_focus_text_input_switches_focus_between_inputs() {
+        let _guard = focus_test_lock().lock().unwrap();
+        blur_all_text_inputs();
+
+        let first = text_input_state();
+        let second = text_input_state();
+
+        focus_text_input(&first);
+        assert!(first.lock().unwrap().visual.is_focused());
+        assert!(has_focused_text_input());
+
+        focus_text_input(&second);
+        assert!(!first.lock().unwrap().visual.is_focused());
+        assert!(second.lock().unwrap().visual.is_focused());
+
+        blur_all_text_inputs();
+        assert!(!has_focused_text_input());
+    }
+
+    #[test]
+    fn test_focus_text_input_moves_masked_cursor_to_end() {
+        let _guard = focus_test_lock().lock().unwrap();
+        blur_all_text_inputs();
+
+        let masked = text_input_state();
+        {
+            let mut data = masked.lock().unwrap();
+            data.value = "secret".to_string();
+            data.masked = true;
+            data.cursor = 0;
+        }
+
+        focus_text_input(&masked);
+
+        let data = masked.lock().unwrap();
+        assert!(data.visual.is_focused());
+        assert_eq!(data.cursor, 6);
+        drop(data);
+
+        blur_all_text_inputs();
+    }
+
+    #[test]
+    fn test_focus_text_input_disabled_target_preserves_existing_focus() {
+        let _guard = focus_test_lock().lock().unwrap();
+        blur_all_text_inputs();
+
+        let first = text_input_state();
+        let disabled = text_input_state();
+        disabled.lock().unwrap().disabled = true;
+
+        focus_text_input(&first);
+        focus_text_input(&disabled);
+
+        assert!(first.lock().unwrap().visual.is_focused());
+        assert!(!disabled.lock().unwrap().visual.is_focused());
+
+        blur_all_text_inputs();
+    }
+
+    #[test]
+    fn test_masked_text_input_cursor_position_from_pointer_x_uses_pointer_location() {
+        let mut data = TextInputData::with_value("secret");
+        data.masked = true;
+
+        let near_start = data.cursor_position_from_pointer_x(0.0, 16.0);
+        let far_end = data.cursor_position_from_pointer_x(10_000.0, 16.0);
+
+        assert_eq!(near_start, 0);
+        assert_eq!(far_end, data.value.chars().count());
+    }
+
+    #[test]
+    fn test_focused_text_widget_ime_area_uses_focused_text_input_bounds() {
+        let _guard = focus_test_lock().lock().unwrap();
+        blur_all_text_inputs();
+
+        let input = text_input_state();
+        {
+            let data = input.lock().unwrap();
+            *data.layout_bounds_storage.lock().unwrap() =
+                Some(ElementBounds::new(10.0, 20.0, 120.0, 32.0));
+        }
+
+        focus_text_input(&input);
+
+        let bounds = focused_text_widget_ime_area().expect("ime area");
+        assert_eq!(bounds.x, 10.0);
+        assert_eq!(bounds.y, 20.0);
+        assert_eq!(bounds.width, 120.0);
+        assert_eq!(bounds.height, 32.0);
+
+        blur_all_text_inputs();
+    }
+
+    #[test]
+    fn test_has_live_focused_text_widget_ignores_stale_global_focus_count() {
+        let _guard = focus_test_lock().lock().unwrap();
+
+        let original_input = {
+            let mut focused = FOCUSED_TEXT_INPUT.lock().unwrap();
+            focused.take()
+        };
+        let original_area = {
+            let mut focused = FOCUSED_TEXT_AREA.lock().unwrap();
+            focused.take()
+        };
+        let original_count = GLOBAL_FOCUS_COUNT.load(Ordering::Relaxed);
+
+        let stale_state = text_input_state();
+        let stale_weak = Arc::downgrade(&stale_state);
+        drop(stale_state);
+
+        {
+            let mut focused = FOCUSED_TEXT_INPUT.lock().unwrap();
+            *focused = Some(stale_weak);
+        }
+        GLOBAL_FOCUS_COUNT.store(1, Ordering::Relaxed);
+
+        assert!(has_focused_text_input());
+        assert!(!has_live_focused_text_widget());
+
+        {
+            let mut focused = FOCUSED_TEXT_INPUT.lock().unwrap();
+            *focused = original_input;
+        }
+        {
+            let mut focused = FOCUSED_TEXT_AREA.lock().unwrap();
+            *focused = original_area;
+        }
+        GLOBAL_FOCUS_COUNT.store(original_count, Ordering::Relaxed);
     }
 }

--- a/crates/blinc_platform/src/ime.rs
+++ b/crates/blinc_platform/src/ime.rs
@@ -1,0 +1,63 @@
+use std::sync::{Mutex, OnceLock};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ImeCursorArea {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+impl ImeCursorArea {
+    pub const fn new(x: f32, y: f32, width: f32, height: f32) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ImeState {
+    pub enabled: bool,
+    pub cursor_area: Option<ImeCursorArea>,
+}
+
+fn ime_state_slot() -> &'static Mutex<ImeState> {
+    static IME_STATE: OnceLock<Mutex<ImeState>> = OnceLock::new();
+    IME_STATE.get_or_init(|| Mutex::new(ImeState::default()))
+}
+
+pub fn current_ime_state() -> ImeState {
+    ime_state_slot()
+        .lock()
+        .map(|guard| *guard)
+        .unwrap_or_default()
+}
+
+pub fn set_ime_state(state: ImeState) {
+    if let Ok(mut guard) = ime_state_slot().lock() {
+        *guard = state;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ime_state_round_trips() {
+        let original = current_ime_state();
+        let next = ImeState {
+            enabled: true,
+            cursor_area: Some(ImeCursorArea::new(10.0, 20.0, 30.0, 40.0)),
+        };
+
+        set_ime_state(next);
+        assert_eq!(current_ime_state(), next);
+
+        set_ime_state(original);
+    }
+}

--- a/crates/blinc_platform/src/input.rs
+++ b/crates/blinc_platform/src/input.rs
@@ -108,6 +108,11 @@ pub enum MouseButton {
 pub struct KeyboardEvent {
     /// The key that was pressed or released
     pub key: Key,
+    /// Text produced by this key event after layout/IME processing.
+    ///
+    /// This is `Some` for committed user-visible text and `None` for
+    /// non-textual keys or in-progress IME composition updates.
+    pub text: Option<String>,
     /// Whether the key was pressed or released
     pub state: KeyState,
     /// Modifier keys held during this event

--- a/crates/blinc_platform/src/lib.rs
+++ b/crates/blinc_platform/src/lib.rs
@@ -47,6 +47,7 @@ pub mod ble;
 pub mod clipboard;
 mod error;
 mod event;
+mod ime;
 mod input;
 pub mod microphone;
 pub mod permissions;
@@ -57,6 +58,7 @@ mod window;
 // Re-export all public types
 pub use error::{PlatformError, Result};
 pub use event::{ControlFlow, Event, EventLoop, LifecycleEvent, WindowEvent};
+pub use ime::{current_ime_state, set_ime_state, ImeCursorArea, ImeState};
 pub use input::{
     InputEvent, Key, KeyState, KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase,
     TouchEvent,
@@ -89,6 +91,7 @@ pub mod prelude {
     };
     pub use crate::error::{PlatformError, Result};
     pub use crate::event::{ControlFlow, Event, EventLoop, LifecycleEvent, WindowEvent};
+    pub use crate::ime::{current_ime_state, set_ime_state, ImeCursorArea, ImeState};
     pub use crate::input::{
         InputEvent, Key, KeyState, KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase,
         TouchEvent,

--- a/extensions/blinc_platform_desktop/src/event_loop.rs
+++ b/extensions/blinc_platform_desktop/src/event_loop.rs
@@ -5,10 +5,12 @@ use std::time::{Duration, Instant};
 use crate::input;
 use crate::window::DesktopWindow;
 use blinc_platform::{
-    ControlFlow, Event, EventLoop, LifecycleEvent, PlatformError, Window, WindowConfig, WindowEvent,
+    current_ime_state, ControlFlow, Event, EventLoop, ImeCursorArea, ImeState, LifecycleEvent,
+    PlatformError, Window, WindowConfig, WindowEvent,
 };
 use winit::application::ApplicationHandler;
-use winit::event::{StartCause, WindowEvent as WinitWindowEvent};
+use winit::dpi::{LogicalPosition, LogicalSize};
+use winit::event::{Ime as WinitIme, StartCause, WindowEvent as WinitWindowEvent};
 use winit::event_loop::{
     ActiveEventLoop, ControlFlow as WinitControlFlow, EventLoop as WinitEventLoop, EventLoopProxy,
 };
@@ -35,6 +37,42 @@ fn scroll_end_deadline(
         return None;
     }
     last_scroll_event_at.map(|last| last + SCROLL_END_DEBOUNCE)
+}
+
+trait DesktopImeWindow {
+    fn set_ime_allowed(&mut self, allowed: bool);
+    fn set_ime_cursor_area(&mut self, area: ImeCursorArea);
+}
+
+impl DesktopImeWindow for DesktopWindow {
+    fn set_ime_allowed(&mut self, allowed: bool) {
+        self.winit_window().set_ime_allowed(allowed);
+    }
+
+    fn set_ime_cursor_area(&mut self, area: ImeCursorArea) {
+        self.winit_window().set_ime_cursor_area(
+            LogicalPosition::new(area.x, area.y),
+            LogicalSize::new(area.width, area.height),
+        );
+    }
+}
+
+fn sync_ime_window_state<W: DesktopImeWindow>(
+    window: &mut W,
+    applied: &mut ImeState,
+    requested: ImeState,
+) {
+    if applied.enabled != requested.enabled {
+        window.set_ime_allowed(requested.enabled);
+    }
+
+    if requested.enabled && applied.cursor_area != requested.cursor_area {
+        if let Some(area) = requested.cursor_area {
+            window.set_ime_cursor_area(area);
+        }
+    }
+
+    *applied = requested;
 }
 
 /// Proxy for waking up the event loop from another thread
@@ -126,6 +164,7 @@ where
     mouse_position: (f32, f32),
     last_scroll_event_at: Option<Instant>,
     scroll_end_pending: bool,
+    applied_ime_state: ImeState,
     should_exit: bool,
 }
 
@@ -142,6 +181,7 @@ where
             mouse_position: (0.0, 0.0),
             last_scroll_event_at: None,
             scroll_end_pending: false,
+            applied_ime_state: ImeState::default(),
             should_exit: false,
         }
     }
@@ -152,6 +192,9 @@ where
             if flow == ControlFlow::Exit {
                 self.should_exit = true;
             }
+        }
+        if let Some(ref mut window) = self.window {
+            sync_ime_window_state(window, &mut self.applied_ime_state, current_ime_state());
         }
     }
 
@@ -169,7 +212,12 @@ where
         // Create window if we don't have one
         if self.window.is_none() {
             match DesktopWindow::new(event_loop, &self.window_config) {
-                Ok(window) => {
+                Ok(mut window) => {
+                    sync_ime_window_state(
+                        &mut window,
+                        &mut self.applied_ime_state,
+                        current_ime_state(),
+                    );
                     self.window = Some(window);
                     self.handle_event(Event::Lifecycle(LifecycleEvent::Resumed));
                 }
@@ -244,10 +292,23 @@ where
             }
 
             WinitWindowEvent::KeyboardInput { event, .. } => {
-                let input_event =
-                    input::convert_keyboard_event(&event.logical_key, event.state, self.modifiers);
+                let input_event = input::convert_keyboard_event(&event, self.modifiers);
                 self.handle_event(Event::Input(input_event));
                 // Request immediate redraw so text input changes render instantly
+                if let Some(ref window) = self.window {
+                    window.request_redraw();
+                }
+            }
+
+            WinitWindowEvent::Ime(ime) => {
+                if let WinitIme::Commit(text) = ime {
+                    if !text.is_empty() {
+                        self.handle_event(Event::Input(input::commit_text_event(
+                            text,
+                            self.modifiers,
+                        )));
+                    }
+                }
                 if let Some(ref window) = self.window {
                     window.request_redraw();
                 }
@@ -364,8 +425,31 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{scroll_end_deadline, should_emit_synthetic_scroll_end, SCROLL_END_DEBOUNCE};
+    use super::{
+        scroll_end_deadline, should_emit_synthetic_scroll_end, sync_ime_window_state,
+        DesktopImeWindow, SCROLL_END_DEBOUNCE,
+    };
+    use crate::input;
+    use blinc_platform::{ImeCursorArea, ImeState};
+    use blinc_platform::{InputEvent, Key, KeyState};
     use std::time::{Duration, Instant};
+    use winit::keyboard::ModifiersState;
+
+    #[derive(Default)]
+    struct TestImeWindow {
+        allowed: Vec<bool>,
+        cursor_areas: Vec<ImeCursorArea>,
+    }
+
+    impl DesktopImeWindow for TestImeWindow {
+        fn set_ime_allowed(&mut self, allowed: bool) {
+            self.allowed.push(allowed);
+        }
+
+        fn set_ime_cursor_area(&mut self, area: ImeCursorArea) {
+            self.cursor_areas.push(area);
+        }
+    }
 
     #[test]
     fn synthetic_scroll_end_requires_pending_and_elapsed_threshold() {
@@ -397,5 +481,38 @@ mod tests {
             scroll_end_deadline(true, Some(now)),
             Some(now + SCROLL_END_DEBOUNCE)
         );
+    }
+
+    #[test]
+    fn ime_commit_is_forwarded_as_keyboard_text() {
+        let input_event = input::commit_text_event("초".to_string(), ModifiersState::empty());
+
+        match input_event {
+            InputEvent::Keyboard(event) => {
+                assert_eq!(event.key, Key::Unknown);
+                assert_eq!(event.text.as_deref(), Some("초"));
+                assert_eq!(event.state, KeyState::Pressed);
+            }
+            other => panic!("expected keyboard input, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sync_ime_window_state_updates_allowed_and_cursor_area() {
+        let mut window = TestImeWindow::default();
+        let mut applied = ImeState::default();
+        let requested = ImeState {
+            enabled: true,
+            cursor_area: Some(ImeCursorArea::new(12.0, 24.0, 80.0, 30.0)),
+        };
+
+        sync_ime_window_state(&mut window, &mut applied, requested);
+
+        assert_eq!(window.allowed, vec![true]);
+        assert_eq!(
+            window.cursor_areas,
+            vec![ImeCursorArea::new(12.0, 24.0, 80.0, 30.0)]
+        );
+        assert_eq!(applied, requested);
     }
 }

--- a/extensions/blinc_platform_desktop/src/input.rs
+++ b/extensions/blinc_platform_desktop/src/input.rs
@@ -4,7 +4,9 @@ use blinc_platform::{
     InputEvent, Key, KeyState, KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase,
     TouchEvent,
 };
-use winit::event::{ElementState, MouseButton as WinitMouseButton, Touch, TouchPhase};
+use winit::event::{
+    ElementState, KeyEvent as WinitKeyEvent, MouseButton as WinitMouseButton, Touch, TouchPhase,
+};
 use winit::keyboard::{Key as WinitKey, ModifiersState, NamedKey};
 
 /// Convert winit mouse button to blinc MouseButton
@@ -140,14 +142,35 @@ pub fn convert_key(key: &WinitKey) -> Key {
 }
 
 /// Convert winit keyboard event to blinc InputEvent
-pub fn convert_keyboard_event(
+pub fn convert_keyboard_event(event: &WinitKeyEvent, modifiers: ModifiersState) -> InputEvent {
+    keyboard_input_event(
+        &event.logical_key,
+        event.text.as_deref(),
+        event.state,
+        modifiers,
+    )
+}
+
+fn keyboard_input_event(
     key: &WinitKey,
+    text: Option<&str>,
     state: ElementState,
     modifiers: ModifiersState,
 ) -> InputEvent {
     InputEvent::Keyboard(KeyboardEvent {
         key: convert_key(key),
+        text: text.map(str::to_string),
         state: convert_key_state(state),
+        modifiers: convert_modifiers(modifiers),
+    })
+}
+
+/// Create a committed text input event from IME output.
+pub fn commit_text_event(text: String, modifiers: ModifiersState) -> InputEvent {
+    InputEvent::Keyboard(KeyboardEvent {
+        key: Key::Unknown,
+        text: Some(text),
+        state: KeyState::Pressed,
         modifiers: convert_modifiers(modifiers),
     })
 }
@@ -226,4 +249,45 @@ pub fn scroll_end_event() -> InputEvent {
 /// `scale` is a ratio delta per update (1.0 = no change).
 pub fn pinch_event(scale: f32) -> InputEvent {
     InputEvent::Pinch { scale }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{commit_text_event, keyboard_input_event};
+    use blinc_platform::{InputEvent, Key, KeyState};
+    use winit::event::ElementState;
+    use winit::keyboard::{Key as WinitKey, ModifiersState};
+
+    #[test]
+    fn convert_keyboard_event_preserves_committed_text() {
+        let input = keyboard_input_event(
+            &WinitKey::Character("a".into()),
+            Some("a"),
+            ElementState::Pressed,
+            ModifiersState::empty(),
+        );
+
+        match input {
+            InputEvent::Keyboard(kb) => {
+                assert_eq!(kb.key, Key::A);
+                assert_eq!(kb.text.as_deref(), Some("a"));
+                assert_eq!(kb.state, KeyState::Pressed);
+            }
+            other => panic!("expected keyboard input, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn commit_text_event_keeps_full_ime_commit_string() {
+        let input = commit_text_event("초".to_string(), ModifiersState::empty());
+
+        match input {
+            InputEvent::Keyboard(kb) => {
+                assert_eq!(kb.key, Key::Unknown);
+                assert_eq!(kb.text.as_deref(), Some("초"));
+                assert_eq!(kb.state, KeyState::Pressed);
+            }
+            other => panic!("expected keyboard input, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- preserve committed keyboard text from winit key events and IME commit events on desktop
- track focused text widget IME state and cursor area through blinc_platform
- add regression tests for committed text handling and focus-driven IME updates

## Test Plan
- cargo fmt --all
- cargo fmt --all -- --check
- cargo test
