### PR TITLE
Implement native readiness workstreams

### DIFF
--- a/.github/workflows/mobile-packaging.yml
+++ b/.github/workflows/mobile-packaging.yml
@@ -1,0 +1,83 @@
+name: Mobile Packaging
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'mobile/example/**'
+      - 'extensions/blinc_platform_android/**'
+      - 'extensions/blinc_platform_ios/**'
+      - 'crates/**'
+      - '.github/workflows/mobile-packaging.yml'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  android-packaging:
+    name: Android Packaging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
+
+      - name: Setup Android SDK / NDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: 'platform-tools ndk;27.0.12077973 build-tools;35.0.0 platforms;android-35'
+
+      - name: Build Android release APK
+        working-directory: mobile/example
+        run: ./build-android.sh release
+
+      - name: Build Android release bundle
+        working-directory: mobile/example
+        run: ./build-android.sh bundle-release
+
+      - name: Upload Android packaging artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-android-packaging
+          path: mobile/example/artifacts/android/**
+          if-no-files-found: error
+
+  ios-packaging:
+    name: iOS Packaging
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - name: Build iOS release libraries
+        working-directory: mobile/example
+        run: ./build-ios.sh release-libs
+
+      - name: Archive iOS app without code signing
+        working-directory: mobile/example
+        run: BLINC_IOS_CODE_SIGNING_ALLOWED=NO ./build-ios.sh archive
+
+      - name: Upload iOS packaging artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-ios-packaging
+          path: mobile/example/artifacts/ios/**
+          if-no-files-found: error

--- a/crates/blinc_app/examples/fuchsia_hello.rs
+++ b/crates/blinc_app/examples/fuchsia_hello.rs
@@ -1,21 +1,27 @@
 //! Fuchsia Hello World Example
 //!
-//! A simple Blinc application for Fuchsia OS demonstrating
-//! basic UI rendering with touch interactions.
+//! A deferred example for the planned Fuchsia target.
+//!
+//! The code is kept as a reference scaffold. The in-tree Fuchsia runtime is
+//! currently unsupported and `FuchsiaApp::run` returns an explicit error.
 //!
 //! # Building
+//!
+//! This example is documentation-only while the in-tree Fuchsia runtime remains
+//! unsupported.
 //!
 //! ```bash
 //! # Add Fuchsia target
 //! rustup target add x86_64-unknown-fuchsia
 //!
-//! # Build for Fuchsia
+//! # Optional: compile the example artifact for external experiments
 //! cargo build --example fuchsia_hello --target x86_64-unknown-fuchsia --features fuchsia
 //! ```
 //!
-//! # Running in Fuchsia Emulator
+//! # Runtime status
 //!
-//! See docs/fuchsia/SETUP.md for emulator setup instructions.
+//! Running this example through `FuchsiaApp::run` is not supported by the
+//! current in-tree runtime.
 
 #[cfg(target_os = "fuchsia")]
 use blinc_app::fuchsia::FuchsiaApp;
@@ -104,7 +110,7 @@ fn main() {
                     .color([0.5, 0.5, 0.6, 1.0]),
             )
     })
-    .expect("Failed to run Fuchsia app");
+    .expect("Fuchsia runtime is currently unsupported in-tree");
 }
 
 #[cfg(not(target_os = "fuchsia"))]

--- a/crates/blinc_app/src/android.rs
+++ b/crates/blinc_app/src/android.rs
@@ -46,8 +46,8 @@ use blinc_platform_android::AndroidAssetLoader;
 use crate::app::BlincApp;
 use crate::error::{BlincError, Result};
 use crate::windowed::{
-    prepare_runtime_scheduler, RefDirtyFlag, SharedAnimationScheduler, SharedElementRegistry,
-    SharedReactiveGraph, SharedReadyCallbacks, WindowedContext,
+    prepare_runtime_scheduler, sync_platform_ime_state, RefDirtyFlag, SharedAnimationScheduler,
+    SharedElementRegistry, SharedReactiveGraph, SharedReadyCallbacks, WindowedContext,
 };
 
 /// Android application runner
@@ -1025,6 +1025,7 @@ impl AndroidApp {
                         tree.start_all_css_animations();
                         tree.clear_dirty(); // Start clean
                         render_tree = Some(tree);
+                        sync_platform_ime_state();
                     } else if let Some(ref mut tree) = render_tree {
                         // Full rebuild
                         *tree = RenderTree::from_element(&element);
@@ -1038,6 +1039,7 @@ impl AndroidApp {
                         tree.start_all_css_animations();
                         // Clear dirty on the NEW tree to prevent immediate re-rebuild
                         tree.clear_dirty();
+                        sync_platform_ime_state();
                     }
                     needs_redraw = true;
                 }

--- a/crates/blinc_app/src/fuchsia.rs
+++ b/crates/blinc_app/src/fuchsia.rs
@@ -1,6 +1,10 @@
 //! Fuchsia application runner
 //!
-//! Provides a unified API for running Blinc applications on Fuchsia OS.
+//! Provides the Fuchsia-facing entry point for Blinc applications.
+//!
+//! Fuchsia is currently a deferred platform target. The runtime entry point is
+//! kept so code continues to compile behind feature gates, but execution fails
+//! explicitly instead of pretending to succeed with a stubbed runner.
 //!
 //! # Example
 //!
@@ -45,15 +49,17 @@ use crate::windowed::WindowedContext;
 
 /// Fuchsia application runner
 ///
-/// Provides a simple way to run a Blinc application on Fuchsia OS
-/// with automatic event handling and rendering via Scenic.
+/// Provides the Fuchsia entry point for Blinc applications.
 pub struct FuchsiaApp;
 
 impl FuchsiaApp {
     /// Run a Fuchsia Blinc application
     ///
-    /// This is the main entry point for Fuchsia applications. It sets up
-    /// the GPU renderer via Scenic, handles lifecycle events, and runs the event loop.
+    /// This is the main entry point for Fuchsia applications.
+    ///
+    /// Fuchsia execution is not currently implemented in-tree. Calling this on
+    /// Fuchsia returns an explicit unsupported-platform error instead of silently
+    /// succeeding with a stubbed runtime.
     ///
     /// # Arguments
     ///
@@ -82,23 +88,14 @@ impl FuchsiaApp {
             .try_init();
 
         tracing::info!("FuchsiaApp::run starting");
-        tracing::info!("Fuchsia platform support is currently a stub implementation");
-        tracing::info!("Full Fuchsia integration requires building within the Fuchsia tree");
-
-        // For now, print a message and return success
-        // Full implementation requires:
-        // 1. Scenic/Flatland integration for window compositing
-        // 2. FIDL bindings for system services
-        // 3. Vulkan surface via ImagePipe2
-        // 4. async event loop with fuchsia-async
-
-        // Placeholder: just log that we'd run the UI
-        tracing::info!("Would run UI with dimensions from Scenic view properties");
-        tracing::info!("Touch/mouse input would come from fuchsia.ui.pointer");
-        tracing::info!("Frame scheduling via Flatland.OnNextFrameBegin");
-
-        // Return success - app "ran" (stub)
-        Ok(())
+        tracing::warn!("Fuchsia platform support is currently unsupported in-tree");
+        tracing::warn!(
+            "Full Fuchsia integration requires Scenic/Flatland, input, and renderer wiring"
+        );
+        let _ = &mut ui_builder;
+        Err(BlincError::PlatformUnsupported(
+            "Fuchsia runtime is currently unsupported in-tree".to_string(),
+        ))
     }
 
     /// Placeholder for non-Fuchsia builds

--- a/crates/blinc_app/src/ios.rs
+++ b/crates/blinc_app/src/ios.rs
@@ -50,8 +50,8 @@ use blinc_platform_ios::{Gesture, GestureDetector, IOSAssetLoader, IOSWakeProxy,
 use crate::app::BlincApp;
 use crate::error::{BlincError, Result};
 use crate::windowed::{
-    prepare_runtime_scheduler, RefDirtyFlag, SharedAnimationScheduler, SharedElementRegistry,
-    SharedReactiveGraph, SharedReadyCallbacks, WindowedContext,
+    prepare_runtime_scheduler, sync_platform_ime_state, RefDirtyFlag, SharedAnimationScheduler,
+    SharedElementRegistry, SharedReactiveGraph, SharedReadyCallbacks, WindowedContext,
 };
 
 /// iOS application runner
@@ -492,6 +492,7 @@ impl IOSRenderContext {
             tree.update_flip_bounds();
             tree.start_all_css_animations();
             self.render_tree = Some(tree);
+            sync_platform_ime_state();
         } else if let Some(ref mut tree) = self.render_tree {
             // Full rebuild
             tree.clear_dirty();
@@ -504,6 +505,7 @@ impl IOSRenderContext {
             tree.compute_layout(self.windowed_ctx.width, self.windowed_ctx.height);
             tree.update_flip_bounds();
             tree.start_all_css_animations();
+            sync_platform_ime_state();
         }
 
         // Tick and apply CSS animations/transitions synchronously with rendering

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -82,7 +82,7 @@ fn e2e_exit_after() -> bool {
     e2e_is_enabled()
 }
 
-fn sync_platform_ime_state() {
+pub(crate) fn sync_platform_ime_state() {
     let cursor_area = blinc_layout::widgets::focused_text_widget_ime_area().map(|bounds| {
         ImeCursorArea::new(
             bounds.x as f64,
@@ -92,9 +92,28 @@ fn sync_platform_ime_state() {
         )
     });
     let enabled = blinc_layout::widgets::has_live_focused_text_widget();
+    let session_id = blinc_layout::widgets::text_input::focused_text_input_node_id()
+        .or_else(blinc_layout::widgets::text_input::focused_text_area_node_id)
+        .map(|node_id| {
+            blinc_platform::TextInputSessionId::new(format!("node:{}", node_id.to_raw()))
+        });
+    let state = if enabled {
+        let mut request = blinc_platform::ImeRequest::new(
+            session_id
+                .unwrap_or_else(|| blinc_platform::TextInputSessionId::new("focused-text-widget")),
+        )
+        .with_visibility(blinc_platform::ImeVisibility::Visible);
+        if let Some(cursor_area) = cursor_area {
+            request = request.with_cursor_area(cursor_area);
+        }
+        ImeState::default().with_request(Some(request))
+    } else {
+        ImeState::default()
+    };
     blinc_platform::set_ime_state(ImeState {
-        enabled,
+        enabled: state.enabled,
         cursor_area,
+        request: state.request,
     });
 }
 
@@ -234,6 +253,7 @@ fn letter_key_char(key: &Key) -> Option<char> {
 ))]
 fn sync_accessibility_snapshot(tree: &blinc_layout::RenderTree) {
     if let Some(snapshot) = blinc_layout::export_accessibility_snapshot(tree) {
+        blinc_platform::update_platform_accessibility_snapshot(snapshot.clone());
         blinc_platform_desktop::update_accessibility_snapshot(snapshot);
     }
 }
@@ -243,7 +263,14 @@ fn sync_accessibility_snapshot(tree: &blinc_layout::RenderTree) {
     all(target_os = "linux", not(target_env = "ohos")),
     target_os = "windows"
 )))]
-fn sync_accessibility_snapshot(_tree: &blinc_layout::RenderTree) {}
+fn sync_accessibility_snapshot(tree: &blinc_layout::RenderTree) {
+    if let Some(snapshot) = blinc_layout::export_accessibility_snapshot(tree) {
+        blinc_platform::update_platform_accessibility_snapshot(snapshot);
+    }
+    blinc_platform::mark_accessibility_unsupported(
+        "platform accessibility bridge is not wired for this runtime",
+    );
+}
 
 fn maybe_record_tree_snapshot(tree: &blinc_layout::RenderTree, windowed_ctx: &WindowedContext) {
     if !blinc_layout::recorder_bridge::is_recording_snapshots() {

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -110,11 +110,7 @@ pub(crate) fn sync_platform_ime_state() {
     } else {
         ImeState::default()
     };
-    blinc_platform::set_ime_state(ImeState {
-        enabled: state.enabled,
-        cursor_area,
-        request: state.request,
-    });
+    blinc_platform::set_ime_state(state);
 }
 
 fn keyboard_text_chars(event: &blinc_platform::KeyboardEvent) -> Vec<char> {

--- a/crates/blinc_debugger/src/app.rs
+++ b/crates/blinc_debugger/src/app.rs
@@ -1,4 +1,4 @@
-//! Main application module for the debugger.
+// Main application module for the debugger.
 
 use crate::panels::{
     CommandPanel, EvidencePanel, InspectorPanel, PreviewConfig, PreviewPanel, TimelinePanel,

--- a/crates/blinc_platform/src/accessibility.rs
+++ b/crates/blinc_platform/src/accessibility.rs
@@ -1,5 +1,7 @@
 //! Shared accessibility semantics contracts.
 
+use std::sync::{Mutex, OnceLock};
+
 /// Stable identifier for a semantic node.
 pub type AccessibilityNodeId = u64;
 
@@ -157,5 +159,71 @@ impl AccessibilityActionRequest {
     pub fn with_value(mut self, value: impl Into<String>) -> Self {
         self.value = Some(value.into());
         self
+    }
+}
+
+/// Last known accessibility sync status for the active runtime.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum AccessibilitySyncStatus {
+    #[default]
+    NotSynced,
+    Synced,
+    SnapshotOnly(String),
+    Unsupported(String),
+}
+
+fn runtime_snapshot_store() -> &'static Mutex<Option<AccessibilityTreeSnapshot>> {
+    static STORE: OnceLock<Mutex<Option<AccessibilityTreeSnapshot>>> = OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(None))
+}
+
+fn runtime_status_store() -> &'static Mutex<AccessibilitySyncStatus> {
+    static STORE: OnceLock<Mutex<AccessibilitySyncStatus>> = OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(AccessibilitySyncStatus::NotSynced))
+}
+
+pub fn update_platform_accessibility_snapshot(snapshot: AccessibilityTreeSnapshot) {
+    if let Ok(mut current) = runtime_snapshot_store().lock() {
+        *current = Some(snapshot);
+    }
+    if let Ok(mut status) = runtime_status_store().lock() {
+        *status = AccessibilitySyncStatus::Synced;
+    }
+}
+
+pub fn mark_accessibility_unsupported(reason: impl Into<String>) {
+    let reason = reason.into();
+    if let Ok(mut status) = runtime_status_store().lock() {
+        *status = match &*status {
+            AccessibilitySyncStatus::Synced | AccessibilitySyncStatus::SnapshotOnly(_) => {
+                AccessibilitySyncStatus::SnapshotOnly(reason)
+            }
+            AccessibilitySyncStatus::NotSynced | AccessibilitySyncStatus::Unsupported(_) => {
+                AccessibilitySyncStatus::Unsupported(reason)
+            }
+        };
+    }
+}
+
+pub fn current_platform_accessibility_snapshot() -> Option<AccessibilityTreeSnapshot> {
+    runtime_snapshot_store()
+        .lock()
+        .map(|snapshot| snapshot.clone())
+        .unwrap_or(None)
+}
+
+pub fn current_accessibility_sync_status() -> AccessibilitySyncStatus {
+    runtime_status_store()
+        .lock()
+        .map(|status| status.clone())
+        .unwrap_or(AccessibilitySyncStatus::NotSynced)
+}
+
+pub fn reset_accessibility_runtime_state() {
+    if let Ok(mut snapshot) = runtime_snapshot_store().lock() {
+        *snapshot = None;
+    }
+    if let Ok(mut status) = runtime_status_store().lock() {
+        *status = AccessibilitySyncStatus::NotSynced;
     }
 }

--- a/crates/blinc_platform/src/app.rs
+++ b/crates/blinc_platform/src/app.rs
@@ -1,0 +1,13 @@
+use blinc_core::native_bridge::native_call;
+
+use crate::error::PlatformError;
+
+/// Open a URL using the platform handler.
+pub fn open_url(url: &str) -> Result<bool, PlatformError> {
+    Ok(native_call("app", "open_url", (url.to_string(),))?)
+}
+
+/// Share a text payload using the platform handler.
+pub fn share_text(text: &str) -> Result<bool, PlatformError> {
+    Ok(native_call("app", "share_text", (text.to_string(),))?)
+}

--- a/crates/blinc_platform/src/app.rs
+++ b/crates/blinc_platform/src/app.rs
@@ -8,6 +8,7 @@ pub fn open_url(url: &str) -> Result<bool, PlatformError> {
 }
 
 /// Share a text payload using the platform handler.
-pub fn share_text(text: &str) -> Result<bool, PlatformError> {
-    Ok(native_call("app", "share_text", (text.to_string(),))?)
+pub fn share_text(text: &str) -> Result<(), PlatformError> {
+    let _: () = native_call("app", "share_text", (text.to_string(),))?;
+    Ok(())
 }

--- a/crates/blinc_platform/src/environment.rs
+++ b/crates/blinc_platform/src/environment.rs
@@ -1,0 +1,73 @@
+use serde::{Deserialize, Serialize};
+
+/// Coarse lifecycle state for a platform runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleState {
+    Foreground,
+    Background,
+    Inactive,
+    Destroyed,
+}
+
+/// Insets applied by system UI in logical points.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct ViewportInsets {
+    pub top: f32,
+    pub left: f32,
+    pub bottom: f32,
+    pub right: f32,
+}
+
+/// Window metrics captured from the active platform surface.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct WindowMetrics {
+    pub logical_width: f32,
+    pub logical_height: f32,
+    pub physical_width: u32,
+    pub physical_height: u32,
+    pub scale_factor: f64,
+}
+
+/// Snapshot of dynamic platform environment values.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PlatformEnvironmentSnapshot {
+    pub lifecycle_state: LifecycleState,
+    pub metrics: WindowMetrics,
+    pub safe_area_insets: ViewportInsets,
+    pub viewport_insets: ViewportInsets,
+    pub is_dark_mode: bool,
+}
+
+impl Default for PlatformEnvironmentSnapshot {
+    fn default() -> Self {
+        Self {
+            lifecycle_state: LifecycleState::Inactive,
+            metrics: WindowMetrics::default(),
+            safe_area_insets: ViewportInsets::default(),
+            viewport_insets: ViewportInsets::default(),
+            is_dark_mode: false,
+        }
+    }
+}
+
+/// Delta event emitted when a snapshot changes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PlatformEnvironmentChanged {
+    pub previous: PlatformEnvironmentSnapshot,
+    pub current: PlatformEnvironmentSnapshot,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_defaults_to_inactive_zeroed_metrics() {
+        let snapshot = PlatformEnvironmentSnapshot::default();
+        assert_eq!(snapshot.lifecycle_state, LifecycleState::Inactive);
+        assert_eq!(snapshot.metrics, WindowMetrics::default());
+        assert_eq!(snapshot.safe_area_insets, ViewportInsets::default());
+        assert!(!snapshot.is_dark_mode);
+    }
+}

--- a/crates/blinc_platform/src/haptics.rs
+++ b/crates/blinc_platform/src/haptics.rs
@@ -1,0 +1,16 @@
+use blinc_core::native_bridge::native_call;
+
+use crate::error::PlatformError;
+
+/// Trigger selection feedback.
+pub fn selection() -> Result<(), PlatformError> {
+    let _: () = native_call("haptics", "selection", ())?;
+    Ok(())
+}
+
+/// Trigger impact feedback using a platform-defined style string such as
+/// `light`, `medium`, or `heavy`.
+pub fn impact(style: &str) -> Result<(), PlatformError> {
+    let _: () = native_call("haptics", "impact", (style.to_string(),))?;
+    Ok(())
+}

--- a/crates/blinc_platform/src/ime.rs
+++ b/crates/blinc_platform/src/ime.rs
@@ -2,6 +2,8 @@
 
 use std::sync::{Mutex, OnceLock};
 
+use crate::ImeCompositionSelection;
+
 /// Cursor anchor area used to position candidate/popup windows.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct ImeCursorArea {
@@ -22,11 +24,98 @@ impl ImeCursorArea {
     }
 }
 
+/// Stable identifier for the currently focused text input session.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct TextInputSessionId(String);
+
+impl TextInputSessionId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Whether the platform keyboard/IME should be visible.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum ImeVisibility {
+    #[default]
+    Hidden,
+    Visible,
+}
+
+/// Selection range for the focused text input in UTF-8 codepoint offsets.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct SelectionRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl SelectionRange {
+    pub fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+}
+
+/// Runtime IME request emitted by the focused text input control.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ImeRequest {
+    pub session: TextInputSessionId,
+    pub visibility: ImeVisibility,
+    pub cursor_area: Option<ImeCursorArea>,
+    pub selection: Option<SelectionRange>,
+    pub composition: Option<ImeCompositionSelection>,
+}
+
+impl ImeRequest {
+    pub fn new(session: TextInputSessionId) -> Self {
+        Self {
+            session,
+            visibility: ImeVisibility::Hidden,
+            cursor_area: None,
+            selection: None,
+            composition: None,
+        }
+    }
+
+    pub fn with_visibility(mut self, visibility: ImeVisibility) -> Self {
+        self.visibility = visibility;
+        self
+    }
+
+    pub fn with_cursor_area(mut self, cursor_area: ImeCursorArea) -> Self {
+        self.cursor_area = Some(cursor_area);
+        self
+    }
+
+    pub fn with_selection(mut self, selection: SelectionRange) -> Self {
+        self.selection = Some(selection);
+        self
+    }
+
+    pub fn with_composition(mut self, composition: Option<ImeCompositionSelection>) -> Self {
+        self.composition = composition;
+        self
+    }
+}
+
 /// Requested IME state from the currently focused text control.
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ImeState {
     pub enabled: bool,
     pub cursor_area: Option<ImeCursorArea>,
+    pub request: Option<ImeRequest>,
+}
+
+impl ImeState {
+    pub fn with_request(mut self, request: Option<ImeRequest>) -> Self {
+        self.enabled = request.is_some();
+        self.cursor_area = request.as_ref().and_then(|request| request.cursor_area);
+        self.request = request;
+        self
+    }
 }
 
 fn global_ime_state() -> &'static Mutex<ImeState> {
@@ -37,7 +126,7 @@ fn global_ime_state() -> &'static Mutex<ImeState> {
 pub fn current_ime_state() -> ImeState {
     global_ime_state()
         .lock()
-        .map(|state| *state)
+        .map(|state| state.clone())
         .unwrap_or_default()
 }
 

--- a/crates/blinc_platform/src/lib.rs
+++ b/crates/blinc_platform/src/lib.rs
@@ -43,11 +43,14 @@
 //! ```
 
 pub mod accessibility;
+pub mod app;
 pub mod assets;
 pub mod ble;
 pub mod clipboard;
+pub mod environment;
 mod error;
 mod event;
+pub mod haptics;
 mod ime;
 mod input;
 pub mod microphone;
@@ -57,9 +60,16 @@ pub mod sensors;
 mod window;
 
 // Re-export all public types
+pub use environment::{
+    LifecycleState, PlatformEnvironmentChanged, PlatformEnvironmentSnapshot, ViewportInsets,
+    WindowMetrics,
+};
 pub use error::{PlatformError, Result};
 pub use event::{ControlFlow, Event, EventLoop, LifecycleEvent, WindowEvent};
-pub use ime::{current_ime_state, set_ime_state, ImeCursorArea, ImeState};
+pub use ime::{
+    current_ime_state, set_ime_state, ImeCursorArea, ImeRequest, ImeState, ImeVisibility,
+    SelectionRange, TextInputSessionId,
+};
 pub use input::{
     FocusTraversalIntent, ImeCompositionSelection, ImeCompositionUpdate, InputEvent, Key, KeyState,
     KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase, TouchEvent,
@@ -69,8 +79,11 @@ pub use window::{Cursor, Window, WindowConfig};
 
 // Re-export commonly used asset types
 pub use accessibility::{
-    AccessibilityAction, AccessibilityActionRequest, AccessibilityBounds, AccessibilityNode,
-    AccessibilityNodeId, AccessibilityRole, AccessibilityTreeSnapshot,
+    current_accessibility_sync_status, current_platform_accessibility_snapshot,
+    mark_accessibility_unsupported, reset_accessibility_runtime_state,
+    update_platform_accessibility_snapshot, AccessibilityAction, AccessibilityActionRequest,
+    AccessibilityBounds, AccessibilityNode, AccessibilityNodeId, AccessibilityRole,
+    AccessibilitySyncStatus, AccessibilityTreeSnapshot,
 };
 pub use assets::{AssetLoader, AssetPath, FilesystemAssetLoader};
 pub use ble::{
@@ -88,9 +101,13 @@ pub use sensors::{
 /// Prelude module for convenient imports
 pub mod prelude {
     pub use crate::accessibility::{
-        AccessibilityAction, AccessibilityActionRequest, AccessibilityBounds, AccessibilityNode,
-        AccessibilityNodeId, AccessibilityRole, AccessibilityTreeSnapshot,
+        current_accessibility_sync_status, current_platform_accessibility_snapshot,
+        mark_accessibility_unsupported, reset_accessibility_runtime_state,
+        update_platform_accessibility_snapshot, AccessibilityAction, AccessibilityActionRequest,
+        AccessibilityBounds, AccessibilityNode, AccessibilityNodeId, AccessibilityRole,
+        AccessibilitySyncStatus, AccessibilityTreeSnapshot,
     };
+    pub use crate::app;
     pub use crate::assets::{
         asset_exists, load_asset, load_asset_string, AssetLoader, AssetPath, FilesystemAssetLoader,
     };
@@ -98,9 +115,17 @@ pub mod prelude {
         BleBackend, BleBatchSummary, BleClient, BleProbeState, BleRuntimeController, BleScanConfig,
         BleScanResult, BleScanStatus,
     };
+    pub use crate::environment::{
+        LifecycleState, PlatformEnvironmentChanged, PlatformEnvironmentSnapshot, ViewportInsets,
+        WindowMetrics,
+    };
     pub use crate::error::{PlatformError, Result};
     pub use crate::event::{ControlFlow, Event, EventLoop, LifecycleEvent, WindowEvent};
-    pub use crate::ime::{current_ime_state, set_ime_state, ImeCursorArea, ImeState};
+    pub use crate::haptics;
+    pub use crate::ime::{
+        current_ime_state, set_ime_state, ImeCursorArea, ImeRequest, ImeState, ImeVisibility,
+        SelectionRange, TextInputSessionId,
+    };
     pub use crate::input::{
         FocusTraversalIntent, ImeCompositionSelection, ImeCompositionUpdate, InputEvent, Key,
         KeyState, KeyboardEvent, Modifiers, MouseButton, MouseEvent, ScrollPhase, TouchEvent,

--- a/crates/blinc_platform/src/microphone.rs
+++ b/crates/blinc_platform/src/microphone.rs
@@ -1,5 +1,5 @@
 use crate::error::PlatformError;
-use crate::permissions::{self, PermissionKind, PermissionStatus};
+use crate::permissions::{self, PermissionKind, PermissionRequestResult, PermissionStatus};
 
 /// Check current microphone permission status.
 pub fn status() -> Result<PermissionStatus, PlatformError> {
@@ -7,6 +7,6 @@ pub fn status() -> Result<PermissionStatus, PlatformError> {
 }
 
 /// Request microphone permission.
-pub fn request() -> Result<PermissionStatus, PlatformError> {
+pub fn request() -> Result<PermissionRequestResult, PlatformError> {
     permissions::request(PermissionKind::Microphone)
 }

--- a/crates/blinc_platform/src/permissions.rs
+++ b/crates/blinc_platform/src/permissions.rs
@@ -1,4 +1,5 @@
-use blinc_core::native_bridge::{native_call, NativeBridgeError};
+use blinc_core::native_bridge::{native_call, NativeBridgeError, NativeValue};
+use serde::{Deserialize, Serialize};
 
 use crate::error::PlatformError;
 
@@ -47,7 +48,8 @@ impl PermissionKind {
 }
 
 /// Unified runtime permission status.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum PermissionStatus {
     Granted,
     Denied,
@@ -56,6 +58,7 @@ pub enum PermissionStatus {
     Limited,
     NotDetermined,
     Provisional,
+    Pending,
     Unknown,
 }
 
@@ -67,21 +70,196 @@ impl PermissionStatus {
             Self::Denied
         }
     }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "granted" => Some(Self::Granted),
+            "denied" => Some(Self::Denied),
+            "permanently_denied" => Some(Self::PermanentlyDenied),
+            "restricted" => Some(Self::Restricted),
+            "limited" => Some(Self::Limited),
+            "not_determined" => Some(Self::NotDetermined),
+            "provisional" => Some(Self::Provisional),
+            "pending" => Some(Self::Pending),
+            "unknown" => Some(Self::Unknown),
+            _ => None,
+        }
+    }
+}
+
+/// Structured capability snapshot for a permission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PermissionCapability {
+    pub status: PermissionStatus,
+    #[serde(default)]
+    pub can_request: bool,
+    #[serde(default)]
+    pub requires_settings_redirect: bool,
+    #[serde(default = "default_supported")]
+    pub supported: bool,
+}
+
+/// Structured result from a permission request round-trip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PermissionRequestResult {
+    pub status: PermissionStatus,
+    #[serde(default)]
+    pub previous_status: Option<PermissionStatus>,
+    #[serde(default = "default_can_request_again")]
+    pub can_request_again: bool,
+    #[serde(default)]
+    pub requires_settings_redirect: bool,
+}
+
+fn default_supported() -> bool {
+    true
+}
+
+fn default_can_request_again() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct PermissionCapabilityPayload {
+    status: PermissionStatusWire,
+    #[serde(default, alias = "canRequest")]
+    can_request: bool,
+    #[serde(default, alias = "requiresSettingsRedirect")]
+    requires_settings_redirect: bool,
+    #[serde(default = "default_supported")]
+    supported: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct PermissionRequestPayload {
+    status: PermissionStatusWire,
+    #[serde(default, alias = "previousStatus")]
+    previous_status: Option<PermissionStatusWire>,
+    #[serde(default = "default_can_request_again", alias = "canRequestAgain")]
+    can_request_again: bool,
+    #[serde(default, alias = "requiresSettingsRedirect")]
+    requires_settings_redirect: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+enum PermissionStatusWire {
+    Named(String),
+    Bool(bool),
+}
+
+impl PermissionStatusWire {
+    fn into_status(self) -> Result<PermissionStatus, PlatformError> {
+        match self {
+            Self::Named(name) => PermissionStatus::from_str(&name).ok_or_else(|| {
+                PlatformError::Other(format!("Unknown permission status payload: {name}"))
+            }),
+            Self::Bool(granted) => Ok(PermissionStatus::from_bool(granted)),
+        }
+    }
+}
+
+impl PermissionCapabilityPayload {
+    fn into_capability(self) -> Result<PermissionCapability, PlatformError> {
+        Ok(PermissionCapability {
+            status: self.status.into_status()?,
+            can_request: self.can_request,
+            requires_settings_redirect: self.requires_settings_redirect,
+            supported: self.supported,
+        })
+    }
+}
+
+impl PermissionRequestPayload {
+    fn into_result(self) -> Result<PermissionRequestResult, PlatformError> {
+        Ok(PermissionRequestResult {
+            status: self.status.into_status()?,
+            previous_status: self
+                .previous_status
+                .map(PermissionStatusWire::into_status)
+                .transpose()?,
+            can_request_again: self.can_request_again,
+            requires_settings_redirect: self.requires_settings_redirect,
+        })
+    }
+}
+
+fn decode_json_payload<T>(value: NativeValue) -> Result<T, PlatformError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    match value {
+        NativeValue::Json(json) => Ok(serde_json::from_str(&json)?),
+        NativeValue::String(json) => Ok(serde_json::from_str(&json)?),
+        other => Err(PlatformError::Bridge(NativeBridgeError::TypeMismatch {
+            expected: "Json",
+            actual: other.type_name().to_string(),
+        })),
+    }
+}
+
+fn fallback_capability(status: PermissionStatus) -> PermissionCapability {
+    PermissionCapability {
+        can_request: matches!(
+            status,
+            PermissionStatus::Denied | PermissionStatus::NotDetermined
+        ),
+        requires_settings_redirect: matches!(
+            status,
+            PermissionStatus::PermanentlyDenied | PermissionStatus::Restricted
+        ),
+        supported: !matches!(status, PermissionStatus::Unknown),
+        status,
+    }
 }
 
 /// Check the current status of a runtime permission.
 pub fn status(kind: PermissionKind) -> Result<PermissionStatus, PlatformError> {
-    match native_call::<bool, _>("permissions", kind.has_name(), ()) {
-        Ok(granted) => Ok(PermissionStatus::from_bool(granted)),
-        Err(NativeBridgeError::NotRegistered { .. }) => Ok(PermissionStatus::Unknown),
+    Ok(capability(kind)?.status)
+}
+
+/// Fetch the current permission capability snapshot.
+pub fn capability(kind: PermissionKind) -> Result<PermissionCapability, PlatformError> {
+    match native_call::<NativeValue, _>("permissions", kind.has_name(), ()) {
+        Ok(NativeValue::Bool(granted)) => {
+            Ok(fallback_capability(PermissionStatus::from_bool(granted)))
+        }
+        Ok(other @ (NativeValue::Json(_) | NativeValue::String(_))) => {
+            decode_json_payload::<PermissionCapabilityPayload>(other)?.into_capability()
+        }
+        Ok(other) => Err(PlatformError::Bridge(NativeBridgeError::TypeMismatch {
+            expected: "Bool|Json",
+            actual: other.type_name().to_string(),
+        })),
+        Err(NativeBridgeError::NotRegistered { .. }) => {
+            Ok(fallback_capability(PermissionStatus::Unknown))
+        }
         Err(err) => Err(PlatformError::Bridge(err)),
     }
 }
 
 /// Request a runtime permission from the OS.
-pub fn request(kind: PermissionKind) -> Result<PermissionStatus, PlatformError> {
-    let granted: bool = native_call("permissions", kind.request_name(), ())?;
-    Ok(PermissionStatus::from_bool(granted))
+pub fn request(kind: PermissionKind) -> Result<PermissionRequestResult, PlatformError> {
+    match native_call::<NativeValue, _>("permissions", kind.request_name(), ())? {
+        NativeValue::Bool(granted) => Ok(PermissionRequestResult {
+            status: PermissionStatus::from_bool(granted),
+            previous_status: None,
+            can_request_again: !granted,
+            requires_settings_redirect: false,
+        }),
+        other @ (NativeValue::Json(_) | NativeValue::String(_)) => {
+            decode_json_payload::<PermissionRequestPayload>(other)?.into_result()
+        }
+        other => Err(PlatformError::Bridge(NativeBridgeError::TypeMismatch {
+            expected: "Bool|Json",
+            actual: other.type_name().to_string(),
+        })),
+    }
+}
+
+/// Open the OS settings page for the current application.
+pub fn open_settings() -> Result<bool, PlatformError> {
+    Ok(native_call("permissions", "open_settings", ())?)
 }
 
 /// Convenience helper returning whether permission is currently granted.

--- a/crates/blinc_platform/src/sensors/permissions.rs
+++ b/crates/blinc_platform/src/sensors/permissions.rs
@@ -1,5 +1,4 @@
-use blinc_core::native_bridge::native_call;
-
+use crate::permissions::{self, PermissionKind, PermissionStatus};
 use crate::SensorError;
 
 /// Snapshot of sensor-related permission states.
@@ -29,19 +28,39 @@ pub struct NativeBridgePermissionBackend;
 
 impl SensorPermissionBackend for NativeBridgePermissionBackend {
     fn has_location(&self) -> Result<bool, SensorError> {
-        native_call("permissions", "has_location", ()).map_err(SensorError::from)
+        permissions::is_granted(PermissionKind::LocationWhenInUse).map_err(|err| match err {
+            crate::PlatformError::Bridge(source) => SensorError::Bridge(source),
+            crate::PlatformError::Serialization(source) => SensorError::Serialization(source),
+            other => SensorError::Backend(other.to_string()),
+        })
     }
 
     fn has_motion(&self) -> Result<bool, SensorError> {
-        native_call("permissions", "has_motion", ()).map_err(SensorError::from)
+        permissions::is_granted(PermissionKind::Motion).map_err(|err| match err {
+            crate::PlatformError::Bridge(source) => SensorError::Bridge(source),
+            crate::PlatformError::Serialization(source) => SensorError::Serialization(source),
+            other => SensorError::Backend(other.to_string()),
+        })
     }
 
     fn request_location_when_in_use(&self) -> Result<bool, SensorError> {
-        native_call("permissions", "request_location_when_in_use", ()).map_err(SensorError::from)
+        permissions::request(PermissionKind::LocationWhenInUse)
+            .map(|result| result.status == PermissionStatus::Granted)
+            .map_err(|err| match err {
+                crate::PlatformError::Bridge(source) => SensorError::Bridge(source),
+                crate::PlatformError::Serialization(source) => SensorError::Serialization(source),
+                other => SensorError::Backend(other.to_string()),
+            })
     }
 
     fn request_motion(&self) -> Result<bool, SensorError> {
-        native_call("permissions", "request_motion", ()).map_err(SensorError::from)
+        permissions::request(PermissionKind::Motion)
+            .map(|result| result.status == PermissionStatus::Granted)
+            .map_err(|err| match err {
+                crate::PlatformError::Bridge(source) => SensorError::Bridge(source),
+                crate::PlatformError::Serialization(source) => SensorError::Serialization(source),
+                other => SensorError::Backend(other.to_string()),
+            })
     }
 }
 

--- a/crates/blinc_platform/tests/accessibility_runtime_api.rs
+++ b/crates/blinc_platform/tests/accessibility_runtime_api.rs
@@ -1,0 +1,66 @@
+use blinc_platform::{
+    current_accessibility_sync_status, current_platform_accessibility_snapshot,
+    mark_accessibility_unsupported, reset_accessibility_runtime_state,
+    update_platform_accessibility_snapshot, AccessibilityNode, AccessibilityRole,
+    AccessibilitySyncStatus, AccessibilityTreeSnapshot,
+};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+fn runtime_state_guard() -> MutexGuard<'static, ()> {
+    static TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+    TEST_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("accessibility runtime test mutex poisoned")
+}
+
+#[test]
+fn platform_accessibility_snapshot_round_trips_latest_value() {
+    let _guard = runtime_state_guard();
+    reset_accessibility_runtime_state();
+    let snapshot = AccessibilityTreeSnapshot::new(
+        11,
+        vec![AccessibilityNode::new(11, AccessibilityRole::Window)],
+    );
+
+    update_platform_accessibility_snapshot(snapshot.clone());
+
+    assert_eq!(current_platform_accessibility_snapshot(), Some(snapshot));
+    assert_eq!(
+        current_accessibility_sync_status(),
+        AccessibilitySyncStatus::Synced
+    );
+}
+
+#[test]
+fn unsupported_accessibility_sync_records_diagnostic() {
+    let _guard = runtime_state_guard();
+    reset_accessibility_runtime_state();
+    mark_accessibility_unsupported("mobile accessibility bridge is not wired");
+
+    assert_eq!(
+        current_accessibility_sync_status(),
+        AccessibilitySyncStatus::Unsupported(
+            "mobile accessibility bridge is not wired".to_string()
+        )
+    );
+}
+
+#[test]
+fn unsupported_bridge_after_snapshot_reports_snapshot_only() {
+    let _guard = runtime_state_guard();
+    reset_accessibility_runtime_state();
+    let snapshot = AccessibilityTreeSnapshot::new(
+        21,
+        vec![AccessibilityNode::new(21, AccessibilityRole::Window)],
+    );
+
+    update_platform_accessibility_snapshot(snapshot.clone());
+    mark_accessibility_unsupported("bridge deferred");
+
+    assert_eq!(current_platform_accessibility_snapshot(), Some(snapshot));
+    assert_eq!(
+        current_accessibility_sync_status(),
+        AccessibilitySyncStatus::SnapshotOnly("bridge deferred".to_string())
+    );
+}

--- a/crates/blinc_platform/tests/ime_api.rs
+++ b/crates/blinc_platform/tests/ime_api.rs
@@ -1,0 +1,37 @@
+use blinc_platform::{
+    current_ime_state, set_ime_state, ImeCompositionSelection, ImeCursorArea, ImeRequest, ImeState,
+    ImeVisibility, SelectionRange, TextInputSessionId,
+};
+
+#[test]
+fn ime_request_captures_mobile_runtime_contract_fields() {
+    let request = ImeRequest::new(TextInputSessionId::new("search"))
+        .with_visibility(ImeVisibility::Visible)
+        .with_cursor_area(ImeCursorArea::new(10.0, 20.0, 30.0, 40.0))
+        .with_selection(SelectionRange::new(2, 5))
+        .with_composition(Some(ImeCompositionSelection::new(0, 1)));
+
+    assert_eq!(request.session, TextInputSessionId::new("search"));
+    assert_eq!(request.visibility, ImeVisibility::Visible);
+    assert_eq!(request.selection, Some(SelectionRange::new(2, 5)));
+    assert_eq!(
+        request.composition,
+        Some(ImeCompositionSelection::new(0, 1))
+    );
+    assert_eq!(
+        request.cursor_area,
+        Some(ImeCursorArea::new(10.0, 20.0, 30.0, 40.0))
+    );
+}
+
+#[test]
+fn ime_state_round_trips_request_metadata() {
+    let state = ImeState::default().with_request(Some(
+        ImeRequest::new(TextInputSessionId::new("editor"))
+            .with_visibility(ImeVisibility::Visible)
+            .with_selection(SelectionRange::new(1, 3)),
+    ));
+
+    set_ime_state(state.clone());
+    assert_eq!(current_ime_state(), state);
+}

--- a/crates/blinc_platform/tests/sensors_runtime_controller.rs
+++ b/crates/blinc_platform/tests/sensors_runtime_controller.rs
@@ -1,9 +1,10 @@
 use std::sync::Mutex;
 
+use blinc_core::native_bridge::{native_register, NativeBridgeState, NativeValue};
 use blinc_platform::sensors::{
-    SensorAccuracy, SensorBackend, SensorClient, SensorConfig, SensorError, SensorFrame,
-    SensorKind, SensorPermissionBackend, SensorPermissionService, SensorRuntimeController,
-    SensorStatus,
+    NativeBridgePermissionBackend, SensorAccuracy, SensorBackend, SensorClient, SensorConfig,
+    SensorError, SensorFrame, SensorKind, SensorPermissionBackend, SensorPermissionService,
+    SensorRuntimeController, SensorStatus,
 };
 
 #[derive(Default)]
@@ -107,4 +108,55 @@ fn runtime_controller_starts_and_polls() {
 
     runtime.stop_if_running().expect("stop");
     assert!(!runtime.running());
+}
+
+#[test]
+fn native_bridge_permission_backend_accepts_structured_permission_payloads() {
+    if !NativeBridgeState::is_initialized() {
+        NativeBridgeState::init();
+    }
+
+    native_register("permissions", "has_location", |_| {
+        Ok(NativeValue::Json(
+            serde_json::json!({
+                "status": "granted",
+                "canRequest": false,
+                "requiresSettingsRedirect": false,
+                "supported": true
+            })
+            .to_string(),
+        ))
+    });
+    native_register("permissions", "has_motion", |_| {
+        Ok(NativeValue::Json(
+            serde_json::json!({
+                "status": "denied",
+                "canRequest": true,
+                "requiresSettingsRedirect": false,
+                "supported": true
+            })
+            .to_string(),
+        ))
+    });
+    native_register("permissions", "request_motion", |_| {
+        Ok(NativeValue::Json(
+            serde_json::json!({
+                "status": "granted",
+                "previousStatus": "denied",
+                "canRequestAgain": false,
+                "requiresSettingsRedirect": false
+            })
+            .to_string(),
+        ))
+    });
+
+    let backend = NativeBridgePermissionBackend;
+    assert!(backend.has_location().expect("has_location"));
+    assert!(!backend.has_motion().expect("has_motion"));
+    assert!(backend.request_motion().expect("request_motion"));
+
+    let bridge = NativeBridgeState::get();
+    let _ = bridge.unregister("permissions", "has_location");
+    let _ = bridge.unregister("permissions", "has_motion");
+    let _ = bridge.unregister("permissions", "request_motion");
 }

--- a/crates/blinc_platform/tests/services_api.rs
+++ b/crates/blinc_platform/tests/services_api.rs
@@ -243,7 +243,7 @@ fn app_and_haptics_wrappers_call_native_bridge() {
             .lock()
             .expect("calls lock")
             .push(format!("share_text:{text}"));
-        Ok(NativeValue::Bool(true))
+        Ok(NativeValue::Void)
     });
 
     let calls = CALLS.get_or_init(|| Mutex::new(Vec::new()));
@@ -270,7 +270,7 @@ fn app_and_haptics_wrappers_call_native_bridge() {
     });
 
     assert!(app::open_url("https://example.com").expect("open_url"));
-    assert!(app::share_text("hello world").expect("share_text"));
+    app::share_text("hello world").expect("share_text");
     haptics::selection().expect("selection");
     haptics::impact("medium").expect("impact");
 

--- a/crates/blinc_platform/tests/services_api.rs
+++ b/crates/blinc_platform/tests/services_api.rs
@@ -3,8 +3,12 @@ use std::sync::{Mutex, OnceLock};
 use blinc_core::native_bridge::{
     native_register, NativeBridgeError, NativeBridgeState, NativeValue,
 };
+use blinc_platform::app;
 use blinc_platform::clipboard;
-use blinc_platform::permissions::{self, PermissionKind, PermissionStatus};
+use blinc_platform::haptics;
+use blinc_platform::permissions::{
+    self, PermissionCapability, PermissionKind, PermissionRequestResult, PermissionStatus,
+};
 
 fn test_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -33,7 +37,8 @@ fn permission_status_and_request_roundtrip() {
     assert_eq!(status, PermissionStatus::Granted);
 
     let requested = permissions::request(PermissionKind::Microphone).expect("request");
-    assert_eq!(requested, PermissionStatus::Denied);
+    assert_eq!(requested.status, PermissionStatus::Denied);
+    assert!(requested.can_request_again);
 
     let granted = permissions::is_granted(PermissionKind::Microphone).expect("is_granted");
     assert!(granted);
@@ -41,6 +46,115 @@ fn permission_status_and_request_roundtrip() {
     let bridge = NativeBridgeState::get();
     let _ = bridge.unregister("permissions", "has_microphone");
     let _ = bridge.unregister("permissions", "request_microphone");
+}
+
+#[test]
+fn permission_status_and_request_support_structured_payloads() {
+    let _guard = test_lock().lock().expect("lock poisoned");
+    ensure_bridge();
+
+    native_register("permissions", "has_notifications", |_| {
+        Ok(NativeValue::Json(
+            serde_json::json!({
+                "status": "provisional",
+                "canRequest": true,
+                "requiresSettingsRedirect": false,
+                "supported": true
+            })
+            .to_string(),
+        ))
+    });
+    native_register("permissions", "request_notifications", |_| {
+        Ok(NativeValue::Json(
+            serde_json::json!({
+                "status": "provisional",
+                "previousStatus": "not_determined",
+                "canRequestAgain": true,
+                "requiresSettingsRedirect": false
+            })
+            .to_string(),
+        ))
+    });
+    native_register("permissions", "open_settings", |_| {
+        Ok(NativeValue::Bool(true))
+    });
+
+    let capability = permissions::capability(PermissionKind::Notifications).expect("capability");
+    assert_eq!(
+        capability,
+        PermissionCapability {
+            status: PermissionStatus::Provisional,
+            can_request: true,
+            requires_settings_redirect: false,
+            supported: true,
+        }
+    );
+
+    let status = permissions::status(PermissionKind::Notifications).expect("status");
+    assert_eq!(status, PermissionStatus::Provisional);
+
+    let request = permissions::request(PermissionKind::Notifications).expect("request");
+    assert_eq!(
+        request,
+        PermissionRequestResult {
+            status: PermissionStatus::Provisional,
+            previous_status: Some(PermissionStatus::NotDetermined),
+            can_request_again: true,
+            requires_settings_redirect: false,
+        }
+    );
+
+    assert!(permissions::open_settings().expect("open_settings"));
+
+    let bridge = NativeBridgeState::get();
+    let _ = bridge.unregister("permissions", "has_notifications");
+    let _ = bridge.unregister("permissions", "request_notifications");
+    let _ = bridge.unregister("permissions", "open_settings");
+}
+
+#[test]
+fn permission_capability_supports_settings_redirect_and_unsupported_payloads() {
+    let _guard = test_lock().lock().expect("lock poisoned");
+    ensure_bridge();
+
+    native_register("permissions", "has_camera", |_| {
+        Ok(NativeValue::Json(
+            serde_json::json!({
+                "status": "restricted",
+                "canRequest": false,
+                "requiresSettingsRedirect": true,
+                "supported": true
+            })
+            .to_string(),
+        ))
+    });
+    native_register("permissions", "request_photos", |_| {
+        Ok(NativeValue::Json(
+            serde_json::json!({
+                "status": "unknown",
+                "previousStatus": "unknown",
+                "canRequestAgain": false,
+                "requiresSettingsRedirect": false
+            })
+            .to_string(),
+        ))
+    });
+
+    let camera = permissions::capability(PermissionKind::Camera).expect("camera capability");
+    assert_eq!(camera.status, PermissionStatus::Restricted);
+    assert!(!camera.can_request);
+    assert!(camera.requires_settings_redirect);
+    assert!(camera.supported);
+
+    let photos = permissions::request(PermissionKind::Photos).expect("photos request");
+    assert_eq!(photos.status, PermissionStatus::Unknown);
+    assert_eq!(photos.previous_status, Some(PermissionStatus::Unknown));
+    assert!(!photos.can_request_again);
+    assert!(!photos.requires_settings_redirect);
+
+    let bridge = NativeBridgeState::get();
+    let _ = bridge.unregister("permissions", "has_camera");
+    let _ = bridge.unregister("permissions", "request_photos");
 }
 
 #[test]
@@ -93,6 +207,93 @@ fn clipboard_wrapper_calls_native_bridge() {
     let _ = bridge.unregister("clipboard", "paste");
     let _ = bridge.unregister("clipboard", "has_content");
     let _ = bridge.unregister("clipboard", "clear");
+}
+
+#[test]
+fn app_and_haptics_wrappers_call_native_bridge() {
+    let _guard = test_lock().lock().expect("lock poisoned");
+    ensure_bridge();
+
+    static CALLS: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+    let calls = CALLS.get_or_init(|| Mutex::new(Vec::new()));
+    calls.lock().expect("calls lock").clear();
+
+    let calls = CALLS.get_or_init(|| Mutex::new(Vec::new()));
+    native_register("app", "open_url", move |args| {
+        let url = args
+            .first()
+            .and_then(NativeValue::as_str)
+            .unwrap_or_default()
+            .to_string();
+        calls
+            .lock()
+            .expect("calls lock")
+            .push(format!("open_url:{url}"));
+        Ok(NativeValue::Bool(true))
+    });
+
+    let calls = CALLS.get_or_init(|| Mutex::new(Vec::new()));
+    native_register("app", "share_text", move |args| {
+        let text = args
+            .first()
+            .and_then(NativeValue::as_str)
+            .unwrap_or_default()
+            .to_string();
+        calls
+            .lock()
+            .expect("calls lock")
+            .push(format!("share_text:{text}"));
+        Ok(NativeValue::Bool(true))
+    });
+
+    let calls = CALLS.get_or_init(|| Mutex::new(Vec::new()));
+    native_register("haptics", "selection", move |_| {
+        calls
+            .lock()
+            .expect("calls lock")
+            .push("selection".to_string());
+        Ok(NativeValue::Void)
+    });
+
+    let calls = CALLS.get_or_init(|| Mutex::new(Vec::new()));
+    native_register("haptics", "impact", move |args| {
+        let style = args
+            .first()
+            .and_then(NativeValue::as_str)
+            .unwrap_or_default()
+            .to_string();
+        calls
+            .lock()
+            .expect("calls lock")
+            .push(format!("impact:{style}"));
+        Ok(NativeValue::Void)
+    });
+
+    assert!(app::open_url("https://example.com").expect("open_url"));
+    assert!(app::share_text("hello world").expect("share_text"));
+    haptics::selection().expect("selection");
+    haptics::impact("medium").expect("impact");
+
+    assert_eq!(
+        CALLS
+            .get()
+            .expect("calls")
+            .lock()
+            .expect("calls lock")
+            .as_slice(),
+        &[
+            "open_url:https://example.com",
+            "share_text:hello world",
+            "selection",
+            "impact:medium",
+        ]
+    );
+
+    let bridge = NativeBridgeState::get();
+    let _ = bridge.unregister("app", "open_url");
+    let _ = bridge.unregister("app", "share_text");
+    let _ = bridge.unregister("haptics", "selection");
+    let _ = bridge.unregister("haptics", "impact");
 }
 
 #[test]

--- a/docs/mobile-release.md
+++ b/docs/mobile-release.md
@@ -1,0 +1,72 @@
+# Mobile Release Packaging
+
+This document defines the current packaging contract for the canonical native
+reference app at `/Users/cypark/.codex/worktrees/d483/Blinc/mobile/example`.
+
+## Build Lanes
+
+- `debug smoke`
+  - Android: `./build-android.sh debug`
+  - iOS: `./build-ios.sh debug-libs`
+- `release artifact`
+  - Android APK: `./build-android.sh release`
+  - Android AAB: `./build-android.sh bundle-release`
+  - iOS static libs: `./build-ios.sh release-libs`
+  - iOS archive: `./build-ios.sh archive`
+  - iOS export: `./build-ios.sh export-archive`
+
+## Artifact Paths
+
+- Android debug APK:
+  - `mobile/example/artifacts/android/debug-apk/app-debug.apk`
+- Android release APK:
+  - `mobile/example/artifacts/android/release-apk/app-release.apk`
+- Android release AAB:
+  - `mobile/example/artifacts/android/release-bundle/app-release.aab`
+- iOS release libraries:
+  - `mobile/example/artifacts/ios/libs/release/device/libexample.a`
+  - `mobile/example/artifacts/ios/libs/release/simulator/libexample.a`
+- iOS archive default:
+  - `mobile/example/artifacts/ios/archive/BlincApp.xcarchive`
+- iOS export default:
+  - `mobile/example/artifacts/ios/export/`
+
+## Signing Inputs
+
+### Android
+
+- `BLINC_ANDROID_KEYSTORE_PATH`
+- `BLINC_ANDROID_KEYSTORE_PASSWORD`
+- `BLINC_ANDROID_KEY_ALIAS`
+- `BLINC_ANDROID_KEY_PASSWORD`
+
+If these are omitted, Gradle must already be configured for unsigned or local
+debug-style builds. The script still exports the generated APK/AAB when Gradle
+produces one.
+
+### iOS
+
+- `BLINC_IOS_TEAM_ID`
+- `BLINC_IOS_CODE_SIGNING_ALLOWED`
+- `BLINC_IOS_ARCHIVE_PATH`
+- `BLINC_IOS_EXPORT_PATH`
+- `BLINC_IOS_EXPORT_OPTIONS_PLIST`
+
+`archive` defaults to `CODE_SIGNING_ALLOWED=NO` so CI and local packaging can
+produce an archive contract without assuming developer signing is available.
+`export-archive` requires an export options plist because `.ipa` export policy
+is distribution-specific.
+
+## CI Split
+
+- `runtime correctness`
+  - Rust tests
+  - bridge sync check
+  - debug-oriented mobile crate checks
+- `packaging`
+  - Android release APK/AAB generation
+  - iOS archive command contract validation
+
+Current repository automation validates the command contract and artifact paths.
+Store submission, notarization, and App Store / Play Console upload remain out
+of scope.

--- a/docs/mobile-release.md
+++ b/docs/mobile-release.md
@@ -1,7 +1,7 @@
 # Mobile Release Packaging
 
 This document defines the current packaging contract for the canonical native
-reference app at `/Users/cypark/.codex/worktrees/d483/Blinc/mobile/example`.
+reference app at [`mobile/example`](../mobile/example/README.md).
 
 ## Build Lanes
 

--- a/docs/native-readiness.md
+++ b/docs/native-readiness.md
@@ -1,0 +1,38 @@
+# Native Readiness
+
+This document defines the current native support contract for Blinc.
+
+`native-ready` is not a single yes/no state in this repository. Support is
+tracked in tiers so platform behavior, examples, and templates can describe the
+same contract.
+
+## Tiers
+
+- `Tier 1`: render, touch/input dispatch, lifecycle wiring, viewport/environment snapshot
+- `Tier 2`: text input/IME, permissions, and basic native services
+- `Tier 3`: accessibility, advanced OS integration, and release productization
+
+## Platform Matrix
+
+| Platform | Tier 1 | Tier 2 | Tier 3 | Notes |
+|----------|--------|--------|--------|-------|
+| Android | Partial | Partial | Deferred | Native bridge, sensors, permissions, clipboard/share/haptics paths exist. IME/runtime lifecycle and release productization are still being hardened. |
+| iOS | Partial | Partial | Deferred | UIKit bridge, rendering, sensors, and environment snapshot work exists. IME/accessibility parity and some native permission paths are still incomplete. |
+| Fuchsia | Unsupported | Unsupported | Unsupported | In-tree runtime is explicitly unsupported. Template files are scaffolding only. |
+| HarmonyOS | Deferred | Deferred | Deferred | Not a verification target in the current repo. |
+
+For the concrete mobile packaging contract, artifact paths, and signing inputs,
+see [`docs/mobile-release.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/mobile-release.md).
+
+## Canonical References
+
+- [`mobile/example`](/Users/cypark/.codex/worktrees/d483/Blinc/mobile/example/README.md): canonical native reference app for current bridge/runtime work
+- [`examples/counter`](/Users/cypark/.codex/worktrees/d483/Blinc/examples/counter/README.md): scaffold example, not the native readiness reference
+- [`toolchain/templates/rust/platforms/android/README.md`](/Users/cypark/.codex/worktrees/d483/Blinc/toolchain/templates/rust/platforms/android/README.md): Android scaffold contract
+- [`toolchain/templates/rust/platforms/fuchsia/README.md`](/Users/cypark/.codex/worktrees/d483/Blinc/toolchain/templates/rust/platforms/fuchsia/README.md): deferred/unsupported Fuchsia scaffolding
+
+## Rules
+
+- No mobile runtime path should silently succeed with stub behavior.
+- If a platform path is not implemented, it should return an explicit unsupported error or be documented as deferred.
+- Example and template documentation should describe the tier they actually satisfy, not an aspirational end state.

--- a/docs/native-readiness.md
+++ b/docs/native-readiness.md
@@ -22,14 +22,14 @@ same contract.
 | HarmonyOS | Deferred | Deferred | Deferred | Not a verification target in the current repo. |
 
 For the concrete mobile packaging contract, artifact paths, and signing inputs,
-see [`docs/mobile-release.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/mobile-release.md).
+see [`docs/mobile-release.md`](mobile-release.md).
 
 ## Canonical References
 
-- [`mobile/example`](/Users/cypark/.codex/worktrees/d483/Blinc/mobile/example/README.md): canonical native reference app for current bridge/runtime work
-- [`examples/counter`](/Users/cypark/.codex/worktrees/d483/Blinc/examples/counter/README.md): scaffold example, not the native readiness reference
-- [`toolchain/templates/rust/platforms/android/README.md`](/Users/cypark/.codex/worktrees/d483/Blinc/toolchain/templates/rust/platforms/android/README.md): Android scaffold contract
-- [`toolchain/templates/rust/platforms/fuchsia/README.md`](/Users/cypark/.codex/worktrees/d483/Blinc/toolchain/templates/rust/platforms/fuchsia/README.md): deferred/unsupported Fuchsia scaffolding
+- [`mobile/example`](../mobile/example/README.md): canonical native reference app for current bridge/runtime work
+- [`examples/counter`](../examples/counter/README.md): scaffold example, not the native readiness reference
+- [`toolchain/templates/rust/platforms/android/README.md`](../toolchain/templates/rust/platforms/android/README.md): Android scaffold contract
+- [`toolchain/templates/rust/platforms/fuchsia/README.md`](../toolchain/templates/rust/platforms/fuchsia/README.md): deferred/unsupported Fuchsia scaffolding
 
 ## Rules
 

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,6 +1,7 @@
 # counter
 
-A Blinc UI application.
+A Blinc UI scaffold example. This project is not the canonical mobile-native
+reference app.
 
 ## Development
 
@@ -14,10 +15,22 @@ blinc dev
 # Desktop (current platform)
 blinc build --release
 
-# Mobile
+# Mobile scaffold output
 blinc build --target android --release
 blinc build --target ios --release
 ```
+
+## Support Tiers
+
+- Tier 1: scaffold generation and desktop/local structure validation
+- Tier 2: Android/iOS output depends on generated platform projects
+- Tier 3: release packaging and native feature parity are out of scope here
+
+Use [`mobile/example`](/Users/cypark/.codex/worktrees/d483/Blinc/mobile/example/README.md)
+as the canonical native reference app for IME, permissions, sensors, and bridge behavior.
+
+Repo-wide native support tiers are defined in
+[`docs/native-readiness.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/native-readiness.md).
 
 ## Project Structure
 
@@ -30,7 +43,7 @@ counter/
 ├── plugins/             # Local plugins
 └── platforms/           # Platform-specific code
     ├── android/         # Android project files
-    ├── ios/             # iOS/Xcode project files
+    ├── ios/             # iOS scaffold files
     ├── macos/           # macOS app bundle config
     ├── windows/         # Windows executable config
     └── linux/           # Linux desktop config

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -26,11 +26,11 @@ blinc build --target ios --release
 - Tier 2: Android/iOS output depends on generated platform projects
 - Tier 3: release packaging and native feature parity are out of scope here
 
-Use [`mobile/example`](/Users/cypark/.codex/worktrees/d483/Blinc/mobile/example/README.md)
+Use [`mobile/example`](../../mobile/example/README.md)
 as the canonical native reference app for IME, permissions, sensors, and bridge behavior.
 
 Repo-wide native support tiers are defined in
-[`docs/native-readiness.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/native-readiness.md).
+[`docs/native-readiness.md`](../../docs/native-readiness.md).
 
 ## Project Structure
 

--- a/extensions/blinc_platform_android/src/jni_bridge.rs
+++ b/extensions/blinc_platform_android/src/jni_bridge.rs
@@ -77,10 +77,129 @@ use ndk::native_window::NativeWindow;
 #[cfg(target_os = "android")]
 use tracing::{debug, error, info, warn};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RuntimeLifecycleState {
+    Foreground,
+    Inactive,
+    Background,
+    Destroyed,
+}
+
+impl RuntimeLifecycleState {
+    fn from_raw(value: i32) -> Self {
+        match value {
+            0 => Self::Foreground,
+            1 => Self::Inactive,
+            2 => Self::Background,
+            3 => Self::Destroyed,
+            _ => Self::Inactive,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct EmbeddingRuntimeState {
+    width: u32,
+    height: u32,
+    scale_factor: f64,
+    surface_attached: bool,
+    destroyed: bool,
+    lifecycle: RuntimeLifecycleState,
+}
+
+impl EmbeddingRuntimeState {
+    fn new(width: u32, height: u32, scale_factor: f64) -> Self {
+        Self {
+            width,
+            height,
+            scale_factor,
+            surface_attached: true,
+            destroyed: false,
+            lifecycle: RuntimeLifecycleState::Foreground,
+        }
+    }
+
+    fn attach_surface(
+        &mut self,
+        width: u32,
+        height: u32,
+        scale_factor: f64,
+    ) -> Result<(), &'static str> {
+        if self.destroyed {
+            return Err("runtime destroyed");
+        }
+        self.width = width;
+        self.height = height;
+        self.scale_factor = scale_factor;
+        self.surface_attached = true;
+        Ok(())
+    }
+
+    fn detach_surface(&mut self) -> Result<(), &'static str> {
+        if self.destroyed {
+            return Err("runtime destroyed");
+        }
+        self.surface_attached = false;
+        Ok(())
+    }
+
+    fn resize(&mut self, width: u32, height: u32) -> Result<(), &'static str> {
+        if self.destroyed {
+            return Err("runtime destroyed");
+        }
+        if !self.surface_attached {
+            return Err("surface detached");
+        }
+        self.width = width;
+        self.height = height;
+        Ok(())
+    }
+
+    fn on_lifecycle(&mut self, lifecycle: RuntimeLifecycleState) -> Result<(), &'static str> {
+        if self.destroyed && lifecycle != RuntimeLifecycleState::Destroyed {
+            return Err("runtime destroyed");
+        }
+        self.lifecycle = lifecycle;
+        if lifecycle == RuntimeLifecycleState::Destroyed {
+            self.destroyed = true;
+            self.surface_attached = false;
+        }
+        Ok(())
+    }
+
+    fn render_allowed(&self) -> bool {
+        !self.destroyed
+            && self.surface_attached
+            && matches!(
+                self.lifecycle,
+                RuntimeLifecycleState::Foreground | RuntimeLifecycleState::Inactive
+            )
+    }
+}
+
+fn commit_surface_attach(
+    runtime: &mut EmbeddingRuntimeState,
+    current_window_ptr: &mut *mut std::ffi::c_void,
+    next_window_ptr: *mut std::ffi::c_void,
+    width: u32,
+    height: u32,
+    scale_factor: f64,
+) -> Result<Option<*mut std::ffi::c_void>, &'static str> {
+    runtime.attach_surface(width, height, scale_factor)?;
+    let previous = if current_window_ptr.is_null() {
+        None
+    } else {
+        Some(*current_window_ptr)
+    };
+    *current_window_ptr = next_window_ptr;
+    Ok(previous)
+}
+
 /// Opaque handle to BlincRenderer state
 /// This is passed to Kotlin as a Long and cast back when needed
 #[cfg(target_os = "android")]
 struct BlincHandle {
+    runtime: EmbeddingRuntimeState,
     /// Width of the surface in pixels
     width: u32,
     /// Height of the surface in pixels
@@ -107,6 +226,7 @@ impl BlincHandle {
         native_window_ptr: *mut std::ffi::c_void,
     ) -> Self {
         Self {
+            runtime: EmbeddingRuntimeState::new(width, height, scale_factor),
             width,
             height,
             scale_factor,
@@ -116,10 +236,6 @@ impl BlincHandle {
         }
     }
 }
-
-// BlincHandle contains a raw pointer but we only use it from the JNI thread
-#[cfg(target_os = "android")]
-unsafe impl Send for BlincHandle {}
 
 /// Initialize Blinc renderer with an Android Surface
 ///
@@ -217,6 +333,11 @@ pub extern "system" fn Java_com_blinc_BlincBridge_nativeRenderFrame(
 
     let _blinc = unsafe { &mut *(handle as *mut BlincHandle) };
 
+    if !_blinc.runtime.render_allowed() {
+        debug!("nativeRenderFrame skipped: runtime not renderable");
+        return;
+    }
+
     // TODO: Implement actual rendering
     // 1. Get surface texture
     // 2. Clear with background color
@@ -224,6 +345,104 @@ pub extern "system" fn Java_com_blinc_BlincBridge_nativeRenderFrame(
     // 4. Present
 
     debug!("nativeRenderFrame called");
+}
+
+/// Attach or re-attach a Surface to an existing runtime.
+#[cfg(target_os = "android")]
+#[no_mangle]
+pub extern "system" fn Java_com_blinc_BlincBridge_nativeAttachSurface(
+    mut env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+    surface: JObject,
+    width: jint,
+    height: jint,
+    density: jfloat,
+) -> jboolean {
+    if handle == 0 || width <= 0 || height <= 0 {
+        return JNI_FALSE;
+    }
+
+    let blinc = unsafe { &mut *(handle as *mut BlincHandle) };
+    let native_window_ptr = match get_native_window_from_surface(&mut env, &surface) {
+        Ok(ptr) => ptr,
+        Err(err) => {
+            error!("nativeAttachSurface failed to get surface: {}", err);
+            return JNI_FALSE;
+        }
+    };
+
+    let next_width = width as u32;
+    let next_height = height as u32;
+    let next_scale_factor = if density > 0.0 { density as f64 } else { 1.0 };
+    match commit_surface_attach(
+        &mut blinc.runtime,
+        &mut blinc.native_window_ptr,
+        native_window_ptr,
+        next_width,
+        next_height,
+        next_scale_factor,
+    ) {
+        Ok(previous_window_ptr) => {
+            blinc.width = next_width;
+            blinc.height = next_height;
+            blinc.scale_factor = next_scale_factor;
+            if let Some(previous_window_ptr) = previous_window_ptr {
+                unsafe { ANativeWindow_release(previous_window_ptr) };
+            }
+            JNI_TRUE
+        }
+        Err(err) => {
+            unsafe { ANativeWindow_release(native_window_ptr) };
+            error!("nativeAttachSurface rejected: {}", err);
+            JNI_FALSE
+        }
+    }
+}
+
+/// Detach the current Surface from an existing runtime without destroying it.
+#[cfg(target_os = "android")]
+#[no_mangle]
+pub extern "system" fn Java_com_blinc_BlincBridge_nativeDetachSurface(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+) {
+    if handle == 0 {
+        return;
+    }
+
+    let blinc = unsafe { &mut *(handle as *mut BlincHandle) };
+    if let Err(err) = blinc.runtime.detach_surface() {
+        warn!("nativeDetachSurface ignored: {}", err);
+        return;
+    }
+    if !blinc.native_window_ptr.is_null() {
+        unsafe { ANativeWindow_release(blinc.native_window_ptr) };
+        blinc.native_window_ptr = std::ptr::null_mut();
+    }
+}
+
+/// Update lifecycle state for the embedded runtime.
+#[cfg(target_os = "android")]
+#[no_mangle]
+pub extern "system" fn Java_com_blinc_BlincBridge_nativeOnLifecycle(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+    state: jint,
+) {
+    if handle == 0 {
+        return;
+    }
+
+    let blinc = unsafe { &mut *(handle as *mut BlincHandle) };
+    if let Err(err) = blinc
+        .runtime
+        .on_lifecycle(RuntimeLifecycleState::from_raw(state))
+    {
+        warn!("nativeOnLifecycle ignored: {}", err);
+    }
 }
 
 /// Handle touch input event
@@ -325,8 +544,16 @@ pub extern "system" fn Java_com_blinc_BlincBridge_nativeResize(
     let blinc = unsafe { &mut *(handle as *mut BlincHandle) };
 
     info!("Surface resized to {}x{}", width, height);
-    blinc.width = width as u32;
-    blinc.height = height as u32;
+    match blinc.runtime.resize(width as u32, height as u32) {
+        Ok(()) => {
+            blinc.width = width as u32;
+            blinc.height = height as u32;
+        }
+        Err(err) => {
+            warn!("nativeResize ignored: {}", err);
+            return;
+        }
+    }
 
     // TODO: Reconfigure wgpu surface with new dimensions
 }
@@ -354,6 +581,8 @@ pub extern "system" fn Java_com_blinc_BlincBridge_nativeDestroy(
 
     // Reclaim the Box and drop it
     let blinc = unsafe { Box::from_raw(handle as *mut BlincHandle) };
+    let mut runtime = blinc.runtime;
+    let _ = runtime.on_lifecycle(RuntimeLifecycleState::Destroyed);
 
     // Release the native window reference
     if !blinc.native_window_ptr.is_null() {
@@ -411,4 +640,75 @@ fn get_native_window_from_surface(
 #[cfg(not(target_os = "android"))]
 pub fn jni_bridge_placeholder() {
     // Placeholder for non-Android builds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{commit_surface_attach, EmbeddingRuntimeState, RuntimeLifecycleState};
+
+    #[test]
+    fn embedding_runtime_state_tracks_attach_detach_and_destroy() {
+        let mut state = EmbeddingRuntimeState::new(100, 200, 2.0);
+        assert!(state.render_allowed());
+
+        state.detach_surface().expect("detach");
+        assert!(!state.render_allowed());
+
+        state.attach_surface(320, 640, 3.0).expect("attach");
+        assert!(state.render_allowed());
+        assert_eq!(state.width, 320);
+        assert_eq!(state.height, 640);
+        assert_eq!(state.scale_factor, 3.0);
+
+        state
+            .on_lifecycle(RuntimeLifecycleState::Background)
+            .expect("background");
+        assert!(!state.render_allowed());
+
+        state
+            .on_lifecycle(RuntimeLifecycleState::Destroyed)
+            .expect("destroy");
+        assert!(state.destroyed);
+        assert!(!state.surface_attached);
+        assert!(!state.render_allowed());
+    }
+
+    #[test]
+    fn runtime_lifecycle_state_maps_from_jni_values() {
+        assert_eq!(
+            RuntimeLifecycleState::from_raw(0),
+            RuntimeLifecycleState::Foreground
+        );
+        assert_eq!(
+            RuntimeLifecycleState::from_raw(1),
+            RuntimeLifecycleState::Inactive
+        );
+        assert_eq!(
+            RuntimeLifecycleState::from_raw(2),
+            RuntimeLifecycleState::Background
+        );
+        assert_eq!(
+            RuntimeLifecycleState::from_raw(3),
+            RuntimeLifecycleState::Destroyed
+        );
+        assert_eq!(
+            RuntimeLifecycleState::from_raw(99),
+            RuntimeLifecycleState::Inactive
+        );
+    }
+
+    #[test]
+    fn failed_surface_attach_does_not_replace_current_window_pointer() {
+        let mut runtime = EmbeddingRuntimeState::new(100, 200, 2.0);
+        runtime
+            .on_lifecycle(RuntimeLifecycleState::Destroyed)
+            .expect("destroy");
+        let original = 0x10usize as *mut std::ffi::c_void;
+        let mut current = original;
+        let next = 0x20usize as *mut std::ffi::c_void;
+
+        let result = commit_surface_attach(&mut runtime, &mut current, next, 320, 640, 3.0);
+        assert_eq!(result, Err("runtime destroyed"));
+        assert_eq!(current, original);
+    }
 }

--- a/extensions/blinc_platform_android/templates/BlincNativeBridge.kt
+++ b/extensions/blinc_platform_android/templates/BlincNativeBridge.kt
@@ -210,7 +210,16 @@ object BlincNativeBridge {
         }
 
         register("haptics", "impact") { args ->
-            val style = args.optInt(0, 1)
+            val style = when {
+                !args.isNull(0) && args.optString(0).isNotEmpty() -> {
+                    when (args.optString(0, "medium").lowercase()) {
+                        "light" -> 0
+                        "heavy" -> 2
+                        else -> 1
+                    }
+                }
+                else -> args.optInt(0, 1)
+            }
             val amplitude = when (style) {
                 0 -> 50   // light
                 2 -> 255  // heavy

--- a/extensions/blinc_platform_android/templates/BlincNativeBridge.kt
+++ b/extensions/blinc_platform_android/templates/BlincNativeBridge.kt
@@ -60,6 +60,13 @@ import java.util.TimeZone
 import java.lang.ref.WeakReference
 
 object BlincNativeBridge {
+    private data class PermissionCapabilityState(
+        val status: String,
+        val canRequest: Boolean,
+        val requiresSettingsRedirect: Boolean,
+        val supported: Boolean = true,
+    )
+
 
     // Handler type: (args: JSONArray) -> Any?
     private val handlers = mutableMapOf<String, MutableMap<String, (JSONArray) -> Any?>>()
@@ -317,58 +324,196 @@ object BlincNativeBridge {
         // =====================================================================
 
         register("permissions", "has_location") {
-            sensorCollector.hasLocationPermission()
+            val granted = sensorCollector.hasLocationPermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                granted = granted,
+            )
         }
         register("permissions", "has_location_always") {
-            sensorCollector.hasLocationAlwaysPermission()
+            val granted = sensorCollector.hasLocationAlwaysPermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+                granted = granted,
+            )
         }
         register("permissions", "has_motion") {
-            sensorCollector.hasMotionPermission()
+            val granted = sensorCollector.hasMotionPermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.ACTIVITY_RECOGNITION,
+                granted = granted,
+            )
         }
         register("permissions", "has_camera") {
-            sensorCollector.hasCameraPermission()
+            val granted = sensorCollector.hasCameraPermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.CAMERA,
+                granted = granted,
+            )
         }
         register("permissions", "has_microphone") {
-            sensorCollector.hasMicrophonePermission()
+            val granted = sensorCollector.hasMicrophonePermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.RECORD_AUDIO,
+                granted = granted,
+            )
         }
         register("permissions", "has_photos") {
-            sensorCollector.hasPhotosPermission()
+            val granted = sensorCollector.hasPhotosPermission()
+            permissionCapabilityPayload(
+                permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    Manifest.permission.READ_MEDIA_IMAGES
+                } else {
+                    Manifest.permission.READ_EXTERNAL_STORAGE
+                },
+                granted = granted,
+            )
         }
         register("permissions", "has_notifications") {
-            sensorCollector.hasNotificationsPermission()
+            val granted = sensorCollector.hasNotificationsPermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.POST_NOTIFICATIONS,
+                granted = granted,
+            )
         }
         register("permissions", "has_bluetooth_scan") {
-            sensorCollector.hasBluetoothScanPermission()
+            val granted = sensorCollector.hasBluetoothScanPermission()
+            permissionCapabilityPayload(
+                permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    Manifest.permission.BLUETOOTH_SCAN
+                } else {
+                    Manifest.permission.ACCESS_FINE_LOCATION
+                },
+                granted = granted,
+            )
         }
         register("permissions", "has_bluetooth_connect") {
-            sensorCollector.hasBluetoothConnectPermission()
+            val granted = sensorCollector.hasBluetoothConnectPermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.BLUETOOTH_CONNECT,
+                granted = granted,
+            )
         }
         register("permissions", "request_location_when_in_use") {
-            sensorCollector.requestLocationPermissionWhenInUse()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                granted = sensorCollector.hasLocationPermission(),
+            )
+            val granted = sensorCollector.requestLocationPermissionWhenInUse()
+            permissionRequestPayload(
+                permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_location_always") {
-            sensorCollector.requestLocationPermissionAlways()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+                granted = sensorCollector.hasLocationAlwaysPermission(),
+            )
+            val granted = sensorCollector.requestLocationPermissionAlways()
+            permissionRequestPayload(
+                permission = Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_motion") {
-            sensorCollector.requestMotionPermission()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.ACTIVITY_RECOGNITION,
+                granted = sensorCollector.hasMotionPermission(),
+            )
+            val granted = sensorCollector.requestMotionPermission()
+            permissionRequestPayload(
+                permission = Manifest.permission.ACTIVITY_RECOGNITION,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_camera") {
-            sensorCollector.requestCameraPermission()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.CAMERA,
+                granted = sensorCollector.hasCameraPermission(),
+            )
+            val granted = sensorCollector.requestCameraPermission()
+            permissionRequestPayload(
+                permission = Manifest.permission.CAMERA,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_microphone") {
-            sensorCollector.requestMicrophonePermission()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.RECORD_AUDIO,
+                granted = sensorCollector.hasMicrophonePermission(),
+            )
+            val granted = sensorCollector.requestMicrophonePermission()
+            permissionRequestPayload(
+                permission = Manifest.permission.RECORD_AUDIO,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_photos") {
-            sensorCollector.requestPhotosPermission()
+            val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                Manifest.permission.READ_MEDIA_IMAGES
+            } else {
+                Manifest.permission.READ_EXTERNAL_STORAGE
+            }
+            val previous = permissionCapabilityState(
+                permission = permission,
+                granted = sensorCollector.hasPhotosPermission(),
+            )
+            val granted = sensorCollector.requestPhotosPermission()
+            permissionRequestPayload(
+                permission = permission,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_notifications") {
-            sensorCollector.requestNotificationsPermission()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.POST_NOTIFICATIONS,
+                granted = sensorCollector.hasNotificationsPermission(),
+            )
+            val granted = sensorCollector.requestNotificationsPermission()
+            permissionRequestPayload(
+                permission = Manifest.permission.POST_NOTIFICATIONS,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_bluetooth_scan") {
-            sensorCollector.requestBluetoothScanPermission()
+            val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                Manifest.permission.BLUETOOTH_SCAN
+            } else {
+                Manifest.permission.ACCESS_FINE_LOCATION
+            }
+            val previous = permissionCapabilityState(
+                permission = permission,
+                granted = sensorCollector.hasBluetoothScanPermission(),
+            )
+            val granted = sensorCollector.requestBluetoothScanPermission()
+            permissionRequestPayload(
+                permission = permission,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_bluetooth_connect") {
-            sensorCollector.requestBluetoothConnectPermission()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.BLUETOOTH_CONNECT,
+                granted = sensorCollector.hasBluetoothConnectPermission(),
+            )
+            val granted = sensorCollector.requestBluetoothConnectPermission()
+            permissionRequestPayload(
+                permission = Manifest.permission.BLUETOOTH_CONNECT,
+                previous = previous,
+                granted = granted,
+            )
+        }
+        register("permissions", "open_settings") {
+            openApplicationSettings()
         }
 
         // =====================================================================
@@ -451,6 +596,8 @@ object BlincNativeBridge {
             is Long -> obj.put("value", value)
             is Float -> obj.put("value", value)
             is Double -> obj.put("value", value)
+            is JSONObject -> obj.put("value", value)
+            is JSONArray -> obj.put("value", value)
             is ByteArray -> obj.put("value", android.util.Base64.encodeToString(value, android.util.Base64.NO_WRAP))
             else -> obj.put("value", value.toString())
         }
@@ -463,6 +610,111 @@ object BlincNativeBridge {
         obj.put("errorType", type)
         obj.put("errorMessage", message)
         return obj.toString()
+    }
+
+    private fun openApplicationSettings(): Boolean {
+        val activity = foregroundActivityRef?.get() ?: return false
+        val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", activity.packageName, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        activity.startActivity(intent)
+        return true
+    }
+
+    private fun permissionCapabilityState(
+        permission: String,
+        granted: Boolean,
+        supported: Boolean = true,
+    ): PermissionCapabilityState {
+        if (!supported) {
+            return PermissionCapabilityState(
+                status = "unknown",
+                canRequest = false,
+                requiresSettingsRedirect = false,
+                supported = false,
+            )
+        }
+        if (granted) {
+            return PermissionCapabilityState(
+                status = "granted",
+                canRequest = false,
+                requiresSettingsRedirect = false,
+            )
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return PermissionCapabilityState(
+                status = "granted",
+                canRequest = false,
+                requiresSettingsRedirect = false,
+            )
+        }
+
+        val activity = foregroundActivityRef?.get()
+        val requestedBefore = activity != null && activity.getPreferences(Context.MODE_PRIVATE)
+            .getBoolean("permission_requested:$permission", false)
+        val shouldShowRationale = activity?.shouldShowRequestPermissionRationale(permission) == true
+        return when {
+            requestedBefore && !shouldShowRationale -> PermissionCapabilityState(
+                status = "permanently_denied",
+                canRequest = false,
+                requiresSettingsRedirect = true,
+            )
+            requestedBefore -> PermissionCapabilityState(
+                status = "denied",
+                canRequest = true,
+                requiresSettingsRedirect = false,
+            )
+            else -> PermissionCapabilityState(
+                status = "not_determined",
+                canRequest = true,
+                requiresSettingsRedirect = false,
+            )
+        }
+    }
+
+    private fun permissionCapabilityPayload(
+        permission: String,
+        granted: Boolean,
+        supported: Boolean = true,
+    ): JSONObject {
+        val state = permissionCapabilityState(
+            permission = permission,
+            granted = granted,
+            supported = supported,
+        )
+        return JSONObject()
+            .put("status", state.status)
+            .put("canRequest", state.canRequest)
+            .put("requiresSettingsRedirect", state.requiresSettingsRedirect)
+            .put("supported", state.supported)
+    }
+
+    private fun permissionRequestPayload(
+        permission: String,
+        previous: PermissionCapabilityState,
+        granted: Boolean,
+        supported: Boolean = true,
+    ): JSONObject {
+        val current = when {
+            !supported -> permissionCapabilityState(permission, granted = false, supported = false)
+            granted -> permissionCapabilityState(permission, granted = true, supported = true)
+            previous.canRequest && !previous.requiresSettingsRedirect -> previous
+            else -> permissionCapabilityState(permission, granted = false, supported = true)
+        }
+        return JSONObject()
+            .put("status", current.status)
+            .put("previousStatus", previous.status)
+            .put("canRequestAgain", current.canRequest)
+            .put("requiresSettingsRedirect", current.requiresSettingsRedirect)
+    }
+
+    private fun markPermissionRequested(permission: String) {
+        val activity = foregroundActivityRef?.get() ?: return
+        activity.getPreferences(Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("permission_requested:$permission", true)
+            .apply()
     }
 
     private fun vibrate(context: Context, durationMs: Long) {
@@ -839,6 +1091,7 @@ private class AndroidSensorCollector {
         if (missing.isEmpty()) {
             return true
         }
+        missing.forEach(::markPermissionRequested)
         activity.runOnUiThread {
             activity.requestPermissions(missing.toTypedArray(), REQUEST_CODE_LOCATION_WHEN_IN_USE)
         }
@@ -859,6 +1112,7 @@ private class AndroidSensorCollector {
         if (granted) {
             return true
         }
+        markPermissionRequested(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
         activity.runOnUiThread {
             activity.requestPermissions(
                 arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION),
@@ -875,6 +1129,7 @@ private class AndroidSensorCollector {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             return true
         }
+        markPermissionRequested(Manifest.permission.ACTIVITY_RECOGNITION)
         requestPermissions(arrayOf(Manifest.permission.ACTIVITY_RECOGNITION), REQUEST_CODE_MOTION)
         return false
     }
@@ -886,6 +1141,7 @@ private class AndroidSensorCollector {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             return true
         }
+        markPermissionRequested(Manifest.permission.CAMERA)
         requestPermissions(arrayOf(Manifest.permission.CAMERA), REQUEST_CODE_CAMERA)
         return false
     }
@@ -897,6 +1153,7 @@ private class AndroidSensorCollector {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             return true
         }
+        markPermissionRequested(Manifest.permission.RECORD_AUDIO)
         requestPermissions(arrayOf(Manifest.permission.RECORD_AUDIO), REQUEST_CODE_MICROPHONE)
         return false
     }
@@ -914,6 +1171,7 @@ private class AndroidSensorCollector {
             @Suppress("DEPRECATION")
             arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
         }
+        permissions.forEach(::markPermissionRequested)
         requestPermissions(permissions, REQUEST_CODE_PHOTOS)
         return false
     }
@@ -925,6 +1183,7 @@ private class AndroidSensorCollector {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             return true
         }
+        markPermissionRequested(Manifest.permission.POST_NOTIFICATIONS)
         requestPermissions(arrayOf(Manifest.permission.POST_NOTIFICATIONS), REQUEST_CODE_NOTIFICATIONS)
         return false
     }
@@ -934,6 +1193,7 @@ private class AndroidSensorCollector {
             return true
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            markPermissionRequested(Manifest.permission.BLUETOOTH_SCAN)
             requestPermissions(arrayOf(Manifest.permission.BLUETOOTH_SCAN), REQUEST_CODE_BLUETOOTH_SCAN)
             return false
         }
@@ -947,6 +1207,7 @@ private class AndroidSensorCollector {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             return true
         }
+        markPermissionRequested(Manifest.permission.BLUETOOTH_CONNECT)
         requestPermissions(
             arrayOf(Manifest.permission.BLUETOOTH_CONNECT),
             REQUEST_CODE_BLUETOOTH_CONNECT,

--- a/extensions/blinc_platform_android/templates/BlincNativeBridge.kt
+++ b/extensions/blinc_platform_android/templates/BlincNativeBridge.kt
@@ -816,6 +816,14 @@ private class AndroidSensorCollector {
         foregroundActivityRef = if (activity == null) null else WeakReference(activity)
     }
 
+    private fun markPermissionRequested(permission: String) {
+        val activity = foregroundActivityRef?.get() ?: return
+        activity.getPreferences(Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("permission_requested:$permission", true)
+            .apply()
+    }
+
     fun configure(configJson: String): Boolean {
         return runCatching {
             val root = JSONObject(configJson)
@@ -1580,6 +1588,14 @@ private class AndroidBleCollector(
 
     fun setForegroundActivity(activity: Activity?) {
         foregroundActivityRef = if (activity == null) null else WeakReference(activity)
+    }
+
+    private fun markPermissionRequested(permission: String) {
+        val activity = foregroundActivityRef?.get() ?: return
+        activity.getPreferences(Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("permission_requested:$permission", true)
+            .apply()
     }
 
     fun configure(configJson: String): Boolean {

--- a/extensions/blinc_platform_desktop/src/event_loop.rs
+++ b/extensions/blinc_platform_desktop/src/event_loop.rs
@@ -494,9 +494,10 @@ mod tests {
         let requested = ImeState {
             enabled: true,
             cursor_area: Some(ImeCursorArea::new(12.0, 24.0, 80.0, 30.0)),
+            request: None,
         };
 
-        sync_ime_window_state(&window, &mut applied, requested);
+        sync_ime_window_state(&window, &mut applied, requested.clone());
 
         assert_eq!(*window.allowed.lock().expect("allowed lock"), vec![true]);
         assert_eq!(
@@ -512,6 +513,7 @@ mod tests {
         let mut applied = ImeState {
             enabled: true,
             cursor_area: Some(ImeCursorArea::new(12.0, 24.0, 80.0, 30.0)),
+            request: None,
         };
 
         sync_ime_window_state(
@@ -520,6 +522,7 @@ mod tests {
             ImeState {
                 enabled: true,
                 cursor_area: None,
+                request: None,
             },
         );
 
@@ -536,6 +539,7 @@ mod tests {
             ImeState {
                 enabled: true,
                 cursor_area: None,
+                request: None,
             }
         );
     }
@@ -546,6 +550,7 @@ mod tests {
         let mut applied = ImeState {
             enabled: true,
             cursor_area: Some(ImeCursorArea::new(12.0, 24.0, 80.0, 30.0)),
+            request: None,
         };
 
         sync_ime_window_state(
@@ -554,6 +559,7 @@ mod tests {
             ImeState {
                 enabled: false,
                 cursor_area: None,
+                request: None,
             },
         );
         sync_ime_window_state(
@@ -562,6 +568,7 @@ mod tests {
             ImeState {
                 enabled: true,
                 cursor_area: None,
+                request: None,
             },
         );
 
@@ -578,6 +585,7 @@ mod tests {
             ImeState {
                 enabled: true,
                 cursor_area: None,
+                request: None,
             }
         );
     }

--- a/extensions/blinc_platform_ios/README.md
+++ b/extensions/blinc_platform_ios/README.md
@@ -7,6 +7,9 @@
 
 iOS platform implementation for Blinc UI.
 
+For the repo-wide native support contract, see
+[`docs/native-readiness.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/native-readiness.md).
+
 ## Overview
 
 `blinc_platform_ios` provides UIKit integration, Metal rendering, and touch input handling for iOS and iPadOS applications.
@@ -16,13 +19,23 @@ iOS platform implementation for Blinc UI.
 - iOS 14.0+
 - iPadOS 14.0+
 
+## Current Support Tier
+
+- Tier 1: partial
+- Tier 2: partial
+- Tier 3: deferred
+
+This crate currently exposes UIKit integration, rendering hooks, touch handling,
+and environment snapshot helpers. It does not yet guarantee full mobile IME,
+accessibility parity, or complete production packaging flows.
+
 ## Features
 
 - **UIKit Integration**: Native iOS view hierarchy
 - **Metal Rendering**: Hardware-accelerated graphics
 - **Touch Input**: Full multi-touch support
-- **iOS Lifecycle**: Proper app state handling
-- **Safe Area**: Automatic safe area inset handling
+- **iOS Lifecycle**: Partial runtime lifecycle wiring
+- **Safe Area**: Environment snapshot helpers for current window metrics/insets
 
 ## Quick Start
 
@@ -31,15 +44,13 @@ use blinc_platform_ios::ios_main;
 
 #[no_mangle]
 pub extern "C" fn main() {
-    ios_main(|ctx| {
-        // Build your UI
-        div()
-            .w_full()
-            .h_full()
-            .child(text("Hello iOS!"))
-    });
+    // Initializes the Rust side of the iOS platform integration.
+    ios_main();
 }
 ```
+
+Today, UI construction and lifecycle wiring are still coordinated from the host
+UIKit/Xcode application rather than a closure-based Rust entrypoint.
 
 ## Project Setup
 
@@ -94,42 +105,23 @@ fn handle_touch(event: TouchEvent) {
 }
 ```
 
-## Safe Area
+## Safe Area Snapshot
 
 ```rust
-// Get safe area insets
-let insets = ctx.safe_area_insets();
+use blinc_platform_ios::get_safe_area_insets;
 
-// Build UI respecting safe area
-div()
-    .pt(insets.top)
-    .pb(insets.bottom)
-    .pl(insets.left)
-    .pr(insets.right)
-    .child(/* content */)
+let insets = get_safe_area_insets();
+
+// Returns (top, left, bottom, right)
+let (top, left, bottom, right) = insets;
 ```
 
-## Lifecycle
+## Lifecycle Hooks
 
 ```rust
-ios_main(|ctx| {
-    // App became active
-    ctx.on_did_become_active(|| {
-        // Resume animations, etc.
-    });
-
-    // App will resign active
-    ctx.on_will_resign_active(|| {
-        // Pause animations, save state
-    });
-
-    // App entered background
-    ctx.on_did_enter_background(|| {
-        // Save data
-    });
-
-    build_ui()
-});
+// Lifecycle callbacks are currently managed by the host UIKit application.
+// Use ios_main() for Rust-side initialization, then forward lifecycle events
+// from AppDelegate / SceneDelegate into your app-specific integration layer.
 ```
 
 ## Building

--- a/extensions/blinc_platform_ios/README.md
+++ b/extensions/blinc_platform_ios/README.md
@@ -8,7 +8,7 @@
 iOS platform implementation for Blinc UI.
 
 For the repo-wide native support contract, see
-[`docs/native-readiness.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/native-readiness.md).
+[`docs/native-readiness.md`](../../docs/native-readiness.md).
 
 ## Overview
 

--- a/extensions/blinc_platform_ios/src/app.rs
+++ b/extensions/blinc_platform_ios/src/app.rs
@@ -4,12 +4,15 @@
 
 use crate::event_loop::IOSEventLoop;
 use crate::window::IOSWindow;
+use blinc_platform::{LifecycleState, PlatformEnvironmentSnapshot};
 use blinc_platform::{Platform, PlatformError};
+#[cfg(target_os = "ios")]
+use blinc_platform::{ViewportInsets, WindowMetrics};
 
 #[cfg(target_os = "ios")]
 use objc2_foundation::MainThreadMarker;
 #[cfg(target_os = "ios")]
-use objc2_ui_kit::UIScreen;
+use objc2_ui_kit::{UIApplication, UIApplicationState, UIScreen, UIUserInterfaceStyle};
 
 #[cfg(target_os = "ios")]
 use tracing::info;
@@ -33,6 +36,21 @@ impl IOSPlatform {
         let screen = UIScreen::mainScreen(mtm);
         screen.scale() as f64
     }
+}
+
+#[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+fn lifecycle_state_from_ios_raw(raw: isize) -> LifecycleState {
+    match raw {
+        0 => LifecycleState::Foreground,
+        1 => LifecycleState::Inactive,
+        2 => LifecycleState::Background,
+        _ => LifecycleState::Inactive,
+    }
+}
+
+#[cfg(target_os = "ios")]
+fn lifecycle_state_from_application_state(state: UIApplicationState) -> LifecycleState {
+    lifecycle_state_from_ios_raw(state.0)
 }
 
 impl Platform for IOSPlatform {
@@ -120,9 +138,7 @@ pub fn get_display_scale() -> f64 {
 /// Check if the system is in dark mode
 #[cfg(target_os = "ios")]
 pub fn is_dark_mode() -> bool {
-    // TODO: Implement proper dark mode detection using UITraitCollection
-    // For now, default to light mode
-    false
+    get_environment_snapshot().is_dark_mode
 }
 
 /// Placeholder for non-iOS builds
@@ -136,16 +152,66 @@ pub fn is_dark_mode() -> bool {
 /// Returns (top, left, bottom, right) insets in logical points.
 #[cfg(target_os = "ios")]
 pub fn get_safe_area_insets() -> (f32, f32, f32, f32) {
-    // Get key window's safe area insets
-    // This accounts for notch, home indicator, etc.
-    // Note: In a real implementation, you'd get this from the UIWindow
-    (0.0, 0.0, 0.0, 0.0)
+    let insets = get_environment_snapshot().safe_area_insets;
+    (insets.top, insets.left, insets.bottom, insets.right)
 }
 
 /// Placeholder for non-iOS builds
 #[cfg(not(target_os = "ios"))]
 pub fn get_safe_area_insets() -> (f32, f32, f32, f32) {
     (0.0, 0.0, 0.0, 0.0)
+}
+
+/// Capture the active iOS platform environment as a window-scoped snapshot.
+#[cfg(target_os = "ios")]
+pub fn get_environment_snapshot() -> PlatformEnvironmentSnapshot {
+    let mtm = MainThreadMarker::new().expect("Must be called from main thread");
+    let screen = UIScreen::mainScreen(mtm);
+    let scale_factor = screen.scale() as f64;
+    let bounds = screen.bounds();
+    let logical_width = bounds.size.width;
+    let logical_height = bounds.size.height;
+    let physical_width = (logical_width * scale_factor as f32).round() as u32;
+    let physical_height = (logical_height * scale_factor as f32).round() as u32;
+
+    let mut safe_area_insets = ViewportInsets::default();
+    let mut is_dark_mode = false;
+
+    let application = UIApplication::sharedApplication(mtm);
+    let lifecycle_state = lifecycle_state_from_application_state(application.applicationState());
+    if let Some(window) = application.keyWindow() {
+        let insets = window.safeAreaInsets();
+        safe_area_insets = ViewportInsets {
+            top: insets.top,
+            left: insets.left,
+            bottom: insets.bottom,
+            right: insets.right,
+        };
+
+        is_dark_mode = matches!(
+            window.traitCollection().userInterfaceStyle(),
+            UIUserInterfaceStyle::Dark
+        );
+    }
+
+    PlatformEnvironmentSnapshot {
+        lifecycle_state,
+        metrics: WindowMetrics {
+            logical_width,
+            logical_height,
+            physical_width,
+            physical_height,
+            scale_factor,
+        },
+        safe_area_insets,
+        viewport_insets: safe_area_insets,
+        is_dark_mode,
+    }
+}
+
+#[cfg(not(target_os = "ios"))]
+pub fn get_environment_snapshot() -> PlatformEnvironmentSnapshot {
+    PlatformEnvironmentSnapshot::default()
 }
 
 /// iOS system font paths
@@ -175,4 +241,17 @@ pub fn system_font_paths() -> &'static [&'static str] {
         "/System/Library/Fonts/CoreAddition/Verdana.ttf",
         "/System/Library/Fonts/CoreAddition/TimesNewRomanPS.ttf",
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_state_mapping_matches_ios_state_values() {
+        assert_eq!(lifecycle_state_from_ios_raw(0), LifecycleState::Foreground);
+        assert_eq!(lifecycle_state_from_ios_raw(1), LifecycleState::Inactive);
+        assert_eq!(lifecycle_state_from_ios_raw(2), LifecycleState::Background);
+        assert_eq!(lifecycle_state_from_ios_raw(99), LifecycleState::Inactive);
+    }
 }

--- a/extensions/blinc_platform_ios/src/app.rs
+++ b/extensions/blinc_platform_ios/src/app.rs
@@ -12,7 +12,9 @@ use blinc_platform::{ViewportInsets, WindowMetrics};
 #[cfg(target_os = "ios")]
 use objc2_foundation::MainThreadMarker;
 #[cfg(target_os = "ios")]
-use objc2_ui_kit::{UIApplication, UIApplicationState, UIScreen, UIUserInterfaceStyle};
+use objc2_ui_kit::{
+    UIApplication, UIApplicationState, UIScreen, UITraitEnvironment, UIUserInterfaceStyle,
+};
 
 #[cfg(target_os = "ios")]
 use tracing::info;
@@ -167,12 +169,12 @@ pub fn get_safe_area_insets() -> (f32, f32, f32, f32) {
 pub fn get_environment_snapshot() -> PlatformEnvironmentSnapshot {
     let mtm = MainThreadMarker::new().expect("Must be called from main thread");
     let screen = UIScreen::mainScreen(mtm);
-    let scale_factor = screen.scale() as f64;
+    let scale_factor = screen.scale() as f32;
     let bounds = screen.bounds();
-    let logical_width = bounds.size.width;
-    let logical_height = bounds.size.height;
-    let physical_width = (logical_width * scale_factor as f32).round() as u32;
-    let physical_height = (logical_height * scale_factor as f32).round() as u32;
+    let logical_width = bounds.size.width as f32;
+    let logical_height = bounds.size.height as f32;
+    let physical_width = (logical_width * scale_factor).round() as u32;
+    let physical_height = (logical_height * scale_factor).round() as u32;
 
     let mut safe_area_insets = ViewportInsets::default();
     let mut is_dark_mode = false;
@@ -182,14 +184,14 @@ pub fn get_environment_snapshot() -> PlatformEnvironmentSnapshot {
     if let Some(window) = application.keyWindow() {
         let insets = window.safeAreaInsets();
         safe_area_insets = ViewportInsets {
-            top: insets.top,
-            left: insets.left,
-            bottom: insets.bottom,
-            right: insets.right,
+            top: insets.top as f32,
+            left: insets.left as f32,
+            bottom: insets.bottom as f32,
+            right: insets.right as f32,
         };
 
         is_dark_mode = matches!(
-            window.traitCollection().userInterfaceStyle(),
+            unsafe { window.traitCollection().userInterfaceStyle() },
             UIUserInterfaceStyle::Dark
         );
     }
@@ -201,7 +203,7 @@ pub fn get_environment_snapshot() -> PlatformEnvironmentSnapshot {
             logical_height,
             physical_width,
             physical_height,
-            scale_factor,
+            scale_factor: f64::from(scale_factor),
         },
         safe_area_insets,
         viewport_insets: safe_area_insets,

--- a/extensions/blinc_platform_ios/templates/BlincNativeBridge.swift
+++ b/extensions/blinc_platform_ios/templates/BlincNativeBridge.swift
@@ -26,8 +26,17 @@ import AVFoundation
 import CoreBluetooth
 import CoreLocation
 import CoreMotion
+import Photos
+import UserNotifications
 
 public final class BlincNativeBridge {
+    private struct PermissionCapabilityState {
+        let status: String
+        let canRequest: Bool
+        let requiresSettingsRedirect: Bool
+        let supported: Bool
+    }
+
 
     public static let shared = BlincNativeBridge()
 
@@ -35,6 +44,8 @@ public final class BlincNativeBridge {
     private var handlers: [String: [String: ([Any]) throws -> Any?]] = [:]
     private let sensorCollector = IOSSensorCollector()
     private let bleCollector = IOSBleCollector()
+    private let notificationCapabilityLock = NSLock()
+    private var cachedNotificationCapability: PermissionCapabilityState?
 
     private init() {}
 
@@ -270,58 +281,96 @@ public final class BlincNativeBridge {
         // =====================================================================
 
         register(namespace: "permissions", name: "has_location") { _ in
-            self.sensorCollector.hasLocationPermission()
+            self.permissionCapabilityPayload(self.locationPermissionCapability(always: false))
         }
         register(namespace: "permissions", name: "has_location_always") { _ in
-            self.sensorCollector.hasLocationAlwaysPermission()
+            self.permissionCapabilityPayload(self.locationPermissionCapability(always: true))
         }
         register(namespace: "permissions", name: "has_motion") { _ in
-            self.sensorCollector.hasMotionPermission()
+            self.permissionCapabilityPayload(self.motionPermissionCapability())
         }
         register(namespace: "permissions", name: "has_camera") { _ in
-            false
+            self.permissionCapabilityPayload(self.cameraPermissionCapability())
         }
         register(namespace: "permissions", name: "has_microphone") { _ in
-            self.hasMicrophonePermission()
+            self.permissionCapabilityPayload(self.microphonePermissionCapability())
         }
         register(namespace: "permissions", name: "has_photos") { _ in
-            false
+            self.permissionCapabilityPayload(self.photosPermissionCapability())
         }
         register(namespace: "permissions", name: "has_notifications") { _ in
-            false
+            self.permissionCapabilityPayload(self.notificationsPermissionCapability())
         }
         register(namespace: "permissions", name: "has_bluetooth_scan") { _ in
-            self.bleCollector.hasBluetoothPermission()
+            self.permissionCapabilityPayload(self.bluetoothPermissionCapability())
         }
         register(namespace: "permissions", name: "has_bluetooth_connect") { _ in
-            self.bleCollector.hasBluetoothPermission()
+            self.permissionCapabilityPayload(self.bluetoothPermissionCapability())
         }
         register(namespace: "permissions", name: "request_location_when_in_use") { _ in
-            self.sensorCollector.requestLocationPermissionWhenInUse()
+            let previous = self.locationPermissionCapability(always: false)
+            _ = self.sensorCollector.requestLocationPermissionWhenInUse()
+            let current = self.locationPermissionCapability(always: false)
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_location_always") { _ in
-            self.sensorCollector.requestLocationPermissionAlways()
+            let previous = self.locationPermissionCapability(always: true)
+            _ = self.sensorCollector.requestLocationPermissionAlways()
+            let current = self.locationPermissionCapability(always: true)
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_motion") { _ in
-            self.sensorCollector.requestMotionPermission()
+            let previous = self.motionPermissionCapability()
+            _ = self.sensorCollector.requestMotionPermission()
+            let current = self.motionPermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_camera") { _ in
-            false
+            let previous = self.cameraPermissionCapability()
+            guard self.requestCameraPermission() != nil else {
+                return self.permissionRequestTimedOutPayload(previous: previous)
+            }
+            let current = self.cameraPermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_microphone") { _ in
-            self.requestMicrophonePermission()
+            let previous = self.microphonePermissionCapability()
+            guard self.requestMicrophonePermission() != nil else {
+                return self.permissionRequestTimedOutPayload(previous: previous)
+            }
+            let current = self.microphonePermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_photos") { _ in
-            false
+            let previous = self.photosPermissionCapability()
+            guard self.requestPhotosPermission() != nil else {
+                return self.permissionRequestTimedOutPayload(previous: previous)
+            }
+            let current = self.photosPermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_notifications") { _ in
-            false
+            let previous = self.notificationsPermissionCapability()
+            guard self.requestNotificationsPermission() != nil else {
+                return self.permissionRequestTimedOutPayload(previous: previous)
+            }
+            let current = self.notificationsPermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_bluetooth_scan") { _ in
-            self.bleCollector.requestBluetoothPermission()
+            let previous = self.bluetoothPermissionCapability()
+            _ = self.bleCollector.requestBluetoothPermission()
+            let current = self.bluetoothPermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_bluetooth_connect") { _ in
-            self.bleCollector.requestBluetoothPermission()
+            let previous = self.bluetoothPermissionCapability()
+            _ = self.bleCollector.requestBluetoothPermission()
+            let current = self.bluetoothPermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
+        }
+        register(namespace: "permissions", name: "open_settings") { _ in
+            self.openApplicationSettings()
         }
 
         // =====================================================================
@@ -399,22 +448,60 @@ public final class BlincNativeBridge {
         return permission == .granted
     }
 
-    private func requestMicrophonePermission() -> Bool {
+    private func hasCameraPermission() -> Bool {
+        AVCaptureDevice.authorizationStatus(for: .video) == .authorized
+    }
+
+    private func requestCameraPermission() -> Bool? {
+        if hasCameraPermission() {
+            return true
+        }
+        return waitForAsyncPermissionDecision { resolve in
+            AVCaptureDevice.requestAccess(for: .video) { allowed in
+                resolve(allowed)
+            }
+        }
+    }
+
+    private func requestMicrophonePermission() -> Bool? {
         if hasMicrophonePermission() {
             return true
         }
-        if Thread.isMainThread {
-            AVAudioSession.sharedInstance().requestRecordPermission { _ in }
-            return hasMicrophonePermission()
+        return waitForAsyncPermissionDecision { resolve in
+            AVAudioSession.sharedInstance().requestRecordPermission { allowed in
+                resolve(allowed)
+            }
         }
-        let semaphore = DispatchSemaphore(value: 0)
-        var granted = false
-        AVAudioSession.sharedInstance().requestRecordPermission { allowed in
-            granted = allowed
-            semaphore.signal()
+    }
+
+    private func requestPhotosPermission() -> Bool? {
+        let currentCapability = photosPermissionCapability()
+        if currentCapability.status == "granted" || currentCapability.status == "limited" {
+            return true
         }
-        _ = semaphore.wait(timeout: .now() + 2.0)
-        return granted
+        return waitForAsyncPermissionDecision { resolve in
+            if #available(iOS 14.0, *) {
+                PHPhotoLibrary.requestAuthorization(for: .readWrite) { status in
+                    resolve(status == .authorized || status == .limited)
+                }
+            } else {
+                PHPhotoLibrary.requestAuthorization { status in
+                    resolve(status == .authorized)
+                }
+            }
+        }
+    }
+
+    private func requestNotificationsPermission() -> Bool? {
+        let capability = notificationsPermissionCapability()
+        if capability.status == "granted" || capability.status == "provisional" {
+            return true
+        }
+        return waitForAsyncPermissionDecision { resolve in
+            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { allowed, _ in
+                resolve(allowed)
+            }
+        }
     }
 
     // MARK: - Helper Functions
@@ -447,6 +534,10 @@ public final class BlincNativeBridge {
             result["value"] = string
         case let data as Data:
             result["value"] = data.base64EncodedString()
+        case let dictionary as [String: Any]:
+            result["value"] = dictionary
+        case let array as [Any]:
+            result["value"] = array
         default:
             result["value"] = String(describing: value)
         }
@@ -470,6 +561,294 @@ public final class BlincNativeBridge {
             return json
         }
         return "{\"success\":false,\"errorType\":\"\(type)\",\"errorMessage\":\"\(message)\"}"
+    }
+
+    private func openApplicationSettings() -> Bool {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else {
+            return false
+        }
+        if Thread.isMainThread {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            return true
+        }
+        DispatchQueue.main.async {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+        return true
+    }
+
+    private func permissionCapabilityPayload(_ capability: PermissionCapabilityState) -> [String: Any] {
+        [
+            "status": capability.status,
+            "canRequest": capability.canRequest,
+            "requiresSettingsRedirect": capability.requiresSettingsRedirect,
+            "supported": capability.supported,
+        ]
+    }
+
+    private func permissionRequestPayload(
+        previous: PermissionCapabilityState,
+        current: PermissionCapabilityState
+    ) -> [String: Any] {
+        let effectiveCurrent: PermissionCapabilityState
+        if current.status == previous.status && previous.canRequest {
+            effectiveCurrent = previous
+        } else {
+            effectiveCurrent = current
+        }
+        [
+            "status": effectiveCurrent.status,
+            "previousStatus": previous.status,
+            "canRequestAgain": effectiveCurrent.canRequest,
+            "requiresSettingsRedirect": effectiveCurrent.requiresSettingsRedirect,
+        ]
+    }
+
+    private func permissionRequestTimedOutPayload(previous: PermissionCapabilityState) -> [String: Any] {
+        [
+            "status": "pending",
+            "previousStatus": previous.status,
+            "canRequestAgain": previous.canRequest,
+            "requiresSettingsRedirect": false,
+            "deferred": true,
+        ]
+    }
+
+    private func waitForAsyncPermissionDecision(
+        timeout: TimeInterval = 30.0,
+        work: (@escaping (Bool) -> Void) -> Void
+    ) -> Bool? {
+        let lock = NSLock()
+        var result: Bool?
+        let semaphore = DispatchSemaphore(value: 0)
+
+        let resolve: (Bool) -> Void = { value in
+            lock.lock()
+            result = value
+            lock.unlock()
+            semaphore.signal()
+        }
+
+        if Thread.isMainThread {
+            work(resolve)
+        } else {
+            DispatchQueue.main.async {
+                work(resolve)
+            }
+            _ = semaphore.wait(timeout: .now() + timeout)
+            lock.lock()
+            let current = result
+            lock.unlock()
+            if let current {
+                return current
+            }
+        }
+
+        return nil
+    }
+
+    private func waitForNotificationPermissionCapability(timeout: TimeInterval = 2.0) -> PermissionCapabilityState {
+        if Thread.isMainThread {
+            if let cached = currentCachedNotificationCapability() {
+                return cached
+            }
+            UNUserNotificationCenter.current().getNotificationSettings { settings in
+                self.storeNotificationCapability(
+                    self.notificationPermissionCapability(settings.authorizationStatus)
+                )
+            }
+            return pendingNotificationCapability()
+        }
+
+        let lock = NSLock()
+        var capability: PermissionCapabilityState?
+        let semaphore = DispatchSemaphore(value: 0)
+
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            let resolved = self.notificationPermissionCapability(settings.authorizationStatus)
+            self.storeNotificationCapability(resolved)
+            lock.lock()
+            capability = resolved
+            lock.unlock()
+            semaphore.signal()
+        }
+
+        _ = semaphore.wait(timeout: .now() + timeout)
+        lock.lock()
+        let current = capability
+        lock.unlock()
+        if let current {
+            return current
+        }
+
+        return unknownNotificationCapability()
+    }
+
+    private func currentCachedNotificationCapability() -> PermissionCapabilityState? {
+        notificationCapabilityLock.lock()
+        defer { notificationCapabilityLock.unlock() }
+        return cachedNotificationCapability
+    }
+
+    private func storeNotificationCapability(_ capability: PermissionCapabilityState) {
+        notificationCapabilityLock.lock()
+        cachedNotificationCapability = capability
+        notificationCapabilityLock.unlock()
+    }
+
+    private func unknownNotificationCapability() -> PermissionCapabilityState {
+        PermissionCapabilityState(
+            status: "unknown",
+            canRequest: false,
+            requiresSettingsRedirect: false,
+            supported: true
+        )
+    }
+
+    private func pendingNotificationCapability() -> PermissionCapabilityState {
+        PermissionCapabilityState(
+            status: "pending",
+            canRequest: false,
+            requiresSettingsRedirect: false,
+            supported: true
+        )
+    }
+
+    private func locationPermissionCapability(always: Bool) -> PermissionCapabilityState {
+        switch self.sensorCollector.locationAuthorizationStatusValue() {
+        case .authorizedAlways:
+            return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .authorizedWhenInUse:
+            if always {
+                return PermissionCapabilityState(status: "denied", canRequest: true, requiresSettingsRedirect: false, supported: true)
+            }
+            return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .denied:
+            return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .restricted:
+            return PermissionCapabilityState(status: "restricted", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .notDetermined:
+            return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+        @unknown default:
+            return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        }
+    }
+
+    private func motionPermissionCapability() -> PermissionCapabilityState {
+        if #available(iOS 11.0, *) {
+            let activity = CMMotionActivityManager.authorizationStatus()
+            let pedometer = CMPedometer.authorizationStatus()
+            if activity == .authorized || pedometer == .authorized {
+                return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+            }
+            if activity == .restricted || pedometer == .restricted {
+                return PermissionCapabilityState(status: "restricted", canRequest: false, requiresSettingsRedirect: true, supported: true)
+            }
+            if activity == .denied || pedometer == .denied {
+                return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+            }
+            return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+        }
+        return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+    }
+
+    private func microphonePermissionCapability() -> PermissionCapabilityState {
+        switch AVAudioSession.sharedInstance().recordPermission {
+        case .granted:
+            return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .denied:
+            return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .undetermined:
+            return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+        @unknown default:
+            return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        }
+    }
+
+    private func cameraPermissionCapability() -> PermissionCapabilityState {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .denied:
+            return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .restricted:
+            return PermissionCapabilityState(status: "restricted", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .notDetermined:
+            return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+        @unknown default:
+            return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        }
+    }
+
+    private func photosPermissionCapability() -> PermissionCapabilityState {
+        if #available(iOS 14.0, *) {
+            switch PHPhotoLibrary.authorizationStatus(for: .readWrite) {
+            case .authorized:
+                return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+            case .limited:
+                return PermissionCapabilityState(status: "limited", canRequest: false, requiresSettingsRedirect: false, supported: true)
+            case .denied:
+                return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+            case .restricted:
+                return PermissionCapabilityState(status: "restricted", canRequest: false, requiresSettingsRedirect: true, supported: true)
+            case .notDetermined:
+                return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+            @unknown default:
+                return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+            }
+        }
+
+        switch PHPhotoLibrary.authorizationStatus() {
+        case .authorized:
+            return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .denied:
+            return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .restricted:
+            return PermissionCapabilityState(status: "restricted", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .notDetermined:
+            return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+        case .limited:
+            return PermissionCapabilityState(status: "limited", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        @unknown default:
+            return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        }
+    }
+
+    private func notificationsPermissionCapability() -> PermissionCapabilityState {
+        waitForNotificationPermissionCapability()
+    }
+
+    private func notificationPermissionCapability(_ status: UNAuthorizationStatus) -> PermissionCapabilityState {
+        switch status {
+        case .authorized:
+            return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .provisional, .ephemeral:
+            return PermissionCapabilityState(status: "provisional", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .denied:
+            return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .notDetermined:
+            return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+        @unknown default:
+            return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        }
+    }
+
+    private func bluetoothPermissionCapability() -> PermissionCapabilityState {
+        if #available(iOS 13.0, *) {
+            switch CBManager.authorization {
+            case .allowedAlways:
+                return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+            case .denied:
+                return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+            case .restricted:
+                return PermissionCapabilityState(status: "restricted", canRequest: false, requiresSettingsRedirect: true, supported: true)
+            case .notDetermined:
+                return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+            @unknown default:
+                return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+            }
+        }
+        return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
     }
 }
 
@@ -668,12 +1047,12 @@ private final class IOSSensorCollector: NSObject, CLLocationManagerDelegate {
     }
 
     func hasLocationPermission() -> Bool {
-        let status = locationAuthorizationStatus()
+        let status = locationAuthorizationStatusValue()
         return status == .authorizedAlways || status == .authorizedWhenInUse
     }
 
     func hasLocationAlwaysPermission() -> Bool {
-        return locationAuthorizationStatus() == .authorizedAlways
+        return locationAuthorizationStatusValue() == .authorizedAlways
     }
 
     func hasMotionPermission() -> Bool {
@@ -1112,7 +1491,7 @@ private final class IOSSensorCollector: NSObject, CLLocationManagerDelegate {
         return max(parsed, minValue)
     }
 
-    private func locationAuthorizationStatus() -> CLAuthorizationStatus {
+    func locationAuthorizationStatusValue() -> CLAuthorizationStatus {
         if #available(iOS 14.0, *) {
             return locationManager.authorizationStatus
         }

--- a/extensions/blinc_platform_ios/templates/BlincNativeBridge.swift
+++ b/extensions/blinc_platform_ios/templates/BlincNativeBridge.swift
@@ -166,7 +166,19 @@ public final class BlincNativeBridge {
 
         register(namespace: "haptics", name: "impact") { args in
             if #available(iOS 10.0, *) {
-                let style: Int = args.first as? Int ?? 1
+                let style: Int
+                if let styleString = args.first as? String {
+                    switch styleString.lowercased() {
+                    case "light":
+                        style = 0
+                    case "heavy":
+                        style = 2
+                    default:
+                        style = 1
+                    }
+                } else {
+                    style = args.first as? Int ?? 1
+                }
                 let feedbackStyle: UIImpactFeedbackGenerator.FeedbackStyle
                 switch style {
                 case 0: feedbackStyle = .light

--- a/extensions/blinc_platform_ios/templates/BlincNativeBridge.swift
+++ b/extensions/blinc_platform_ios/templates/BlincNativeBridge.swift
@@ -596,7 +596,7 @@ public final class BlincNativeBridge {
         } else {
             effectiveCurrent = current
         }
-        [
+        return [
             "status": effectiveCurrent.status,
             "previousStatus": previous.status,
             "canRequestAgain": effectiveCurrent.canRequest,
@@ -605,7 +605,7 @@ public final class BlincNativeBridge {
     }
 
     private func permissionRequestTimedOutPayload(previous: PermissionCapabilityState) -> [String: Any] {
-        [
+        return [
             "status": "pending",
             "previousStatus": previous.status,
             "canRequestAgain": previous.canRequest,
@@ -616,7 +616,7 @@ public final class BlincNativeBridge {
 
     private func waitForAsyncPermissionDecision(
         timeout: TimeInterval = 30.0,
-        work: (@escaping (Bool) -> Void) -> Void
+        work: @escaping (@escaping (Bool) -> Void) -> Void
     ) -> Bool? {
         let lock = NSLock()
         var result: Bool?
@@ -631,6 +631,10 @@ public final class BlincNativeBridge {
 
         if Thread.isMainThread {
             work(resolve)
+            lock.lock()
+            let current = result
+            lock.unlock()
+            return current
         } else {
             DispatchQueue.main.async {
                 work(resolve)

--- a/mobile/example/README.md
+++ b/mobile/example/README.md
@@ -3,9 +3,9 @@
 A Blinc UI application with cross-platform support for desktop, Android, and iOS.
 This is the canonical native reference app for current mobile runtime and bridge work.
 
-See [`docs/native-readiness.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/native-readiness.md)
+See [`docs/native-readiness.md`](../../docs/native-readiness.md)
 for the repo-wide support contract and tier definitions.
-See [`docs/mobile-release.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/mobile-release.md)
+See [`docs/mobile-release.md`](../../docs/mobile-release.md)
 for the debug-vs-release packaging contract and artifact paths.
 
 ## Quick Start

--- a/mobile/example/README.md
+++ b/mobile/example/README.md
@@ -1,6 +1,12 @@
 # example
 
 A Blinc UI application with cross-platform support for desktop, Android, and iOS.
+This is the canonical native reference app for current mobile runtime and bridge work.
+
+See [`docs/native-readiness.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/native-readiness.md)
+for the repo-wide support contract and tier definitions.
+See [`docs/mobile-release.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/mobile-release.md)
+for the debug-vs-release packaging contract and artifact paths.
 
 ## Quick Start
 
@@ -13,22 +19,40 @@ cargo run --features desktop
 ### Android
 
 ```bash
-# Build + install on connected device/emulator
-./build-android.sh
+# Debug smoke: build + install on connected device/emulator
+./build-android.sh debug
+
+# Release packaging: APK
+./build-android.sh release
+
+# Release packaging: Android App Bundle
+./build-android.sh bundle-release
 ```
 
-The script requests runtime permissions needed for sensors and platform services:
+The debug script grants runtime permissions needed for sensors and platform services:
 `LOCATION`, `ACTIVITY_RECOGNITION`, `MICROPHONE`, and `BLUETOOTH` (Android 12+).
+Release artifacts are exported under `artifacts/android/`.
 
 ### iOS
 
 ```bash
-# Build Rust static libraries for device/simulator
-./build-ios.sh
+# Debug smoke: build Rust static libraries for device/simulator
+./build-ios.sh debug-libs
+
+# Release packaging: Rust static libraries
+./build-ios.sh release-libs
+
+# Release packaging: Xcode archive
+./build-ios.sh archive
+
+# Export a previously-created archive (.ipa export requires export options)
+BLINC_IOS_EXPORT_OPTIONS_PLIST=/abs/path/ExportOptions.plist ./build-ios.sh export-archive
 
 # Open Xcode project and run
 open platforms/ios/BlincApp.xcodeproj
 ```
+
+Release artifacts are exported under `artifacts/ios/`.
 
 ### Verify Mobile Builds
 
@@ -39,6 +63,13 @@ open platforms/ios/BlincApp.xcodeproj
 # Android + iOS end-to-end build verification
 ./test-mobile-builds.sh
 ```
+
+Current support tiers for this example:
+
+- Tier 1: cross-target build, native bridge sync, simulator/device debug runs
+- Tier 2: runtime feature validation for sensors, permissions, clipboard/share/haptics bridge paths
+- Packaging progress: release APK/AAB export, iOS archive/export command contract, artifact path stability
+- Deferred: store submission, notarization, and app-store-specific release automation
 
 ### Verify Runtime Sensors On Device
 

--- a/mobile/example/build-android.sh
+++ b/mobile/example/build-android.sh
@@ -1,19 +1,48 @@
 #!/bin/bash
 # Build script for Android mobile example
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# Set Java 17 for Android Gradle Plugin compatibility
-export JAVA_HOME=/opt/homebrew/opt/openjdk@17
+# Prefer caller-provided Java/Android toolchains; fall back to common local defaults.
+if [ -z "${JAVA_HOME:-}" ] && [ -d /opt/homebrew/opt/openjdk@17 ]; then
+    export JAVA_HOME=/opt/homebrew/opt/openjdk@17
+fi
 
-# Set Android SDK paths
-export ANDROID_HOME=~/Library/Android/sdk
+export ANDROID_HOME="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/Library/Android/sdk}}"
 ADB="$ANDROID_HOME/platform-tools/adb"
 PACKAGE_NAME="com.blinc.example"
 ACTIVITY_NAME=".MainActivity"
+ARTIFACT_ROOT="$SCRIPT_DIR/artifacts/android"
+DEFAULT_ABIS="${BLINC_ANDROID_ABIS:-arm64-v8a}"
+
+usage() {
+    cat <<'EOF'
+Usage: ./build-android.sh [debug|release|bundle-release]
+
+Modes:
+  debug           Build, install, and launch a debug APK on a connected device.
+  release         Build a release APK and export it under artifacts/android/release-apk/.
+  bundle-release  Build an Android App Bundle (.aab) and export it under artifacts/android/release-bundle/.
+
+Environment:
+  BLINC_ANDROID_ABIS                  Space-separated ABI list for cargo-ndk (default: "arm64-v8a")
+  BLINC_ANDROID_SKIP_INSTALL=1        Skip device install/launch even for debug builds
+  BLINC_ANDROID_KEYSTORE_PATH         Optional keystore for signed release builds
+  BLINC_ANDROID_KEYSTORE_PASSWORD     Optional keystore password
+  BLINC_ANDROID_KEY_ALIAS             Optional key alias
+  BLINC_ANDROID_KEY_PASSWORD          Optional key password
+EOF
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Missing required command: $1" >&2
+        exit 1
+    fi
+}
 
 grant_runtime_permissions() {
     local serial="$1"
@@ -21,38 +50,106 @@ grant_runtime_permissions() {
     "$ADB" -s "$serial" shell pm grant "$PACKAGE_NAME" android.permission.ACCESS_FINE_LOCATION || true
     "$ADB" -s "$serial" shell pm grant "$PACKAGE_NAME" android.permission.ACCESS_COARSE_LOCATION || true
     "$ADB" -s "$serial" shell pm grant "$PACKAGE_NAME" android.permission.ACTIVITY_RECOGNITION || true
+    "$ADB" -s "$serial" shell pm grant "$PACKAGE_NAME" android.permission.RECORD_AUDIO || true
+    "$ADB" -s "$serial" shell pm grant "$PACKAGE_NAME" android.permission.BLUETOOTH_SCAN || true
+    "$ADB" -s "$serial" shell pm grant "$PACKAGE_NAME" android.permission.BLUETOOTH_CONNECT || true
 }
 
+MODE="${1:-debug}"
+case "$MODE" in
+    debug)
+        GRADLE_TASK="assembleDebug"
+        RUST_FLAGS=""
+        OUTPUT_PATH="platforms/android/app/build/outputs/apk/debug/app-debug.apk"
+        ARTIFACT_DIR="$ARTIFACT_ROOT/debug-apk"
+        INSTALL_ON_DEVICE=1
+        ;;
+    release)
+        GRADLE_TASK="assembleRelease"
+        RUST_FLAGS="--release"
+        OUTPUT_PATH="platforms/android/app/build/outputs/apk/release/app-release.apk"
+        ARTIFACT_DIR="$ARTIFACT_ROOT/release-apk"
+        INSTALL_ON_DEVICE=0
+        ;;
+    bundle-release)
+        GRADLE_TASK="bundleRelease"
+        RUST_FLAGS="--release"
+        OUTPUT_PATH="platforms/android/app/build/outputs/bundle/release/app-release.aab"
+        ARTIFACT_DIR="$ARTIFACT_ROOT/release-bundle"
+        INSTALL_ON_DEVICE=0
+        ;;
+    -h|--help|help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown mode: $MODE" >&2
+        usage
+        exit 1
+        ;;
+esac
+
+if [ "${BLINC_ANDROID_SKIP_INSTALL:-0}" = "1" ]; then
+    INSTALL_ON_DEVICE=0
+fi
+
+require_command cargo
+require_command cargo-ndk
+require_command ./platforms/android/gradlew
+
+mkdir -p "$ARTIFACT_DIR"
+
+if [ -n "${BLINC_ANDROID_KEYSTORE_PATH:-}" ]; then
+    export BLINC_ANDROID_KEYSTORE_PATH
+    export BLINC_ANDROID_KEYSTORE_PASSWORD="${BLINC_ANDROID_KEYSTORE_PASSWORD:-}"
+    export BLINC_ANDROID_KEY_ALIAS="${BLINC_ANDROID_KEY_ALIAS:-}"
+    export BLINC_ANDROID_KEY_PASSWORD="${BLINC_ANDROID_KEY_PASSWORD:-}"
+    echo "Configured Android signing inputs from BLINC_ANDROID_* environment variables."
+fi
+
 # Step 1: Build Rust library for Android
-echo "Building Rust library for arm64-v8a..."
-cargo ndk -t arm64-v8a -o platforms/android/app/src/main/jniLibs build --release
+echo "Building Rust library for Android ABIs: ${DEFAULT_ABIS} (${MODE})..."
+ABI_ARGS=()
+for abi in $DEFAULT_ABIS; do
+    ABI_ARGS+=("-t" "$abi")
+done
+cargo ndk "${ABI_ARGS[@]}" -o platforms/android/app/src/main/jniLibs build $RUST_FLAGS
 
-# Step 2: Build APK
-echo "Building APK..."
+# Step 2: Build Gradle artifact
+echo "Building APK via ${GRADLE_TASK}..."
 cd platforms/android
-./gradlew assembleDebug
+./gradlew "${GRADLE_TASK}"
+cd "$SCRIPT_DIR"
 
-# Step 3: Install APK (if device connected)
-DEVICE_SERIAL="$($ADB devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
-if [ -n "$DEVICE_SERIAL" ]; then
-    echo "Installing APK..."
-    $ADB -s "$DEVICE_SERIAL" install -r app/build/outputs/apk/debug/app-debug.apk
-    grant_runtime_permissions "$DEVICE_SERIAL"
+if [ ! -f "$OUTPUT_PATH" ]; then
+    echo "Expected Android artifact was not produced: $OUTPUT_PATH" >&2
+    exit 1
+fi
 
-    # Step 4: Start the app
-    echo "Starting app..."
-    $ADB -s "$DEVICE_SERIAL" shell am start -n "${PACKAGE_NAME}/${ACTIVITY_NAME}"
+cp "$OUTPUT_PATH" "$ARTIFACT_DIR/"
+echo "Exported Android artifact:"
+echo "  $ARTIFACT_DIR/$(basename "$OUTPUT_PATH")"
 
-    # Step 5: Show logs
-    echo "Showing logs (Ctrl+C to exit)..."
-    $ADB -s "$DEVICE_SERIAL" logcat -c  # Clear old logs
-    $ADB -s "$DEVICE_SERIAL" logcat | grep --line-buffered -E "Sensor permissions requested|Supported mobile sensors|Sensor batch #|Mobile sensors started|Mobile sensors stopped|Blinc|RustStdoutStderr"
-else
-    echo "No device connected. APK is at:"
-    echo "  platforms/android/app/build/outputs/apk/debug/app-debug.apk"
-    echo ""
-    echo "Tips:"
-    echo "  1. Enable USB debugging on the Android phone."
-    echo "  2. Accept the host RSA prompt on the device."
-    echo "  3. Verify with: $ADB devices -l"
+# Step 3: Install APK (debug only)
+if [ "$INSTALL_ON_DEVICE" -eq 1 ]; then
+    DEVICE_SERIAL="$($ADB devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
+    if [ -n "$DEVICE_SERIAL" ]; then
+        echo "Installing APK..."
+        "$ADB" -s "$DEVICE_SERIAL" install -r "$OUTPUT_PATH"
+        grant_runtime_permissions "$DEVICE_SERIAL"
+
+        echo "Starting app..."
+        "$ADB" -s "$DEVICE_SERIAL" shell am start -n "${PACKAGE_NAME}/${ACTIVITY_NAME}"
+
+        echo "Showing logs (Ctrl+C to exit)..."
+        "$ADB" -s "$DEVICE_SERIAL" logcat -c
+        "$ADB" -s "$DEVICE_SERIAL" logcat | grep --line-buffered -E "Sensor permissions requested|Supported mobile sensors|Sensor batch #|Mobile sensors started|Mobile sensors stopped|Blinc|RustStdoutStderr"
+    else
+        echo "No device connected. Debug APK is at:"
+        echo "  $ARTIFACT_DIR/$(basename "$OUTPUT_PATH")"
+        echo "Verify with: $ADB devices -l"
+    fi
+elif [ "$MODE" = "release" ] || [ "$MODE" = "bundle-release" ]; then
+    echo "Release packaging finished."
+    echo "If signing is required, provide BLINC_ANDROID_KEYSTORE_* inputs before distribution."
 fi

--- a/mobile/example/build-android.sh
+++ b/mobile/example/build-android.sh
@@ -62,13 +62,16 @@ case "$MODE" in
         RUST_FLAGS=""
         OUTPUT_PATH="platforms/android/app/build/outputs/apk/debug/app-debug.apk"
         ARTIFACT_DIR="$ARTIFACT_ROOT/debug-apk"
+        ARTIFACT_NAME="app-debug.apk"
         INSTALL_ON_DEVICE=1
         ;;
     release)
         GRADLE_TASK="assembleRelease"
         RUST_FLAGS="--release"
         OUTPUT_PATH="platforms/android/app/build/outputs/apk/release/app-release.apk"
+        FALLBACK_OUTPUT_PATH="platforms/android/app/build/outputs/apk/release/app-release-unsigned.apk"
         ARTIFACT_DIR="$ARTIFACT_ROOT/release-apk"
+        ARTIFACT_NAME="app-release.apk"
         INSTALL_ON_DEVICE=0
         ;;
     bundle-release)
@@ -76,6 +79,7 @@ case "$MODE" in
         RUST_FLAGS="--release"
         OUTPUT_PATH="platforms/android/app/build/outputs/bundle/release/app-release.aab"
         ARTIFACT_DIR="$ARTIFACT_ROOT/release-bundle"
+        ARTIFACT_NAME="app-release.aab"
         INSTALL_ON_DEVICE=0
         ;;
     -h|--help|help)
@@ -121,14 +125,18 @@ cd platforms/android
 ./gradlew "${GRADLE_TASK}"
 cd "$SCRIPT_DIR"
 
+if [ ! -f "$OUTPUT_PATH" ] && [ -n "${FALLBACK_OUTPUT_PATH:-}" ] && [ -f "$FALLBACK_OUTPUT_PATH" ]; then
+    OUTPUT_PATH="$FALLBACK_OUTPUT_PATH"
+fi
+
 if [ ! -f "$OUTPUT_PATH" ]; then
     echo "Expected Android artifact was not produced: $OUTPUT_PATH" >&2
     exit 1
 fi
 
-cp "$OUTPUT_PATH" "$ARTIFACT_DIR/"
+cp "$OUTPUT_PATH" "$ARTIFACT_DIR/$ARTIFACT_NAME"
 echo "Exported Android artifact:"
-echo "  $ARTIFACT_DIR/$(basename "$OUTPUT_PATH")"
+echo "  $ARTIFACT_DIR/$ARTIFACT_NAME"
 
 # Step 3: Install APK (debug only)
 if [ "$INSTALL_ON_DEVICE" -eq 1 ]; then

--- a/mobile/example/build-ios.sh
+++ b/mobile/example/build-ios.sh
@@ -11,6 +11,7 @@ PROJECT_NAME="BlincApp"
 BUNDLE_ID="com.blinc.example"
 LIB_NAME="libexample.a"
 PROJECT_PATH="$SCRIPT_DIR/platforms/ios/${PROJECT_NAME}.xcodeproj"
+PROJECT_LIB_ROOT="$SCRIPT_DIR/platforms/ios/libs"
 SCHEME_NAME="${BLINC_IOS_SCHEME:-$PROJECT_NAME}"
 ARTIFACT_ROOT="$SCRIPT_DIR/artifacts/ios"
 ARCHIVE_PATH_DEFAULT="$ARTIFACT_ROOT/archive/${PROJECT_NAME}.xcarchive"
@@ -98,6 +99,8 @@ build_rust_libraries() {
 
     mkdir -p "$LIBS_DIR/device"
     mkdir -p "$LIBS_DIR/simulator"
+    mkdir -p "$PROJECT_LIB_ROOT/device"
+    mkdir -p "$PROJECT_LIB_ROOT/simulator"
 
     echo "Copying libraries..."
     cp "target/$TARGET_ARM64/$TARGET_DIR/$LIB_NAME" "$LIBS_DIR/device/"
@@ -110,6 +113,10 @@ build_rust_libraries() {
         "$LIBS_DIR/simulator/$LIB_NAME.x86_64" \
         -output "$LIBS_DIR/simulator/$LIB_NAME"
     rm -f "$LIBS_DIR/simulator/$LIB_NAME.arm64" "$LIBS_DIR/simulator/$LIB_NAME.x86_64"
+
+    # Keep the Xcode project link paths populated for archive/export commands.
+    cp "$LIBS_DIR/device/$LIB_NAME" "$PROJECT_LIB_ROOT/device/$LIB_NAME"
+    cp "$LIBS_DIR/simulator/$LIB_NAME" "$PROJECT_LIB_ROOT/simulator/$LIB_NAME"
 
     echo ""
     echo "Libraries are at:"

--- a/mobile/example/build-ios.sh
+++ b/mobile/example/build-ios.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Build script for iOS mobile example
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
@@ -10,24 +10,61 @@ cd "$SCRIPT_DIR"
 PROJECT_NAME="BlincApp"
 BUNDLE_ID="com.blinc.example"
 LIB_NAME="libexample.a"
+PROJECT_PATH="$SCRIPT_DIR/platforms/ios/${PROJECT_NAME}.xcodeproj"
+SCHEME_NAME="${BLINC_IOS_SCHEME:-$PROJECT_NAME}"
+ARTIFACT_ROOT="$SCRIPT_DIR/artifacts/ios"
+ARCHIVE_PATH_DEFAULT="$ARTIFACT_ROOT/archive/${PROJECT_NAME}.xcarchive"
+EXPORT_PATH_DEFAULT="$ARTIFACT_ROOT/export"
 
 # iOS targets
 TARGET_ARM64="aarch64-apple-ios"
 TARGET_SIM_ARM64="aarch64-apple-ios-sim"
 TARGET_SIM_X86="x86_64-apple-ios"
 
-# Detect build mode
-BUILD_MODE="${1:-debug}"
-CARGO_FLAGS=""
-TARGET_DIR="debug"
+usage() {
+    cat <<'EOF'
+Usage: ./build-ios.sh [debug-libs|release-libs|archive|export-archive]
 
-if [ "$BUILD_MODE" = "release" ]; then
-    CARGO_FLAGS="--release"
-    TARGET_DIR="release"
-    echo "Building in RELEASE mode..."
-else
-    echo "Building in DEBUG mode..."
-fi
+Modes:
+  debug-libs      Build Rust iOS static libraries for local debug runs.
+  release-libs    Build Rust iOS static libraries for release packaging.
+  archive         Build release Rust libs, then run xcodebuild archive.
+  export-archive  Export an existing archive to an .ipa or xcarchive export directory.
+
+Environment:
+  BLINC_IOS_SCHEME                  Xcode scheme (default: BlincApp)
+  BLINC_IOS_CONFIGURATION           Xcode configuration (default: Release)
+  BLINC_IOS_DESTINATION             Xcode destination (default: generic/platform=iOS)
+  BLINC_IOS_ARCHIVE_PATH            Archive output path (default: artifacts/ios/archive/BlincApp.xcarchive)
+  BLINC_IOS_EXPORT_PATH             Export output path (default: artifacts/ios/export)
+  BLINC_IOS_EXPORT_OPTIONS_PLIST    Required for export-archive
+  BLINC_IOS_TEAM_ID                 Optional development team
+  BLINC_IOS_CODE_SIGNING_ALLOWED    YES/NO; default NO for archive automation
+EOF
+}
+
+MODE="${1:-debug-libs}"
+case "$MODE" in
+    debug-libs)
+        CARGO_FLAGS=""
+        TARGET_DIR="debug"
+        LIBS_DIR="$ARTIFACT_ROOT/libs/debug"
+        ;;
+    release-libs|archive|export-archive)
+        CARGO_FLAGS="--release"
+        TARGET_DIR="release"
+        LIBS_DIR="$ARTIFACT_ROOT/libs/release"
+        ;;
+    -h|--help|help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown mode: $MODE" >&2
+        usage
+        exit 1
+        ;;
+esac
 
 # Ensure iOS targets are installed
 echo "Checking Rust iOS targets..."
@@ -45,50 +82,122 @@ if ! rustup target list --installed | grep -q "$TARGET_SIM_X86"; then
     rustup target add "$TARGET_SIM_X86"
 fi
 
-# Step 1: Build Rust static library
-echo ""
-echo "=== Building Rust static library ==="
-cd "$SCRIPT_DIR"
+build_rust_libraries() {
+    echo ""
+    echo "=== Building Rust static library (${MODE}) ==="
+    cd "$SCRIPT_DIR"
 
-# Build for device (arm64)
-echo "Building for device ($TARGET_ARM64)..."
-cargo build --lib --features ios $CARGO_FLAGS --target "$TARGET_ARM64"
+    echo "Building for device ($TARGET_ARM64)..."
+    cargo build --lib --features ios $CARGO_FLAGS --target "$TARGET_ARM64"
 
-# Build for simulator (arm64 for Apple Silicon Macs)
-echo "Building for simulator ($TARGET_SIM_ARM64)..."
-cargo build --lib --features ios $CARGO_FLAGS --target "$TARGET_SIM_ARM64"
+    echo "Building for simulator ($TARGET_SIM_ARM64)..."
+    cargo build --lib --features ios $CARGO_FLAGS --target "$TARGET_SIM_ARM64"
 
-# Build for simulator (x86_64 for Intel Macs / CI)
-echo "Building for simulator ($TARGET_SIM_X86)..."
-cargo build --lib --features ios $CARGO_FLAGS --target "$TARGET_SIM_X86"
+    echo "Building for simulator ($TARGET_SIM_X86)..."
+    cargo build --lib --features ios $CARGO_FLAGS --target "$TARGET_SIM_X86"
 
-# Copy libraries to iOS project
-LIBS_DIR="$SCRIPT_DIR/platforms/ios/libs"
-mkdir -p "$LIBS_DIR/device"
-mkdir -p "$LIBS_DIR/simulator"
+    mkdir -p "$LIBS_DIR/device"
+    mkdir -p "$LIBS_DIR/simulator"
 
-echo "Copying libraries..."
-cp "target/$TARGET_ARM64/$TARGET_DIR/$LIB_NAME" "$LIBS_DIR/device/"
-cp "target/$TARGET_SIM_ARM64/$TARGET_DIR/$LIB_NAME" "$LIBS_DIR/simulator/$LIB_NAME.arm64"
-cp "target/$TARGET_SIM_X86/$TARGET_DIR/$LIB_NAME" "$LIBS_DIR/simulator/$LIB_NAME.x86_64"
+    echo "Copying libraries..."
+    cp "target/$TARGET_ARM64/$TARGET_DIR/$LIB_NAME" "$LIBS_DIR/device/"
+    cp "target/$TARGET_SIM_ARM64/$TARGET_DIR/$LIB_NAME" "$LIBS_DIR/simulator/$LIB_NAME.arm64"
+    cp "target/$TARGET_SIM_X86/$TARGET_DIR/$LIB_NAME" "$LIBS_DIR/simulator/$LIB_NAME.x86_64"
 
-# Create universal library for simulator (arm64 + x86_64)
-echo "Creating universal simulator library..."
-lipo -create \
-    "$LIBS_DIR/simulator/$LIB_NAME.arm64" \
-    "$LIBS_DIR/simulator/$LIB_NAME.x86_64" \
-    -output "$LIBS_DIR/simulator/$LIB_NAME"
-rm -f "$LIBS_DIR/simulator/$LIB_NAME.arm64" "$LIBS_DIR/simulator/$LIB_NAME.x86_64"
+    echo "Creating universal simulator library..."
+    lipo -create \
+        "$LIBS_DIR/simulator/$LIB_NAME.arm64" \
+        "$LIBS_DIR/simulator/$LIB_NAME.x86_64" \
+        -output "$LIBS_DIR/simulator/$LIB_NAME"
+    rm -f "$LIBS_DIR/simulator/$LIB_NAME.arm64" "$LIBS_DIR/simulator/$LIB_NAME.x86_64"
 
-echo ""
-echo "=== Build complete ==="
-echo ""
-echo "Libraries are at:"
-echo "  Device:    $LIBS_DIR/device/$LIB_NAME"
-echo "  Simulator: $LIBS_DIR/simulator/$LIB_NAME"
-echo ""
-echo "Next steps:"
-echo "  1. Open platforms/ios/$PROJECT_NAME.xcodeproj in Xcode"
-echo "  2. Select your target device/simulator"
-echo "  3. Build and run (Cmd+R)"
-echo ""
+    echo ""
+    echo "Libraries are at:"
+    echo "  Device:    $LIBS_DIR/device/$LIB_NAME"
+    echo "  Simulator: $LIBS_DIR/simulator/$LIB_NAME"
+}
+
+archive_app() {
+    local configuration="${BLINC_IOS_CONFIGURATION:-Release}"
+    local destination="${BLINC_IOS_DESTINATION:-generic/platform=iOS}"
+    local archive_path="${BLINC_IOS_ARCHIVE_PATH:-$ARCHIVE_PATH_DEFAULT}"
+    local code_signing_allowed="${BLINC_IOS_CODE_SIGNING_ALLOWED:-NO}"
+
+    if [ ! -d "$PROJECT_PATH" ]; then
+        echo "Missing iOS Xcode project: $PROJECT_PATH" >&2
+        exit 1
+    fi
+    if ! command -v xcodebuild >/dev/null 2>&1; then
+        echo "xcodebuild is required for archive mode." >&2
+        exit 1
+    fi
+
+    mkdir -p "$(dirname "$archive_path")"
+    build_rust_libraries
+
+    echo ""
+    echo "=== Archiving iOS app ==="
+    XCODE_ARGS=(
+        -project "$PROJECT_PATH"
+        -scheme "$SCHEME_NAME"
+        -configuration "$configuration"
+        -destination "$destination"
+        -archivePath "$archive_path"
+        archive
+        CODE_SIGNING_ALLOWED="$code_signing_allowed"
+    )
+    if [ -n "${BLINC_IOS_TEAM_ID:-}" ]; then
+        XCODE_ARGS+=("DEVELOPMENT_TEAM=${BLINC_IOS_TEAM_ID}")
+    fi
+    xcodebuild "${XCODE_ARGS[@]}"
+
+    echo "Archive exported to:"
+    echo "  $archive_path"
+}
+
+export_archive() {
+    local archive_path="${BLINC_IOS_ARCHIVE_PATH:-$ARCHIVE_PATH_DEFAULT}"
+    local export_path="${BLINC_IOS_EXPORT_PATH:-$EXPORT_PATH_DEFAULT}"
+    local export_options_plist="${BLINC_IOS_EXPORT_OPTIONS_PLIST:-}"
+
+    if [ -z "$export_options_plist" ]; then
+        echo "BLINC_IOS_EXPORT_OPTIONS_PLIST is required for export-archive." >&2
+        exit 1
+    fi
+    if [ ! -d "$archive_path" ]; then
+        echo "Archive does not exist: $archive_path" >&2
+        exit 1
+    fi
+    if ! command -v xcodebuild >/dev/null 2>&1; then
+        echo "xcodebuild is required for export-archive mode." >&2
+        exit 1
+    fi
+
+    mkdir -p "$export_path"
+    echo ""
+    echo "=== Exporting iOS archive ==="
+    xcodebuild -exportArchive \
+        -archivePath "$archive_path" \
+        -exportPath "$export_path" \
+        -exportOptionsPlist "$export_options_plist"
+
+    echo "Exported iOS artifacts to:"
+    echo "  $export_path"
+}
+
+case "$MODE" in
+    debug-libs|release-libs)
+        build_rust_libraries
+        echo ""
+        echo "Next steps:"
+        echo "  1. Open platforms/ios/$PROJECT_NAME.xcodeproj in Xcode"
+        echo "  2. Select your target device/simulator"
+        echo "  3. Build and run (Cmd+R)"
+        ;;
+    archive)
+        archive_app
+        ;;
+    export-archive)
+        export_archive
+        ;;
+esac

--- a/mobile/example/platforms/android/app/src/main/kotlin/com/blinc/BlincNativeBridge.kt
+++ b/mobile/example/platforms/android/app/src/main/kotlin/com/blinc/BlincNativeBridge.kt
@@ -210,7 +210,16 @@ object BlincNativeBridge {
         }
 
         register("haptics", "impact") { args ->
-            val style = args.optInt(0, 1)
+            val style = when {
+                !args.isNull(0) && args.optString(0).isNotEmpty() -> {
+                    when (args.optString(0, "medium").lowercase()) {
+                        "light" -> 0
+                        "heavy" -> 2
+                        else -> 1
+                    }
+                }
+                else -> args.optInt(0, 1)
+            }
             val amplitude = when (style) {
                 0 -> 50   // light
                 2 -> 255  // heavy

--- a/mobile/example/platforms/android/app/src/main/kotlin/com/blinc/BlincNativeBridge.kt
+++ b/mobile/example/platforms/android/app/src/main/kotlin/com/blinc/BlincNativeBridge.kt
@@ -60,6 +60,13 @@ import java.util.TimeZone
 import java.lang.ref.WeakReference
 
 object BlincNativeBridge {
+    private data class PermissionCapabilityState(
+        val status: String,
+        val canRequest: Boolean,
+        val requiresSettingsRedirect: Boolean,
+        val supported: Boolean = true,
+    )
+
 
     // Handler type: (args: JSONArray) -> Any?
     private val handlers = mutableMapOf<String, MutableMap<String, (JSONArray) -> Any?>>()
@@ -317,58 +324,196 @@ object BlincNativeBridge {
         // =====================================================================
 
         register("permissions", "has_location") {
-            sensorCollector.hasLocationPermission()
+            val granted = sensorCollector.hasLocationPermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                granted = granted,
+            )
         }
         register("permissions", "has_location_always") {
-            sensorCollector.hasLocationAlwaysPermission()
+            val granted = sensorCollector.hasLocationAlwaysPermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+                granted = granted,
+            )
         }
         register("permissions", "has_motion") {
-            sensorCollector.hasMotionPermission()
+            val granted = sensorCollector.hasMotionPermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.ACTIVITY_RECOGNITION,
+                granted = granted,
+            )
         }
         register("permissions", "has_camera") {
-            sensorCollector.hasCameraPermission()
+            val granted = sensorCollector.hasCameraPermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.CAMERA,
+                granted = granted,
+            )
         }
         register("permissions", "has_microphone") {
-            sensorCollector.hasMicrophonePermission()
+            val granted = sensorCollector.hasMicrophonePermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.RECORD_AUDIO,
+                granted = granted,
+            )
         }
         register("permissions", "has_photos") {
-            sensorCollector.hasPhotosPermission()
+            val granted = sensorCollector.hasPhotosPermission()
+            permissionCapabilityPayload(
+                permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    Manifest.permission.READ_MEDIA_IMAGES
+                } else {
+                    Manifest.permission.READ_EXTERNAL_STORAGE
+                },
+                granted = granted,
+            )
         }
         register("permissions", "has_notifications") {
-            sensorCollector.hasNotificationsPermission()
+            val granted = sensorCollector.hasNotificationsPermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.POST_NOTIFICATIONS,
+                granted = granted,
+            )
         }
         register("permissions", "has_bluetooth_scan") {
-            sensorCollector.hasBluetoothScanPermission()
+            val granted = sensorCollector.hasBluetoothScanPermission()
+            permissionCapabilityPayload(
+                permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    Manifest.permission.BLUETOOTH_SCAN
+                } else {
+                    Manifest.permission.ACCESS_FINE_LOCATION
+                },
+                granted = granted,
+            )
         }
         register("permissions", "has_bluetooth_connect") {
-            sensorCollector.hasBluetoothConnectPermission()
+            val granted = sensorCollector.hasBluetoothConnectPermission()
+            permissionCapabilityPayload(
+                permission = Manifest.permission.BLUETOOTH_CONNECT,
+                granted = granted,
+            )
         }
         register("permissions", "request_location_when_in_use") {
-            sensorCollector.requestLocationPermissionWhenInUse()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                granted = sensorCollector.hasLocationPermission(),
+            )
+            val granted = sensorCollector.requestLocationPermissionWhenInUse()
+            permissionRequestPayload(
+                permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_location_always") {
-            sensorCollector.requestLocationPermissionAlways()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+                granted = sensorCollector.hasLocationAlwaysPermission(),
+            )
+            val granted = sensorCollector.requestLocationPermissionAlways()
+            permissionRequestPayload(
+                permission = Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_motion") {
-            sensorCollector.requestMotionPermission()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.ACTIVITY_RECOGNITION,
+                granted = sensorCollector.hasMotionPermission(),
+            )
+            val granted = sensorCollector.requestMotionPermission()
+            permissionRequestPayload(
+                permission = Manifest.permission.ACTIVITY_RECOGNITION,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_camera") {
-            sensorCollector.requestCameraPermission()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.CAMERA,
+                granted = sensorCollector.hasCameraPermission(),
+            )
+            val granted = sensorCollector.requestCameraPermission()
+            permissionRequestPayload(
+                permission = Manifest.permission.CAMERA,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_microphone") {
-            sensorCollector.requestMicrophonePermission()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.RECORD_AUDIO,
+                granted = sensorCollector.hasMicrophonePermission(),
+            )
+            val granted = sensorCollector.requestMicrophonePermission()
+            permissionRequestPayload(
+                permission = Manifest.permission.RECORD_AUDIO,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_photos") {
-            sensorCollector.requestPhotosPermission()
+            val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                Manifest.permission.READ_MEDIA_IMAGES
+            } else {
+                Manifest.permission.READ_EXTERNAL_STORAGE
+            }
+            val previous = permissionCapabilityState(
+                permission = permission,
+                granted = sensorCollector.hasPhotosPermission(),
+            )
+            val granted = sensorCollector.requestPhotosPermission()
+            permissionRequestPayload(
+                permission = permission,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_notifications") {
-            sensorCollector.requestNotificationsPermission()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.POST_NOTIFICATIONS,
+                granted = sensorCollector.hasNotificationsPermission(),
+            )
+            val granted = sensorCollector.requestNotificationsPermission()
+            permissionRequestPayload(
+                permission = Manifest.permission.POST_NOTIFICATIONS,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_bluetooth_scan") {
-            sensorCollector.requestBluetoothScanPermission()
+            val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                Manifest.permission.BLUETOOTH_SCAN
+            } else {
+                Manifest.permission.ACCESS_FINE_LOCATION
+            }
+            val previous = permissionCapabilityState(
+                permission = permission,
+                granted = sensorCollector.hasBluetoothScanPermission(),
+            )
+            val granted = sensorCollector.requestBluetoothScanPermission()
+            permissionRequestPayload(
+                permission = permission,
+                previous = previous,
+                granted = granted,
+            )
         }
         register("permissions", "request_bluetooth_connect") {
-            sensorCollector.requestBluetoothConnectPermission()
+            val previous = permissionCapabilityState(
+                permission = Manifest.permission.BLUETOOTH_CONNECT,
+                granted = sensorCollector.hasBluetoothConnectPermission(),
+            )
+            val granted = sensorCollector.requestBluetoothConnectPermission()
+            permissionRequestPayload(
+                permission = Manifest.permission.BLUETOOTH_CONNECT,
+                previous = previous,
+                granted = granted,
+            )
+        }
+        register("permissions", "open_settings") {
+            openApplicationSettings()
         }
 
         // =====================================================================
@@ -451,6 +596,8 @@ object BlincNativeBridge {
             is Long -> obj.put("value", value)
             is Float -> obj.put("value", value)
             is Double -> obj.put("value", value)
+            is JSONObject -> obj.put("value", value)
+            is JSONArray -> obj.put("value", value)
             is ByteArray -> obj.put("value", android.util.Base64.encodeToString(value, android.util.Base64.NO_WRAP))
             else -> obj.put("value", value.toString())
         }
@@ -463,6 +610,111 @@ object BlincNativeBridge {
         obj.put("errorType", type)
         obj.put("errorMessage", message)
         return obj.toString()
+    }
+
+    private fun openApplicationSettings(): Boolean {
+        val activity = foregroundActivityRef?.get() ?: return false
+        val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", activity.packageName, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        activity.startActivity(intent)
+        return true
+    }
+
+    private fun permissionCapabilityState(
+        permission: String,
+        granted: Boolean,
+        supported: Boolean = true,
+    ): PermissionCapabilityState {
+        if (!supported) {
+            return PermissionCapabilityState(
+                status = "unknown",
+                canRequest = false,
+                requiresSettingsRedirect = false,
+                supported = false,
+            )
+        }
+        if (granted) {
+            return PermissionCapabilityState(
+                status = "granted",
+                canRequest = false,
+                requiresSettingsRedirect = false,
+            )
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return PermissionCapabilityState(
+                status = "granted",
+                canRequest = false,
+                requiresSettingsRedirect = false,
+            )
+        }
+
+        val activity = foregroundActivityRef?.get()
+        val requestedBefore = activity != null && activity.getPreferences(Context.MODE_PRIVATE)
+            .getBoolean("permission_requested:$permission", false)
+        val shouldShowRationale = activity?.shouldShowRequestPermissionRationale(permission) == true
+        return when {
+            requestedBefore && !shouldShowRationale -> PermissionCapabilityState(
+                status = "permanently_denied",
+                canRequest = false,
+                requiresSettingsRedirect = true,
+            )
+            requestedBefore -> PermissionCapabilityState(
+                status = "denied",
+                canRequest = true,
+                requiresSettingsRedirect = false,
+            )
+            else -> PermissionCapabilityState(
+                status = "not_determined",
+                canRequest = true,
+                requiresSettingsRedirect = false,
+            )
+        }
+    }
+
+    private fun permissionCapabilityPayload(
+        permission: String,
+        granted: Boolean,
+        supported: Boolean = true,
+    ): JSONObject {
+        val state = permissionCapabilityState(
+            permission = permission,
+            granted = granted,
+            supported = supported,
+        )
+        return JSONObject()
+            .put("status", state.status)
+            .put("canRequest", state.canRequest)
+            .put("requiresSettingsRedirect", state.requiresSettingsRedirect)
+            .put("supported", state.supported)
+    }
+
+    private fun permissionRequestPayload(
+        permission: String,
+        previous: PermissionCapabilityState,
+        granted: Boolean,
+        supported: Boolean = true,
+    ): JSONObject {
+        val current = when {
+            !supported -> permissionCapabilityState(permission, granted = false, supported = false)
+            granted -> permissionCapabilityState(permission, granted = true, supported = true)
+            previous.canRequest && !previous.requiresSettingsRedirect -> previous
+            else -> permissionCapabilityState(permission, granted = false, supported = true)
+        }
+        return JSONObject()
+            .put("status", current.status)
+            .put("previousStatus", previous.status)
+            .put("canRequestAgain", current.canRequest)
+            .put("requiresSettingsRedirect", current.requiresSettingsRedirect)
+    }
+
+    private fun markPermissionRequested(permission: String) {
+        val activity = foregroundActivityRef?.get() ?: return
+        activity.getPreferences(Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("permission_requested:$permission", true)
+            .apply()
     }
 
     private fun vibrate(context: Context, durationMs: Long) {
@@ -839,6 +1091,7 @@ private class AndroidSensorCollector {
         if (missing.isEmpty()) {
             return true
         }
+        missing.forEach(::markPermissionRequested)
         activity.runOnUiThread {
             activity.requestPermissions(missing.toTypedArray(), REQUEST_CODE_LOCATION_WHEN_IN_USE)
         }
@@ -859,6 +1112,7 @@ private class AndroidSensorCollector {
         if (granted) {
             return true
         }
+        markPermissionRequested(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
         activity.runOnUiThread {
             activity.requestPermissions(
                 arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION),
@@ -875,6 +1129,7 @@ private class AndroidSensorCollector {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             return true
         }
+        markPermissionRequested(Manifest.permission.ACTIVITY_RECOGNITION)
         requestPermissions(arrayOf(Manifest.permission.ACTIVITY_RECOGNITION), REQUEST_CODE_MOTION)
         return false
     }
@@ -886,6 +1141,7 @@ private class AndroidSensorCollector {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             return true
         }
+        markPermissionRequested(Manifest.permission.CAMERA)
         requestPermissions(arrayOf(Manifest.permission.CAMERA), REQUEST_CODE_CAMERA)
         return false
     }
@@ -897,6 +1153,7 @@ private class AndroidSensorCollector {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             return true
         }
+        markPermissionRequested(Manifest.permission.RECORD_AUDIO)
         requestPermissions(arrayOf(Manifest.permission.RECORD_AUDIO), REQUEST_CODE_MICROPHONE)
         return false
     }
@@ -914,6 +1171,7 @@ private class AndroidSensorCollector {
             @Suppress("DEPRECATION")
             arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
         }
+        permissions.forEach(::markPermissionRequested)
         requestPermissions(permissions, REQUEST_CODE_PHOTOS)
         return false
     }
@@ -925,6 +1183,7 @@ private class AndroidSensorCollector {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             return true
         }
+        markPermissionRequested(Manifest.permission.POST_NOTIFICATIONS)
         requestPermissions(arrayOf(Manifest.permission.POST_NOTIFICATIONS), REQUEST_CODE_NOTIFICATIONS)
         return false
     }
@@ -934,6 +1193,7 @@ private class AndroidSensorCollector {
             return true
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            markPermissionRequested(Manifest.permission.BLUETOOTH_SCAN)
             requestPermissions(arrayOf(Manifest.permission.BLUETOOTH_SCAN), REQUEST_CODE_BLUETOOTH_SCAN)
             return false
         }
@@ -947,6 +1207,7 @@ private class AndroidSensorCollector {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             return true
         }
+        markPermissionRequested(Manifest.permission.BLUETOOTH_CONNECT)
         requestPermissions(
             arrayOf(Manifest.permission.BLUETOOTH_CONNECT),
             REQUEST_CODE_BLUETOOTH_CONNECT,

--- a/mobile/example/platforms/android/app/src/main/kotlin/com/blinc/BlincNativeBridge.kt
+++ b/mobile/example/platforms/android/app/src/main/kotlin/com/blinc/BlincNativeBridge.kt
@@ -816,6 +816,14 @@ private class AndroidSensorCollector {
         foregroundActivityRef = if (activity == null) null else WeakReference(activity)
     }
 
+    private fun markPermissionRequested(permission: String) {
+        val activity = foregroundActivityRef?.get() ?: return
+        activity.getPreferences(Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("permission_requested:$permission", true)
+            .apply()
+    }
+
     fun configure(configJson: String): Boolean {
         return runCatching {
             val root = JSONObject(configJson)
@@ -1580,6 +1588,14 @@ private class AndroidBleCollector(
 
     fun setForegroundActivity(activity: Activity?) {
         foregroundActivityRef = if (activity == null) null else WeakReference(activity)
+    }
+
+    private fun markPermissionRequested(permission: String) {
+        val activity = foregroundActivityRef?.get() ?: return
+        activity.getPreferences(Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("permission_requested:$permission", true)
+            .apply()
     }
 
     fun configure(configJson: String): Boolean {

--- a/mobile/example/platforms/ios/BlincApp/BlincNativeBridge.swift
+++ b/mobile/example/platforms/ios/BlincApp/BlincNativeBridge.swift
@@ -26,8 +26,17 @@ import AVFoundation
 import CoreBluetooth
 import CoreLocation
 import CoreMotion
+import Photos
+import UserNotifications
 
 public final class BlincNativeBridge {
+    private struct PermissionCapabilityState {
+        let status: String
+        let canRequest: Bool
+        let requiresSettingsRedirect: Bool
+        let supported: Bool
+    }
+
 
     public static let shared = BlincNativeBridge()
 
@@ -35,6 +44,8 @@ public final class BlincNativeBridge {
     private var handlers: [String: [String: ([Any]) throws -> Any?]] = [:]
     private let sensorCollector = IOSSensorCollector()
     private let bleCollector = IOSBleCollector()
+    private let notificationCapabilityLock = NSLock()
+    private var cachedNotificationCapability: PermissionCapabilityState?
 
     private init() {}
 
@@ -270,58 +281,96 @@ public final class BlincNativeBridge {
         // =====================================================================
 
         register(namespace: "permissions", name: "has_location") { _ in
-            self.sensorCollector.hasLocationPermission()
+            self.permissionCapabilityPayload(self.locationPermissionCapability(always: false))
         }
         register(namespace: "permissions", name: "has_location_always") { _ in
-            self.sensorCollector.hasLocationAlwaysPermission()
+            self.permissionCapabilityPayload(self.locationPermissionCapability(always: true))
         }
         register(namespace: "permissions", name: "has_motion") { _ in
-            self.sensorCollector.hasMotionPermission()
+            self.permissionCapabilityPayload(self.motionPermissionCapability())
         }
         register(namespace: "permissions", name: "has_camera") { _ in
-            false
+            self.permissionCapabilityPayload(self.cameraPermissionCapability())
         }
         register(namespace: "permissions", name: "has_microphone") { _ in
-            self.hasMicrophonePermission()
+            self.permissionCapabilityPayload(self.microphonePermissionCapability())
         }
         register(namespace: "permissions", name: "has_photos") { _ in
-            false
+            self.permissionCapabilityPayload(self.photosPermissionCapability())
         }
         register(namespace: "permissions", name: "has_notifications") { _ in
-            false
+            self.permissionCapabilityPayload(self.notificationsPermissionCapability())
         }
         register(namespace: "permissions", name: "has_bluetooth_scan") { _ in
-            self.bleCollector.hasBluetoothPermission()
+            self.permissionCapabilityPayload(self.bluetoothPermissionCapability())
         }
         register(namespace: "permissions", name: "has_bluetooth_connect") { _ in
-            self.bleCollector.hasBluetoothPermission()
+            self.permissionCapabilityPayload(self.bluetoothPermissionCapability())
         }
         register(namespace: "permissions", name: "request_location_when_in_use") { _ in
-            self.sensorCollector.requestLocationPermissionWhenInUse()
+            let previous = self.locationPermissionCapability(always: false)
+            _ = self.sensorCollector.requestLocationPermissionWhenInUse()
+            let current = self.locationPermissionCapability(always: false)
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_location_always") { _ in
-            self.sensorCollector.requestLocationPermissionAlways()
+            let previous = self.locationPermissionCapability(always: true)
+            _ = self.sensorCollector.requestLocationPermissionAlways()
+            let current = self.locationPermissionCapability(always: true)
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_motion") { _ in
-            self.sensorCollector.requestMotionPermission()
+            let previous = self.motionPermissionCapability()
+            _ = self.sensorCollector.requestMotionPermission()
+            let current = self.motionPermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_camera") { _ in
-            false
+            let previous = self.cameraPermissionCapability()
+            guard self.requestCameraPermission() != nil else {
+                return self.permissionRequestTimedOutPayload(previous: previous)
+            }
+            let current = self.cameraPermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_microphone") { _ in
-            self.requestMicrophonePermission()
+            let previous = self.microphonePermissionCapability()
+            guard self.requestMicrophonePermission() != nil else {
+                return self.permissionRequestTimedOutPayload(previous: previous)
+            }
+            let current = self.microphonePermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_photos") { _ in
-            false
+            let previous = self.photosPermissionCapability()
+            guard self.requestPhotosPermission() != nil else {
+                return self.permissionRequestTimedOutPayload(previous: previous)
+            }
+            let current = self.photosPermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_notifications") { _ in
-            false
+            let previous = self.notificationsPermissionCapability()
+            guard self.requestNotificationsPermission() != nil else {
+                return self.permissionRequestTimedOutPayload(previous: previous)
+            }
+            let current = self.notificationsPermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_bluetooth_scan") { _ in
-            self.bleCollector.requestBluetoothPermission()
+            let previous = self.bluetoothPermissionCapability()
+            _ = self.bleCollector.requestBluetoothPermission()
+            let current = self.bluetoothPermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
         }
         register(namespace: "permissions", name: "request_bluetooth_connect") { _ in
-            self.bleCollector.requestBluetoothPermission()
+            let previous = self.bluetoothPermissionCapability()
+            _ = self.bleCollector.requestBluetoothPermission()
+            let current = self.bluetoothPermissionCapability()
+            return self.permissionRequestPayload(previous: previous, current: current)
+        }
+        register(namespace: "permissions", name: "open_settings") { _ in
+            self.openApplicationSettings()
         }
 
         // =====================================================================
@@ -399,22 +448,60 @@ public final class BlincNativeBridge {
         return permission == .granted
     }
 
-    private func requestMicrophonePermission() -> Bool {
+    private func hasCameraPermission() -> Bool {
+        AVCaptureDevice.authorizationStatus(for: .video) == .authorized
+    }
+
+    private func requestCameraPermission() -> Bool? {
+        if hasCameraPermission() {
+            return true
+        }
+        return waitForAsyncPermissionDecision { resolve in
+            AVCaptureDevice.requestAccess(for: .video) { allowed in
+                resolve(allowed)
+            }
+        }
+    }
+
+    private func requestMicrophonePermission() -> Bool? {
         if hasMicrophonePermission() {
             return true
         }
-        if Thread.isMainThread {
-            AVAudioSession.sharedInstance().requestRecordPermission { _ in }
-            return hasMicrophonePermission()
+        return waitForAsyncPermissionDecision { resolve in
+            AVAudioSession.sharedInstance().requestRecordPermission { allowed in
+                resolve(allowed)
+            }
         }
-        let semaphore = DispatchSemaphore(value: 0)
-        var granted = false
-        AVAudioSession.sharedInstance().requestRecordPermission { allowed in
-            granted = allowed
-            semaphore.signal()
+    }
+
+    private func requestPhotosPermission() -> Bool? {
+        let currentCapability = photosPermissionCapability()
+        if currentCapability.status == "granted" || currentCapability.status == "limited" {
+            return true
         }
-        _ = semaphore.wait(timeout: .now() + 2.0)
-        return granted
+        return waitForAsyncPermissionDecision { resolve in
+            if #available(iOS 14.0, *) {
+                PHPhotoLibrary.requestAuthorization(for: .readWrite) { status in
+                    resolve(status == .authorized || status == .limited)
+                }
+            } else {
+                PHPhotoLibrary.requestAuthorization { status in
+                    resolve(status == .authorized)
+                }
+            }
+        }
+    }
+
+    private func requestNotificationsPermission() -> Bool? {
+        let capability = notificationsPermissionCapability()
+        if capability.status == "granted" || capability.status == "provisional" {
+            return true
+        }
+        return waitForAsyncPermissionDecision { resolve in
+            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { allowed, _ in
+                resolve(allowed)
+            }
+        }
     }
 
     // MARK: - Helper Functions
@@ -447,6 +534,10 @@ public final class BlincNativeBridge {
             result["value"] = string
         case let data as Data:
             result["value"] = data.base64EncodedString()
+        case let dictionary as [String: Any]:
+            result["value"] = dictionary
+        case let array as [Any]:
+            result["value"] = array
         default:
             result["value"] = String(describing: value)
         }
@@ -470,6 +561,294 @@ public final class BlincNativeBridge {
             return json
         }
         return "{\"success\":false,\"errorType\":\"\(type)\",\"errorMessage\":\"\(message)\"}"
+    }
+
+    private func openApplicationSettings() -> Bool {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else {
+            return false
+        }
+        if Thread.isMainThread {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            return true
+        }
+        DispatchQueue.main.async {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+        return true
+    }
+
+    private func permissionCapabilityPayload(_ capability: PermissionCapabilityState) -> [String: Any] {
+        [
+            "status": capability.status,
+            "canRequest": capability.canRequest,
+            "requiresSettingsRedirect": capability.requiresSettingsRedirect,
+            "supported": capability.supported,
+        ]
+    }
+
+    private func permissionRequestPayload(
+        previous: PermissionCapabilityState,
+        current: PermissionCapabilityState
+    ) -> [String: Any] {
+        let effectiveCurrent: PermissionCapabilityState
+        if current.status == previous.status && previous.canRequest {
+            effectiveCurrent = previous
+        } else {
+            effectiveCurrent = current
+        }
+        [
+            "status": effectiveCurrent.status,
+            "previousStatus": previous.status,
+            "canRequestAgain": effectiveCurrent.canRequest,
+            "requiresSettingsRedirect": effectiveCurrent.requiresSettingsRedirect,
+        ]
+    }
+
+    private func permissionRequestTimedOutPayload(previous: PermissionCapabilityState) -> [String: Any] {
+        [
+            "status": "pending",
+            "previousStatus": previous.status,
+            "canRequestAgain": previous.canRequest,
+            "requiresSettingsRedirect": false,
+            "deferred": true,
+        ]
+    }
+
+    private func waitForAsyncPermissionDecision(
+        timeout: TimeInterval = 30.0,
+        work: (@escaping (Bool) -> Void) -> Void
+    ) -> Bool? {
+        let lock = NSLock()
+        var result: Bool?
+        let semaphore = DispatchSemaphore(value: 0)
+
+        let resolve: (Bool) -> Void = { value in
+            lock.lock()
+            result = value
+            lock.unlock()
+            semaphore.signal()
+        }
+
+        if Thread.isMainThread {
+            work(resolve)
+        } else {
+            DispatchQueue.main.async {
+                work(resolve)
+            }
+            _ = semaphore.wait(timeout: .now() + timeout)
+            lock.lock()
+            let current = result
+            lock.unlock()
+            if let current {
+                return current
+            }
+        }
+
+        return nil
+    }
+
+    private func waitForNotificationPermissionCapability(timeout: TimeInterval = 2.0) -> PermissionCapabilityState {
+        if Thread.isMainThread {
+            if let cached = currentCachedNotificationCapability() {
+                return cached
+            }
+            UNUserNotificationCenter.current().getNotificationSettings { settings in
+                self.storeNotificationCapability(
+                    self.notificationPermissionCapability(settings.authorizationStatus)
+                )
+            }
+            return pendingNotificationCapability()
+        }
+
+        let lock = NSLock()
+        var capability: PermissionCapabilityState?
+        let semaphore = DispatchSemaphore(value: 0)
+
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            let resolved = self.notificationPermissionCapability(settings.authorizationStatus)
+            self.storeNotificationCapability(resolved)
+            lock.lock()
+            capability = resolved
+            lock.unlock()
+            semaphore.signal()
+        }
+
+        _ = semaphore.wait(timeout: .now() + timeout)
+        lock.lock()
+        let current = capability
+        lock.unlock()
+        if let current {
+            return current
+        }
+
+        return unknownNotificationCapability()
+    }
+
+    private func currentCachedNotificationCapability() -> PermissionCapabilityState? {
+        notificationCapabilityLock.lock()
+        defer { notificationCapabilityLock.unlock() }
+        return cachedNotificationCapability
+    }
+
+    private func storeNotificationCapability(_ capability: PermissionCapabilityState) {
+        notificationCapabilityLock.lock()
+        cachedNotificationCapability = capability
+        notificationCapabilityLock.unlock()
+    }
+
+    private func unknownNotificationCapability() -> PermissionCapabilityState {
+        PermissionCapabilityState(
+            status: "unknown",
+            canRequest: false,
+            requiresSettingsRedirect: false,
+            supported: true
+        )
+    }
+
+    private func pendingNotificationCapability() -> PermissionCapabilityState {
+        PermissionCapabilityState(
+            status: "pending",
+            canRequest: false,
+            requiresSettingsRedirect: false,
+            supported: true
+        )
+    }
+
+    private func locationPermissionCapability(always: Bool) -> PermissionCapabilityState {
+        switch self.sensorCollector.locationAuthorizationStatusValue() {
+        case .authorizedAlways:
+            return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .authorizedWhenInUse:
+            if always {
+                return PermissionCapabilityState(status: "denied", canRequest: true, requiresSettingsRedirect: false, supported: true)
+            }
+            return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .denied:
+            return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .restricted:
+            return PermissionCapabilityState(status: "restricted", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .notDetermined:
+            return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+        @unknown default:
+            return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        }
+    }
+
+    private func motionPermissionCapability() -> PermissionCapabilityState {
+        if #available(iOS 11.0, *) {
+            let activity = CMMotionActivityManager.authorizationStatus()
+            let pedometer = CMPedometer.authorizationStatus()
+            if activity == .authorized || pedometer == .authorized {
+                return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+            }
+            if activity == .restricted || pedometer == .restricted {
+                return PermissionCapabilityState(status: "restricted", canRequest: false, requiresSettingsRedirect: true, supported: true)
+            }
+            if activity == .denied || pedometer == .denied {
+                return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+            }
+            return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+        }
+        return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+    }
+
+    private func microphonePermissionCapability() -> PermissionCapabilityState {
+        switch AVAudioSession.sharedInstance().recordPermission {
+        case .granted:
+            return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .denied:
+            return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .undetermined:
+            return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+        @unknown default:
+            return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        }
+    }
+
+    private func cameraPermissionCapability() -> PermissionCapabilityState {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .denied:
+            return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .restricted:
+            return PermissionCapabilityState(status: "restricted", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .notDetermined:
+            return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+        @unknown default:
+            return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        }
+    }
+
+    private func photosPermissionCapability() -> PermissionCapabilityState {
+        if #available(iOS 14.0, *) {
+            switch PHPhotoLibrary.authorizationStatus(for: .readWrite) {
+            case .authorized:
+                return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+            case .limited:
+                return PermissionCapabilityState(status: "limited", canRequest: false, requiresSettingsRedirect: false, supported: true)
+            case .denied:
+                return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+            case .restricted:
+                return PermissionCapabilityState(status: "restricted", canRequest: false, requiresSettingsRedirect: true, supported: true)
+            case .notDetermined:
+                return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+            @unknown default:
+                return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+            }
+        }
+
+        switch PHPhotoLibrary.authorizationStatus() {
+        case .authorized:
+            return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .denied:
+            return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .restricted:
+            return PermissionCapabilityState(status: "restricted", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .notDetermined:
+            return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+        case .limited:
+            return PermissionCapabilityState(status: "limited", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        @unknown default:
+            return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        }
+    }
+
+    private func notificationsPermissionCapability() -> PermissionCapabilityState {
+        waitForNotificationPermissionCapability()
+    }
+
+    private func notificationPermissionCapability(_ status: UNAuthorizationStatus) -> PermissionCapabilityState {
+        switch status {
+        case .authorized:
+            return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .provisional, .ephemeral:
+            return PermissionCapabilityState(status: "provisional", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        case .denied:
+            return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+        case .notDetermined:
+            return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+        @unknown default:
+            return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+        }
+    }
+
+    private func bluetoothPermissionCapability() -> PermissionCapabilityState {
+        if #available(iOS 13.0, *) {
+            switch CBManager.authorization {
+            case .allowedAlways:
+                return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
+            case .denied:
+                return PermissionCapabilityState(status: "denied", canRequest: false, requiresSettingsRedirect: true, supported: true)
+            case .restricted:
+                return PermissionCapabilityState(status: "restricted", canRequest: false, requiresSettingsRedirect: true, supported: true)
+            case .notDetermined:
+                return PermissionCapabilityState(status: "not_determined", canRequest: true, requiresSettingsRedirect: false, supported: true)
+            @unknown default:
+                return PermissionCapabilityState(status: "unknown", canRequest: false, requiresSettingsRedirect: false, supported: true)
+            }
+        }
+        return PermissionCapabilityState(status: "granted", canRequest: false, requiresSettingsRedirect: false, supported: true)
     }
 }
 
@@ -668,12 +1047,12 @@ private final class IOSSensorCollector: NSObject, CLLocationManagerDelegate {
     }
 
     func hasLocationPermission() -> Bool {
-        let status = locationAuthorizationStatus()
+        let status = locationAuthorizationStatusValue()
         return status == .authorizedAlways || status == .authorizedWhenInUse
     }
 
     func hasLocationAlwaysPermission() -> Bool {
-        return locationAuthorizationStatus() == .authorizedAlways
+        return locationAuthorizationStatusValue() == .authorizedAlways
     }
 
     func hasMotionPermission() -> Bool {
@@ -1112,7 +1491,7 @@ private final class IOSSensorCollector: NSObject, CLLocationManagerDelegate {
         return max(parsed, minValue)
     }
 
-    private func locationAuthorizationStatus() -> CLAuthorizationStatus {
+    func locationAuthorizationStatusValue() -> CLAuthorizationStatus {
         if #available(iOS 14.0, *) {
             return locationManager.authorizationStatus
         }

--- a/mobile/example/platforms/ios/BlincApp/BlincNativeBridge.swift
+++ b/mobile/example/platforms/ios/BlincApp/BlincNativeBridge.swift
@@ -166,7 +166,19 @@ public final class BlincNativeBridge {
 
         register(namespace: "haptics", name: "impact") { args in
             if #available(iOS 10.0, *) {
-                let style: Int = args.first as? Int ?? 1
+                let style: Int
+                if let styleString = args.first as? String {
+                    switch styleString.lowercased() {
+                    case "light":
+                        style = 0
+                    case "heavy":
+                        style = 2
+                    default:
+                        style = 1
+                    }
+                } else {
+                    style = args.first as? Int ?? 1
+                }
                 let feedbackStyle: UIImpactFeedbackGenerator.FeedbackStyle
                 switch style {
                 case 0: feedbackStyle = .light

--- a/mobile/example/platforms/ios/BlincApp/BlincNativeBridge.swift
+++ b/mobile/example/platforms/ios/BlincApp/BlincNativeBridge.swift
@@ -596,7 +596,7 @@ public final class BlincNativeBridge {
         } else {
             effectiveCurrent = current
         }
-        [
+        return [
             "status": effectiveCurrent.status,
             "previousStatus": previous.status,
             "canRequestAgain": effectiveCurrent.canRequest,
@@ -605,7 +605,7 @@ public final class BlincNativeBridge {
     }
 
     private func permissionRequestTimedOutPayload(previous: PermissionCapabilityState) -> [String: Any] {
-        [
+        return [
             "status": "pending",
             "previousStatus": previous.status,
             "canRequestAgain": previous.canRequest,
@@ -616,7 +616,7 @@ public final class BlincNativeBridge {
 
     private func waitForAsyncPermissionDecision(
         timeout: TimeInterval = 30.0,
-        work: (@escaping (Bool) -> Void) -> Void
+        work: @escaping (@escaping (Bool) -> Void) -> Void
     ) -> Bool? {
         let lock = NSLock()
         var result: Bool?
@@ -631,6 +631,10 @@ public final class BlincNativeBridge {
 
         if Thread.isMainThread {
             work(resolve)
+            lock.lock()
+            let current = result
+            lock.unlock()
+            return current
         } else {
             DispatchQueue.main.async {
                 work(resolve)

--- a/mobile/example/src/sensor_inspector.rs
+++ b/mobile/example/src/sensor_inspector.rs
@@ -2,6 +2,7 @@ use blinc_app::prelude::*;
 use blinc_app::windowed::WindowedContext;
 use blinc_core::native_bridge::native_call;
 use blinc_core::reactive::State;
+use blinc_platform::permissions::{self, PermissionCapability, PermissionKind, PermissionStatus};
 use blinc_platform::sensors::native_bridge::NativeBridgeBackend;
 use blinc_platform::sensors::{SensorClient, SensorConfig, SensorFrame, SensorKind};
 use std::collections::BTreeMap;
@@ -30,7 +31,7 @@ impl Default for SensorPanelData {
     fn default() -> Self {
         Self {
             status_line: "running=false  session=-  buffered=0".to_string(),
-            permission_line: "permission: location=false  motion=false".to_string(),
+            permission_line: "permission: location=unknown  motion=unknown".to_string(),
             supported_line: "supported: []".to_string(),
             kinds_line: "kinds: []".to_string(),
             sample_line: "sample: turn ON to stream frames".to_string(),
@@ -76,15 +77,44 @@ fn sensor_config() -> SensorConfig {
     }
 }
 
-fn sensor_permission_state() -> (bool, bool) {
-    let has_location = native_call::<bool, _>("permissions", "has_location", ()).unwrap_or(false);
-    let has_motion = native_call::<bool, _>("permissions", "has_motion", ()).unwrap_or(false);
-    (has_location, has_motion)
+fn permission_status_label(capability: &PermissionCapability) -> &'static str {
+    match capability.status {
+        PermissionStatus::Granted => "granted",
+        PermissionStatus::Denied => "denied",
+        PermissionStatus::PermanentlyDenied => "permanently_denied",
+        PermissionStatus::Restricted => "restricted",
+        PermissionStatus::Limited => "limited",
+        PermissionStatus::NotDetermined => "not_determined",
+        PermissionStatus::Provisional => "provisional",
+        PermissionStatus::Pending => "pending",
+        PermissionStatus::Unknown => "unknown",
+    }
+}
+
+fn sensor_permission_state() -> (PermissionCapability, PermissionCapability) {
+    let fallback = PermissionCapability {
+        status: PermissionStatus::Unknown,
+        can_request: false,
+        requires_settings_redirect: false,
+        supported: false,
+    };
+    let location = permissions::capability(PermissionKind::LocationWhenInUse).unwrap_or_else(|_| fallback.clone());
+    let motion = permissions::capability(PermissionKind::Motion).unwrap_or(fallback);
+    (location, motion)
 }
 
 fn prepare_sensor_streaming(client: &SensorClient<NativeBridgeBackend>) -> std::result::Result<(), String> {
-    let _ = native_call::<bool, _>("permissions", "request_location_when_in_use", ());
-    let _ = native_call::<bool, _>("permissions", "request_motion", ());
+    let location = permissions::request(PermissionKind::LocationWhenInUse)
+        .map_err(|err| format!("location permission request failed: {}", err))?;
+    let motion = permissions::request(PermissionKind::Motion)
+        .map_err(|err| format!("motion permission request failed: {}", err))?;
+
+    if location.requires_settings_redirect || motion.requires_settings_redirect {
+        let _ = permissions::open_settings();
+        return Err(
+            "permission requires Settings access; opened app settings".to_string(),
+        );
+    }
 
     client
         .configure(&sensor_config())
@@ -144,10 +174,11 @@ fn summarize_frames(frames: &[SensorFrame]) -> (BTreeMap<SensorKind, usize>, BTr
 fn fetch_sensor_panel_data(client: &SensorClient<NativeBridgeBackend>) -> SensorPanelData {
     let mut data = SensorPanelData::default();
 
-    let (has_location, has_motion) = sensor_permission_state();
+    let (location, motion) = sensor_permission_state();
     data.permission_line = format!(
         "permission: location={}  motion={}",
-        has_location, has_motion
+        permission_status_label(&location),
+        permission_status_label(&motion)
     );
 
     let status = match client.status() {
@@ -329,14 +360,15 @@ fn sensor_toggle_button(
                 return;
             }
 
-            let (has_location, has_motion) = sensor_permission_state();
-            if !(has_location && has_motion) {
+            let (location, motion) = sensor_permission_state();
+            if !(location.status == PermissionStatus::Granted && motion.status == PermissionStatus::Granted) {
                 live_enabled.set(true);
                 pending_start.set(true);
                 let mut data = fetch_sensor_panel_data(&client);
                 data.note_line = format!(
                     "waiting permissions: location={} motion={} (grant prompt, then auto-start)",
-                    has_location, has_motion
+                    permission_status_label(&location),
+                    permission_status_label(&motion)
                 );
                 snapshot.set(data);
                 return;
@@ -396,8 +428,8 @@ pub fn sensor_section(ctx: &WindowedContext, section_card: fn(&str) -> Div) -> D
                         return;
                     }
 
-                    let (has_location, has_motion) = sensor_permission_state();
-                    if has_location && has_motion {
+                    let (location, motion) = sensor_permission_state();
+                    if location.status == PermissionStatus::Granted && motion.status == PermissionStatus::Granted {
                         match start_sensor_streaming(&client) {
                             Ok(()) => {
                                 pending_start.set(false);
@@ -419,7 +451,8 @@ pub fn sensor_section(ctx: &WindowedContext, section_card: fn(&str) -> Div) -> D
                     let mut data = fetch_sensor_panel_data(&client);
                     data.note_line = format!(
                         "waiting permissions: location={} motion={} (grant prompt, then auto-start)",
-                        has_location, has_motion
+                        permission_status_label(&location),
+                        permission_status_label(&motion)
                     );
                     snapshot.set(data);
                     return;

--- a/toolchain/templates/rust/platforms/android/README.md
+++ b/toolchain/templates/rust/platforms/android/README.md
@@ -1,7 +1,7 @@
 # Android Platform Setup
 
 For the repo-wide support contract, see
-[`docs/native-readiness.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/native-readiness.md).
+[`docs/native-readiness.md`](../../../../../docs/native-readiness.md).
 
 ## Prerequisites
 

--- a/toolchain/templates/rust/platforms/android/README.md
+++ b/toolchain/templates/rust/platforms/android/README.md
@@ -1,5 +1,8 @@
 # Android Platform Setup
 
+For the repo-wide support contract, see
+[`docs/native-readiness.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/native-readiness.md).
+
 ## Prerequisites
 
 - Android Studio (latest)
@@ -38,6 +41,12 @@ cd platforms/android
 ./gradlew assembleRelease
 ```
 
+This template currently guarantees scaffold-level Android integration:
+
+- Tier 1: Rust library build + Gradle project generation
+- Tier 2: app launch and native bridge integration after project-specific wiring
+- Deferred: production signing, store publishing, full mobile accessibility parity
+
 ## Running
 
 ```bash
@@ -53,9 +62,7 @@ adb shell am start -n com.blinc.{{project_name_snake}}/.MainActivity
 platforms/android/
 ├── app/
 │   ├── src/main/
-│   │   ├── kotlin/com/blinc/
-│   │   │   ├── MainActivity.kt      # Android entry point
-│   │   │   └── BlincNativeBridge.kt # Rust-to-Kotlin bridge
+│   │   ├── kotlin/com/blinc/        # App-specific sources added after scaffold generation
 │   │   ├── jniLibs/                  # Rust .so files (auto-copied)
 │   │   └── AndroidManifest.xml
 │   └── build.gradle.kts
@@ -78,3 +85,8 @@ BlincNativeBridge.registerString("device", "get_battery_level") {
     // Return battery percentage as string
 }
 ```
+
+`BlincNativeBridge.kt` is maintained alongside the native platform extensions and
+may need to be copied into generated projects as the scaffold evolves. If your
+generated project does not yet include it, treat the template output as
+incomplete scaffold wiring rather than production-ready mobile support.

--- a/toolchain/templates/rust/platforms/fuchsia/README.md
+++ b/toolchain/templates/rust/platforms/fuchsia/README.md
@@ -1,10 +1,28 @@
 # Fuchsia Platform Template
 
-This directory contains templates for building Blinc applications on Fuchsia OS.
+This directory contains the deferred Fuchsia template surface for Blinc applications.
 
-## Quick Start
+For the repo-wide support contract, see
+[`docs/native-readiness.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/native-readiness.md).
+
+## Support Status
+
+Fuchsia is currently `unsupported in-tree`.
+
+- Tier 1: not shipped
+- Tier 2: not shipped
+- Tier 3: not shipped
+
+The files in this directory are kept as scaffolding for future work and for external
+experiments that wire Blinc into a full Fuchsia tree. They should not be treated as
+an officially supported local development path today.
+
+## Reference Workflow
 
 ```bash
+# This workflow is currently deferred. The commands below document the intended
+# shape of a future or external integration, not a supported local setup.
+
 # 1. Run the complete setup (SDK + emulator + verification)
 ./scripts/setup-fuchsia-all.sh
 
@@ -39,11 +57,14 @@ fuchsia/
 | `setup-fuchsia-emulator.sh` | Emulator setup |
 | `verify-fuchsia-tools.sh` | Verify installation |
 
-## Build Workflows
+## Deferred Build Workflows
 
-### Option 1: Cargo + Manual Packaging (Recommended for Blinc)
+These workflows are design scaffolding, not a support guarantee for the current repo.
 
-This is the simplest workflow for Rust-first development:
+### Option 1: Cargo + Manual Packaging (Reference Only)
+
+This documents one possible external workflow shape for Rust-first Fuchsia
+experiments. It is not a supported in-tree path in the current repository:
 
 ```bash
 # Build

--- a/toolchain/templates/rust/platforms/fuchsia/README.md
+++ b/toolchain/templates/rust/platforms/fuchsia/README.md
@@ -3,7 +3,7 @@
 This directory contains the deferred Fuchsia template surface for Blinc applications.
 
 For the repo-wide support contract, see
-[`docs/native-readiness.md`](/Users/cypark/.codex/worktrees/d483/Blinc/docs/native-readiness.md).
+[`docs/native-readiness.md`](../../../../../docs/native-readiness.md).
 
 ## Support Status
 


### PR DESCRIPTION
## Summary
- stabilize the mobile native runtime contract with shared environment, IME, and accessibility state
- complete the Android embedding lifecycle slice and replace key iOS permission stubs with structured native permission results
- split the canonical mobile example into debug-vs-release packaging lanes and document the current native readiness contract

## Testing
- cargo test -p blinc_platform
- cargo check --manifest-path mobile/example/Cargo.toml
- ./scripts/check-mobile-native-bridge-sync.sh
- cargo fmt --all
- cargo fmt --all -- --check
- bash -n mobile/example/build-android.sh
- bash -n mobile/example/build-ios.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mobile-packaging.yml")'
