### PR TITLE
Preserve committed text from desktop key events

### DIFF
--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -156,6 +156,45 @@ fn should_skip_composition_commit(
         && keyboard_committed_text.is_some_and(|chars| chars == composition_chars.as_slice())
 }
 
+fn track_keyboard_committed_text(
+    tracked_text: &mut Option<Vec<char>>,
+    event: &blinc_platform::KeyboardEvent,
+) {
+    if event.state != KeyState::Pressed {
+        return;
+    }
+
+    let mods = &event.modifiers;
+    if mods.ctrl || mods.meta {
+        *tracked_text = None;
+        return;
+    }
+
+    *tracked_text = event
+        .text
+        .as_deref()
+        .map(visible_text_chars)
+        .filter(|chars| !chars.is_empty());
+}
+
+fn take_composition_commit_text(
+    tracked_text: &mut Option<Vec<char>>,
+    composition_text: &str,
+) -> Vec<char> {
+    let composition_chars = visible_text_chars(composition_text);
+    let should_skip = !composition_chars.is_empty()
+        && tracked_text
+            .as_deref()
+            .is_some_and(|chars| chars == composition_chars.as_slice());
+    *tracked_text = None;
+
+    if should_skip {
+        Vec::new()
+    } else {
+        composition_chars
+    }
+}
+
 fn letter_key_char(key: &Key) -> Option<char> {
     match key {
         Key::A => Some('a'),
@@ -2585,6 +2624,9 @@ impl WindowedApp {
         let mut needs_rebuild = true;
         // Track if we need to relayout (e.g., after resize even if tree unchanged)
         let mut needs_relayout = false;
+        // Track committed keyboard text across platform input events so a following
+        // IME commit event can suppress duplicate TEXT_INPUT dispatch.
+        let mut keyboard_committed_text: Option<Vec<char>> = None;
         // Shared dirty flag for element refs
         let ref_dirty_flag: RefDirtyFlag = Arc::new(AtomicBool::new(false));
         // Shared reactive graph for signal-based state management
@@ -3004,7 +3046,6 @@ impl WindowedApp {
                             let mut pending_events: Vec<PendingEvent> = Vec::new();
                             // Separate collection for keyboard events (TEXT_INPUT)
                             let mut keyboard_events: Vec<PendingEvent> = Vec::new();
-                            let mut keyboard_committed_text: Option<Vec<char>> = None;
                             // Track if scroll ended (momentum finished)
                             let mut scroll_ended = false;
                             // Track if gesture ended (finger lifted - may still have momentum)
@@ -3253,11 +3294,10 @@ impl WindowedApp {
                                             // For character-producing keys, dispatch TEXT_INPUT
                                             // We use broadcast dispatch so any focused text input can receive it
                                             if !mods.ctrl && !mods.meta {
-                                                keyboard_committed_text = kb_event
-                                                    .text
-                                                    .as_ref()
-                                                    .map(|_| text_chars.clone())
-                                                    .filter(|chars| !chars.is_empty());
+                                                track_keyboard_committed_text(
+                                                    &mut keyboard_committed_text,
+                                                    &kb_event,
+                                                );
                                                 for c in text_chars {
                                                     keyboard_events.push(PendingEvent {
                                                         event_type: blinc_core::events::event_types::TEXT_INPUT,
@@ -3270,8 +3310,6 @@ impl WindowedApp {
                                                         ..Default::default()
                                                     });
                                                 }
-                                            } else {
-                                                keyboard_committed_text = None;
                                             }
 
                                             // For KEY_DOWN events with special keys (backspace, arrows)
@@ -3386,6 +3424,7 @@ impl WindowedApp {
                                     scroll_ended = true;
                                 }
                                 InputEvent::CompositionStarted => {
+                                    keyboard_committed_text = None;
                                     blinc_layout::widgets::set_focused_text_widget_composition(None);
                                 }
                                 InputEvent::CompositionUpdated(update) => {
@@ -3395,21 +3434,19 @@ impl WindowedApp {
                                 }
                                 InputEvent::CompositionCommitted(text) => {
                                     blinc_layout::widgets::set_focused_text_widget_composition(None);
-                                    if !should_skip_composition_commit(
-                                        keyboard_committed_text.as_deref(),
+                                    for c in take_composition_commit_text(
+                                        &mut keyboard_committed_text,
                                         &text,
                                     ) {
-                                        for c in visible_text_chars(&text) {
-                                            keyboard_events.push(PendingEvent {
-                                                event_type: blinc_core::events::event_types::TEXT_INPUT,
-                                                key_char: Some(c),
-                                                ..Default::default()
-                                            });
-                                        }
+                                        keyboard_events.push(PendingEvent {
+                                            event_type: blinc_core::events::event_types::TEXT_INPUT,
+                                            key_char: Some(c),
+                                            ..Default::default()
+                                        });
                                     }
-                                    keyboard_committed_text = None;
                                 }
                                 InputEvent::CompositionCancelled => {
+                                    keyboard_committed_text = None;
                                     blinc_layout::widgets::set_focused_text_widget_composition(None);
                                 }
                                 InputEvent::FocusTraversal(intent) => {
@@ -4789,5 +4826,38 @@ mod tests {
             Some(keyboard_chars.as_slice()),
             "초성"
         ));
+    }
+
+    #[test]
+    fn tracked_keyboard_text_skips_matching_later_composition_commit() {
+        let mut tracked = None;
+        let event = KeyboardEvent {
+            key: Key::Unknown,
+            text: Some("한글".to_string()),
+            state: KeyState::Pressed,
+            modifiers: Modifiers::default(),
+        };
+
+        track_keyboard_committed_text(&mut tracked, &event);
+
+        assert!(take_composition_commit_text(&mut tracked, "한글").is_empty());
+    }
+
+    #[test]
+    fn tracked_keyboard_text_does_not_skip_different_later_composition_commit() {
+        let mut tracked = None;
+        let event = KeyboardEvent {
+            key: Key::Unknown,
+            text: Some("한글".to_string()),
+            state: KeyState::Pressed,
+            modifiers: Modifiers::default(),
+        };
+
+        track_keyboard_committed_text(&mut tracked, &event);
+
+        assert_eq!(
+            take_composition_commit_text(&mut tracked, "초성"),
+            vec!['초', '성']
+        );
     }
 }

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -799,7 +799,7 @@ impl WindowedContext {
         let _init_guard = headless_context_init_lock()
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        let animations = shared_runtime_scheduler();
+        let animations = prepare_runtime_scheduler(None, false);
         let (global, reactive, hooks, ref_dirty_flag) = Self::ensure_global_context_state();
         let element_registry = Self::ensure_element_registry(global);
         let ready_callbacks: SharedReadyCallbacks = Arc::new(Mutex::new(Vec::new()));
@@ -2318,6 +2318,27 @@ mod windowed_context_tests {
 
         assert!(Arc::ptr_eq(&scheduler, &prepared));
         let guard = prepared.lock().unwrap();
+        assert_eq!(guard.tick_callback_count(), 0);
+        assert!(!guard.is_background_running());
+        assert!(!guard.is_continuous_redraw());
+    }
+
+    #[test]
+    fn new_headless_resets_shared_scheduler_state() {
+        let _guard = test_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let scheduler = shared_runtime_scheduler();
+        {
+            let mut guard = scheduler.lock().unwrap();
+            guard.add_tick_callback(|_| {});
+            let wake_callback: WakeCallback = Arc::new(|| {});
+            guard.set_wake_callback_arc(wake_callback);
+            guard.start_background();
+        }
+
+        let ctx = WindowedContext::new_headless(640.0, 360.0);
+
+        assert!(Arc::ptr_eq(&scheduler, &ctx.animations));
+        let guard = scheduler.lock().unwrap();
         assert_eq!(guard.tick_callback_count(), 0);
         assert!(!guard.is_background_running());
         assert!(!guard.is_continuous_redraw());

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -98,6 +98,68 @@ fn sync_platform_ime_state() {
     });
 }
 
+fn keyboard_text_chars(event: &blinc_platform::KeyboardEvent) -> Vec<char> {
+    if let Some(text) = event.text.as_deref() {
+        return text.chars().filter(|ch| !ch.is_control()).collect();
+    }
+
+    let mods = &event.modifiers;
+    let fallback = match &event.key {
+        Key::Char(c) => Some(*c),
+        Key::Space => Some(' '),
+        Key::A => Some(if mods.shift { 'A' } else { 'a' }),
+        Key::B => Some(if mods.shift { 'B' } else { 'b' }),
+        Key::C => Some(if mods.shift { 'C' } else { 'c' }),
+        Key::D => Some(if mods.shift { 'D' } else { 'd' }),
+        Key::E => Some(if mods.shift { 'E' } else { 'e' }),
+        Key::F => Some(if mods.shift { 'F' } else { 'f' }),
+        Key::G => Some(if mods.shift { 'G' } else { 'g' }),
+        Key::H => Some(if mods.shift { 'H' } else { 'h' }),
+        Key::I => Some(if mods.shift { 'I' } else { 'i' }),
+        Key::J => Some(if mods.shift { 'J' } else { 'j' }),
+        Key::K => Some(if mods.shift { 'K' } else { 'k' }),
+        Key::L => Some(if mods.shift { 'L' } else { 'l' }),
+        Key::M => Some(if mods.shift { 'M' } else { 'm' }),
+        Key::N => Some(if mods.shift { 'N' } else { 'n' }),
+        Key::O => Some(if mods.shift { 'O' } else { 'o' }),
+        Key::P => Some(if mods.shift { 'P' } else { 'p' }),
+        Key::Q => Some(if mods.shift { 'Q' } else { 'q' }),
+        Key::R => Some(if mods.shift { 'R' } else { 'r' }),
+        Key::S => Some(if mods.shift { 'S' } else { 's' }),
+        Key::T => Some(if mods.shift { 'T' } else { 't' }),
+        Key::U => Some(if mods.shift { 'U' } else { 'u' }),
+        Key::V => Some(if mods.shift { 'V' } else { 'v' }),
+        Key::W => Some(if mods.shift { 'W' } else { 'w' }),
+        Key::X => Some(if mods.shift { 'X' } else { 'x' }),
+        Key::Y => Some(if mods.shift { 'Y' } else { 'y' }),
+        Key::Z => Some(if mods.shift { 'Z' } else { 'z' }),
+        Key::Num0 => Some(if mods.shift { ')' } else { '0' }),
+        Key::Num1 => Some(if mods.shift { '!' } else { '1' }),
+        Key::Num2 => Some(if mods.shift { '@' } else { '2' }),
+        Key::Num3 => Some(if mods.shift { '#' } else { '3' }),
+        Key::Num4 => Some(if mods.shift { '$' } else { '4' }),
+        Key::Num5 => Some(if mods.shift { '%' } else { '5' }),
+        Key::Num6 => Some(if mods.shift { '^' } else { '6' }),
+        Key::Num7 => Some(if mods.shift { '&' } else { '7' }),
+        Key::Num8 => Some(if mods.shift { '*' } else { '8' }),
+        Key::Num9 => Some(if mods.shift { '(' } else { '9' }),
+        Key::Minus => Some(if mods.shift { '_' } else { '-' }),
+        Key::Equals => Some(if mods.shift { '+' } else { '=' }),
+        Key::LeftBracket => Some(if mods.shift { '{' } else { '[' }),
+        Key::RightBracket => Some(if mods.shift { '}' } else { ']' }),
+        Key::Backslash => Some(if mods.shift { '|' } else { '\\' }),
+        Key::Semicolon => Some(if mods.shift { ':' } else { ';' }),
+        Key::Quote => Some(if mods.shift { '"' } else { '\'' }),
+        Key::Comma => Some(if mods.shift { '<' } else { ',' }),
+        Key::Period => Some(if mods.shift { '>' } else { '.' }),
+        Key::Slash => Some(if mods.shift { '?' } else { '/' }),
+        Key::Grave => Some(if mods.shift { '~' } else { '`' }),
+        _ => None,
+    };
+
+    fallback.into_iter().collect()
+}
+
 #[cfg(any(
     target_os = "macos",
     all(target_os = "linux", not(target_env = "ohos")),
@@ -3100,60 +3162,7 @@ impl WindowedApp {
                                 },
                                 InputEvent::Keyboard(kb_event) => {
                                     let mods = &kb_event.modifiers;
-
-                                    // Extract character from key if applicable
-                                    let key_char = match &kb_event.key {
-                                        Key::Char(c) => Some(*c),
-                                        Key::Space => Some(' '),
-                                        Key::A => Some(if mods.shift { 'A' } else { 'a' }),
-                                        Key::B => Some(if mods.shift { 'B' } else { 'b' }),
-                                        Key::C => Some(if mods.shift { 'C' } else { 'c' }),
-                                        Key::D => Some(if mods.shift { 'D' } else { 'd' }),
-                                        Key::E => Some(if mods.shift { 'E' } else { 'e' }),
-                                        Key::F => Some(if mods.shift { 'F' } else { 'f' }),
-                                        Key::G => Some(if mods.shift { 'G' } else { 'g' }),
-                                        Key::H => Some(if mods.shift { 'H' } else { 'h' }),
-                                        Key::I => Some(if mods.shift { 'I' } else { 'i' }),
-                                        Key::J => Some(if mods.shift { 'J' } else { 'j' }),
-                                        Key::K => Some(if mods.shift { 'K' } else { 'k' }),
-                                        Key::L => Some(if mods.shift { 'L' } else { 'l' }),
-                                        Key::M => Some(if mods.shift { 'M' } else { 'm' }),
-                                        Key::N => Some(if mods.shift { 'N' } else { 'n' }),
-                                        Key::O => Some(if mods.shift { 'O' } else { 'o' }),
-                                        Key::P => Some(if mods.shift { 'P' } else { 'p' }),
-                                        Key::Q => Some(if mods.shift { 'Q' } else { 'q' }),
-                                        Key::R => Some(if mods.shift { 'R' } else { 'r' }),
-                                        Key::S => Some(if mods.shift { 'S' } else { 's' }),
-                                        Key::T => Some(if mods.shift { 'T' } else { 't' }),
-                                        Key::U => Some(if mods.shift { 'U' } else { 'u' }),
-                                        Key::V => Some(if mods.shift { 'V' } else { 'v' }),
-                                        Key::W => Some(if mods.shift { 'W' } else { 'w' }),
-                                        Key::X => Some(if mods.shift { 'X' } else { 'x' }),
-                                        Key::Y => Some(if mods.shift { 'Y' } else { 'y' }),
-                                        Key::Z => Some(if mods.shift { 'Z' } else { 'z' }),
-                                        Key::Num0 => Some(if mods.shift { ')' } else { '0' }),
-                                        Key::Num1 => Some(if mods.shift { '!' } else { '1' }),
-                                        Key::Num2 => Some(if mods.shift { '@' } else { '2' }),
-                                        Key::Num3 => Some(if mods.shift { '#' } else { '3' }),
-                                        Key::Num4 => Some(if mods.shift { '$' } else { '4' }),
-                                        Key::Num5 => Some(if mods.shift { '%' } else { '5' }),
-                                        Key::Num6 => Some(if mods.shift { '^' } else { '6' }),
-                                        Key::Num7 => Some(if mods.shift { '&' } else { '7' }),
-                                        Key::Num8 => Some(if mods.shift { '*' } else { '8' }),
-                                        Key::Num9 => Some(if mods.shift { '(' } else { '9' }),
-                                        Key::Minus => Some(if mods.shift { '_' } else { '-' }),
-                                        Key::Equals => Some(if mods.shift { '+' } else { '=' }),
-                                        Key::LeftBracket => Some(if mods.shift { '{' } else { '[' }),
-                                        Key::RightBracket => Some(if mods.shift { '}' } else { ']' }),
-                                        Key::Backslash => Some(if mods.shift { '|' } else { '\\' }),
-                                        Key::Semicolon => Some(if mods.shift { ':' } else { ';' }),
-                                        Key::Quote => Some(if mods.shift { '"' } else { '\'' }),
-                                        Key::Comma => Some(if mods.shift { '<' } else { ',' }),
-                                        Key::Period => Some(if mods.shift { '>' } else { '.' }),
-                                        Key::Slash => Some(if mods.shift { '?' } else { '/' }),
-                                        Key::Grave => Some(if mods.shift { '~' } else { '`' }),
-                                        _ => None,
-                                    };
+                                    let text_chars = keyboard_text_chars(&kb_event);
 
                                     // Key code for special key handling (backspace, arrows, etc)
                                     let key_code = match &kb_event.key {
@@ -3193,9 +3202,8 @@ impl WindowedApp {
 
                                             // For character-producing keys, dispatch TEXT_INPUT
                                             // We use broadcast dispatch so any focused text input can receive it
-                                            if let Some(c) = key_char {
-                                                // Don't send text input if ctrl/cmd is held (shortcuts)
-                                                if !mods.ctrl && !mods.meta {
+                                            if !mods.ctrl && !mods.meta {
+                                                for c in text_chars {
                                                     keyboard_events.push(PendingEvent {
                                                         event_type: blinc_core::events::event_types::TEXT_INPUT,
                                                         key_char: Some(c),
@@ -4552,6 +4560,7 @@ where
 mod tests {
     use super::*;
     use blinc_core::BlincContextState;
+    use blinc_platform::{Key, KeyState, KeyboardEvent, Modifiers};
     use blinc_recorder::{
         install_recorder, uninstall_recorder, RecordingConfig, SharedRecordingSession,
     };
@@ -4643,5 +4652,29 @@ mod tests {
         assert!(export.snapshots[0].elements.contains_key("status"));
 
         uninstall_recorder();
+    }
+
+    #[test]
+    fn keyboard_text_chars_prefers_committed_text() {
+        let event = KeyboardEvent {
+            key: Key::Unknown,
+            text: Some("초".to_string()),
+            state: KeyState::Pressed,
+            modifiers: Modifiers::default(),
+        };
+
+        assert_eq!(keyboard_text_chars(&event), vec!['초']);
+    }
+
+    #[test]
+    fn keyboard_text_chars_filters_control_characters() {
+        let event = KeyboardEvent {
+            key: Key::Enter,
+            text: Some("\r".to_string()),
+            state: KeyState::Pressed,
+            modifiers: Modifiers::default(),
+        };
+
+        assert!(keyboard_text_chars(&event).is_empty());
     }
 }

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -100,7 +100,7 @@ fn sync_platform_ime_state() {
 
 fn keyboard_text_chars(event: &blinc_platform::KeyboardEvent) -> Vec<char> {
     if let Some(text) = event.text.as_deref() {
-        return text.chars().filter(|ch| !ch.is_control()).collect();
+        return visible_text_chars(text);
     }
 
     let mods = &event.modifiers;
@@ -141,6 +141,19 @@ fn keyboard_text_chars(event: &blinc_platform::KeyboardEvent) -> Vec<char> {
     );
 
     fallback.into_iter().collect()
+}
+
+fn visible_text_chars(text: &str) -> Vec<char> {
+    text.chars().filter(|ch| !ch.is_control()).collect()
+}
+
+fn should_skip_composition_commit(
+    keyboard_committed_text: Option<&[char]>,
+    composition_text: &str,
+) -> bool {
+    let composition_chars = visible_text_chars(composition_text);
+    !composition_chars.is_empty()
+        && keyboard_committed_text.is_some_and(|chars| chars == composition_chars.as_slice())
 }
 
 fn letter_key_char(key: &Key) -> Option<char> {
@@ -2970,6 +2983,7 @@ impl WindowedApp {
                             let mut pending_events: Vec<PendingEvent> = Vec::new();
                             // Separate collection for keyboard events (TEXT_INPUT)
                             let mut keyboard_events: Vec<PendingEvent> = Vec::new();
+                            let mut keyboard_committed_text: Option<Vec<char>> = None;
                             // Track if scroll ended (momentum finished)
                             let mut scroll_ended = false;
                             // Track if gesture ended (finger lifted - may still have momentum)
@@ -3218,6 +3232,11 @@ impl WindowedApp {
                                             // For character-producing keys, dispatch TEXT_INPUT
                                             // We use broadcast dispatch so any focused text input can receive it
                                             if !mods.ctrl && !mods.meta {
+                                                keyboard_committed_text = kb_event
+                                                    .text
+                                                    .as_ref()
+                                                    .map(|_| text_chars.clone())
+                                                    .filter(|chars| !chars.is_empty());
                                                 for c in text_chars {
                                                     keyboard_events.push(PendingEvent {
                                                         event_type: blinc_core::events::event_types::TEXT_INPUT,
@@ -3230,6 +3249,8 @@ impl WindowedApp {
                                                         ..Default::default()
                                                     });
                                                 }
+                                            } else {
+                                                keyboard_committed_text = None;
                                             }
 
                                             // For KEY_DOWN events with special keys (backspace, arrows)
@@ -3353,13 +3374,19 @@ impl WindowedApp {
                                 }
                                 InputEvent::CompositionCommitted(text) => {
                                     blinc_layout::widgets::set_focused_text_widget_composition(None);
-                                    for c in text.chars().filter(|c| !c.is_control()) {
-                                        keyboard_events.push(PendingEvent {
-                                            event_type: blinc_core::events::event_types::TEXT_INPUT,
-                                            key_char: Some(c),
-                                            ..Default::default()
-                                        });
+                                    if !should_skip_composition_commit(
+                                        keyboard_committed_text.as_deref(),
+                                        &text,
+                                    ) {
+                                        for c in visible_text_chars(&text) {
+                                            keyboard_events.push(PendingEvent {
+                                                event_type: blinc_core::events::event_types::TEXT_INPUT,
+                                                key_char: Some(c),
+                                                ..Default::default()
+                                            });
+                                        }
                                     }
+                                    keyboard_committed_text = None;
                                 }
                                 InputEvent::CompositionCancelled => {
                                     blinc_layout::widgets::set_focused_text_widget_composition(None);
@@ -4721,5 +4748,25 @@ mod tests {
         };
 
         assert_eq!(keyboard_text_chars(&event), vec!['?']);
+    }
+
+    #[test]
+    fn composition_commit_is_skipped_when_keyboard_event_already_carried_same_text() {
+        let keyboard_chars = vec!['한', '글'];
+
+        assert!(should_skip_composition_commit(
+            Some(keyboard_chars.as_slice()),
+            "한글"
+        ));
+    }
+
+    #[test]
+    fn composition_commit_is_not_skipped_when_text_differs() {
+        let keyboard_chars = vec!['한', '글'];
+
+        assert!(!should_skip_composition_commit(
+            Some(keyboard_chars.as_slice()),
+            "초성"
+        ));
     }
 }

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -104,60 +104,75 @@ fn keyboard_text_chars(event: &blinc_platform::KeyboardEvent) -> Vec<char> {
     }
 
     let mods = &event.modifiers;
-    let fallback = match &event.key {
-        Key::Char(c) => Some(*c),
-        Key::Space => Some(' '),
-        Key::A => Some(if mods.shift { 'A' } else { 'a' }),
-        Key::B => Some(if mods.shift { 'B' } else { 'b' }),
-        Key::C => Some(if mods.shift { 'C' } else { 'c' }),
-        Key::D => Some(if mods.shift { 'D' } else { 'd' }),
-        Key::E => Some(if mods.shift { 'E' } else { 'e' }),
-        Key::F => Some(if mods.shift { 'F' } else { 'f' }),
-        Key::G => Some(if mods.shift { 'G' } else { 'g' }),
-        Key::H => Some(if mods.shift { 'H' } else { 'h' }),
-        Key::I => Some(if mods.shift { 'I' } else { 'i' }),
-        Key::J => Some(if mods.shift { 'J' } else { 'j' }),
-        Key::K => Some(if mods.shift { 'K' } else { 'k' }),
-        Key::L => Some(if mods.shift { 'L' } else { 'l' }),
-        Key::M => Some(if mods.shift { 'M' } else { 'm' }),
-        Key::N => Some(if mods.shift { 'N' } else { 'n' }),
-        Key::O => Some(if mods.shift { 'O' } else { 'o' }),
-        Key::P => Some(if mods.shift { 'P' } else { 'p' }),
-        Key::Q => Some(if mods.shift { 'Q' } else { 'q' }),
-        Key::R => Some(if mods.shift { 'R' } else { 'r' }),
-        Key::S => Some(if mods.shift { 'S' } else { 's' }),
-        Key::T => Some(if mods.shift { 'T' } else { 't' }),
-        Key::U => Some(if mods.shift { 'U' } else { 'u' }),
-        Key::V => Some(if mods.shift { 'V' } else { 'v' }),
-        Key::W => Some(if mods.shift { 'W' } else { 'w' }),
-        Key::X => Some(if mods.shift { 'X' } else { 'x' }),
-        Key::Y => Some(if mods.shift { 'Y' } else { 'y' }),
-        Key::Z => Some(if mods.shift { 'Z' } else { 'z' }),
-        Key::Num0 => Some(if mods.shift { ')' } else { '0' }),
-        Key::Num1 => Some(if mods.shift { '!' } else { '1' }),
-        Key::Num2 => Some(if mods.shift { '@' } else { '2' }),
-        Key::Num3 => Some(if mods.shift { '#' } else { '3' }),
-        Key::Num4 => Some(if mods.shift { '$' } else { '4' }),
-        Key::Num5 => Some(if mods.shift { '%' } else { '5' }),
-        Key::Num6 => Some(if mods.shift { '^' } else { '6' }),
-        Key::Num7 => Some(if mods.shift { '&' } else { '7' }),
-        Key::Num8 => Some(if mods.shift { '*' } else { '8' }),
-        Key::Num9 => Some(if mods.shift { '(' } else { '9' }),
-        Key::Minus => Some(if mods.shift { '_' } else { '-' }),
-        Key::Equals => Some(if mods.shift { '+' } else { '=' }),
-        Key::LeftBracket => Some(if mods.shift { '{' } else { '[' }),
-        Key::RightBracket => Some(if mods.shift { '}' } else { ']' }),
-        Key::Backslash => Some(if mods.shift { '|' } else { '\\' }),
-        Key::Semicolon => Some(if mods.shift { ':' } else { ';' }),
-        Key::Quote => Some(if mods.shift { '"' } else { '\'' }),
-        Key::Comma => Some(if mods.shift { '<' } else { ',' }),
-        Key::Period => Some(if mods.shift { '>' } else { '.' }),
-        Key::Slash => Some(if mods.shift { '?' } else { '/' }),
-        Key::Grave => Some(if mods.shift { '~' } else { '`' }),
-        _ => None,
-    };
+    let fallback = letter_key_char(&event.key).map_or_else(
+        || match &event.key {
+            Key::Char(c) => Some(*c),
+            Key::Space => Some(' '),
+            Key::Num0 => Some(if mods.shift { ')' } else { '0' }),
+            Key::Num1 => Some(if mods.shift { '!' } else { '1' }),
+            Key::Num2 => Some(if mods.shift { '@' } else { '2' }),
+            Key::Num3 => Some(if mods.shift { '#' } else { '3' }),
+            Key::Num4 => Some(if mods.shift { '$' } else { '4' }),
+            Key::Num5 => Some(if mods.shift { '%' } else { '5' }),
+            Key::Num6 => Some(if mods.shift { '^' } else { '6' }),
+            Key::Num7 => Some(if mods.shift { '&' } else { '7' }),
+            Key::Num8 => Some(if mods.shift { '*' } else { '8' }),
+            Key::Num9 => Some(if mods.shift { '(' } else { '9' }),
+            Key::Minus => Some(if mods.shift { '_' } else { '-' }),
+            Key::Equals => Some(if mods.shift { '+' } else { '=' }),
+            Key::LeftBracket => Some(if mods.shift { '{' } else { '[' }),
+            Key::RightBracket => Some(if mods.shift { '}' } else { ']' }),
+            Key::Backslash => Some(if mods.shift { '|' } else { '\\' }),
+            Key::Semicolon => Some(if mods.shift { ':' } else { ';' }),
+            Key::Quote => Some(if mods.shift { '"' } else { '\'' }),
+            Key::Comma => Some(if mods.shift { '<' } else { ',' }),
+            Key::Period => Some(if mods.shift { '>' } else { '.' }),
+            Key::Slash => Some(if mods.shift { '?' } else { '/' }),
+            Key::Grave => Some(if mods.shift { '~' } else { '`' }),
+            _ => None,
+        },
+        |base| {
+            Some(if mods.shift {
+                base.to_ascii_uppercase()
+            } else {
+                base
+            })
+        },
+    );
 
     fallback.into_iter().collect()
+}
+
+fn letter_key_char(key: &Key) -> Option<char> {
+    match key {
+        Key::A => Some('a'),
+        Key::B => Some('b'),
+        Key::C => Some('c'),
+        Key::D => Some('d'),
+        Key::E => Some('e'),
+        Key::F => Some('f'),
+        Key::G => Some('g'),
+        Key::H => Some('h'),
+        Key::I => Some('i'),
+        Key::J => Some('j'),
+        Key::K => Some('k'),
+        Key::L => Some('l'),
+        Key::M => Some('m'),
+        Key::N => Some('n'),
+        Key::O => Some('o'),
+        Key::P => Some('p'),
+        Key::Q => Some('q'),
+        Key::R => Some('r'),
+        Key::S => Some('s'),
+        Key::T => Some('t'),
+        Key::U => Some('u'),
+        Key::V => Some('v'),
+        Key::W => Some('w'),
+        Key::X => Some('x'),
+        Key::Y => Some('y'),
+        Key::Z => Some('z'),
+        _ => None,
+    }
 }
 
 #[cfg(any(
@@ -4676,5 +4691,35 @@ mod tests {
         };
 
         assert!(keyboard_text_chars(&event).is_empty());
+    }
+
+    #[test]
+    fn keyboard_text_chars_falls_back_to_shifted_letters() {
+        let event = KeyboardEvent {
+            key: Key::A,
+            text: None,
+            state: KeyState::Pressed,
+            modifiers: Modifiers {
+                shift: true,
+                ..Modifiers::default()
+            },
+        };
+
+        assert_eq!(keyboard_text_chars(&event), vec!['A']);
+    }
+
+    #[test]
+    fn keyboard_text_chars_falls_back_to_symbols() {
+        let event = KeyboardEvent {
+            key: Key::Slash,
+            text: None,
+            state: KeyState::Pressed,
+            modifiers: Modifiers {
+                shift: true,
+                ..Modifiers::default()
+            },
+        };
+
+        assert_eq!(keyboard_text_chars(&event), vec!['?']);
     }
 }

--- a/crates/blinc_platform/src/input.rs
+++ b/crates/blinc_platform/src/input.rs
@@ -118,6 +118,11 @@ pub enum MouseButton {
 pub struct KeyboardEvent {
     /// The key that was pressed or released
     pub key: Key,
+    /// Text produced by this key event after layout processing.
+    ///
+    /// This is `Some` for committed user-visible text and `None` for
+    /// non-textual keys.
+    pub text: Option<String>,
     /// Whether the key was pressed or released
     pub state: KeyState,
     /// Modifier keys held during this event

--- a/extensions/blinc_platform_desktop/src/event_loop.rs
+++ b/extensions/blinc_platform_desktop/src/event_loop.rs
@@ -300,8 +300,7 @@ where
             }
 
             WinitWindowEvent::KeyboardInput { event, .. } => {
-                let input_event =
-                    input::convert_keyboard_event(&event.logical_key, event.state, self.modifiers);
+                let input_event = input::convert_key_event(&event, self.modifiers);
                 self.handle_event(Event::Input(input_event));
                 // Request immediate redraw so text input changes render instantly
                 if let Some(ref window) = self.window {

--- a/extensions/blinc_platform_desktop/src/input.rs
+++ b/extensions/blinc_platform_desktop/src/input.rs
@@ -5,7 +5,8 @@ use blinc_platform::{
     KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase, TouchEvent,
 };
 use winit::event::{
-    ElementState, Ime as WinitIme, MouseButton as WinitMouseButton, Touch, TouchPhase,
+    ElementState, Ime as WinitIme, KeyEvent as WinitKeyEvent, MouseButton as WinitMouseButton,
+    Touch, TouchPhase,
 };
 use winit::keyboard::{Key as WinitKey, ModifiersState, NamedKey};
 
@@ -147,9 +148,28 @@ pub fn convert_keyboard_event(
     state: ElementState,
     modifiers: ModifiersState,
 ) -> InputEvent {
+    keyboard_input_event(key, None, convert_key_state(state), modifiers)
+}
+
+/// Convert a full winit key event so committed text can be preserved.
+pub fn convert_key_event(event: &WinitKeyEvent, modifiers: ModifiersState) -> InputEvent {
+    keyboard_input_event(
+        &event.logical_key,
+        event.text.as_deref(),
+        convert_key_state(event.state),
+        modifiers,
+    )
+}
+
+fn keyboard_input_event(
+    key: &WinitKey,
+    text: Option<&str>,
+    state: KeyState,
+    modifiers: ModifiersState,
+) -> InputEvent {
     let is_shortcut_tab = modifiers.control_key() || modifiers.alt_key() || modifiers.super_key();
 
-    if state == ElementState::Pressed
+    if state == KeyState::Pressed
         && !is_shortcut_tab
         && matches!(key, WinitKey::Named(NamedKey::Tab))
     {
@@ -163,7 +183,8 @@ pub fn convert_keyboard_event(
 
     InputEvent::Keyboard(KeyboardEvent {
         key: convert_key(key),
-        state: convert_key_state(state),
+        text: text.map(str::to_string),
+        state,
         modifiers: convert_modifiers(modifiers),
     })
 }
@@ -263,4 +284,42 @@ pub fn scroll_end_event() -> InputEvent {
 /// `scale` is a ratio delta per update (1.0 = no change).
 pub fn pinch_event(scale: f32) -> InputEvent {
     InputEvent::Pinch { scale }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::keyboard_input_event;
+    use blinc_platform::{InputEvent, Key, KeyState};
+    use winit::keyboard::{Key as WinitKey, ModifiersState, NamedKey};
+
+    #[test]
+    fn convert_keyboard_event_preserves_committed_text() {
+        let input = keyboard_input_event(
+            &WinitKey::Character("a".into()),
+            Some("a"),
+            KeyState::Pressed,
+            ModifiersState::empty(),
+        );
+
+        match input {
+            InputEvent::Keyboard(kb) => {
+                assert_eq!(kb.key, Key::A);
+                assert_eq!(kb.text.as_deref(), Some("a"));
+                assert_eq!(kb.state, KeyState::Pressed);
+            }
+            other => panic!("expected keyboard input, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_keyboard_event_keeps_tab_focus_traversal_behavior() {
+        let input = keyboard_input_event(
+            &WinitKey::Named(NamedKey::Tab),
+            None,
+            KeyState::Pressed,
+            ModifiersState::empty(),
+        );
+
+        assert!(matches!(input, InputEvent::FocusTraversal(_)));
+    }
 }


### PR DESCRIPTION
## Summary
- preserve committed text from desktop winit KeyEvent values in platform keyboard events
- prefer committed keyboard text for TEXT_INPUT dispatch in the windowed app before falling back to key mapping
- keep existing desktop IME composition and focus traversal paths unchanged

## Test Plan
- cargo fmt --all
- cargo fmt --all -- --check
- cargo test -p blinc_platform_desktop
- cargo test -p blinc_app

## Notes
- cargo test for the full workspace was not used as the completion gate here because the current workspace includes long-running blinc_cli fixture tests, and I did not obtain a clean full-workspace completion signal in this turn.
