### PR TITLE
Stabilize debugger one-shot export fetch

### DIFF
--- a/crates/blinc_debugger/Cargo.toml
+++ b/crates/blinc_debugger/Cargo.toml
@@ -40,3 +40,4 @@ clap = { version = "4", features = ["derive"] }
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+socket2 = "0.6"

--- a/crates/blinc_debugger/src/app.rs
+++ b/crates/blinc_debugger/src/app.rs
@@ -1,4 +1,4 @@
-/// Main application module for the debugger.
+//! Main application module for the debugger.
 use crate::panels::{
     CommandPanel, EvidencePanel, InspectorPanel, PreviewConfig, PreviewPanel, TimelinePanel,
     TimelinePanelState, TreePanel, TreePanelState,

--- a/crates/blinc_debugger/src/app.rs
+++ b/crates/blinc_debugger/src/app.rs
@@ -1,5 +1,4 @@
-//! Main application module for the debugger.
-
+/// Main application module for the debugger.
 use crate::panels::{
     CommandPanel, EvidencePanel, InspectorPanel, PreviewConfig, PreviewPanel, TimelinePanel,
     TimelinePanelState, TreePanel, TreePanelState,
@@ -16,15 +15,18 @@ use blinc_recorder::{
     RecordedEvent, RecordingExport, Timestamp, TimestampedEvent, TraceEntry, TraceEntryKind,
     TreeSnapshot,
 };
+use socket2::{Domain, SockAddr, Socket, Type};
 use std::collections::BTreeSet;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const MAX_NETWORK_PAYLOAD_BYTES: usize = 100 * 1024 * 1024;
 const MAX_EXPORT_STREAM_PAYLOAD_BYTES: usize = MAX_NETWORK_PAYLOAD_BYTES;
 const MAX_SERVER_MESSAGES_TO_PARSE: usize = 32;
+// Fixed from the manual one-shot latency benchmark in recorder integration tests.
+const ONE_SHOT_EXPORT_TIMEOUT: Duration = Duration::from_millis(350);
 
 /// Application state
 #[derive(Default)]
@@ -703,20 +705,17 @@ fn write_len_prefixed<W: Write>(writer: &mut W, payload: &[u8]) -> Result<()> {
 fn request_export_from_server(addr: &str) -> Result<RecordingExport> {
     #[cfg(unix)]
     {
-        match resolve_connect_target(addr)
+        return match resolve_connect_target(addr)
             .with_context(|| format!("invalid --connect target: {addr}"))?
         {
-            ConnectTarget::Unix(socket) => {
-                return request_export_over_unix_socket(&socket)
-                    .with_context(|| format!("failed to connect to unix socket {socket}"));
-            }
-            ConnectTarget::Tcp(target) => {
-                return request_export_over_tcp(&target)
-                    .with_context(|| format!("failed to connect to tcp server {target}"));
-            }
-        }
+            ConnectTarget::Unix(socket) => request_export_over_unix_socket(&socket)
+                .with_context(|| format!("failed to connect to unix socket {socket}")),
+            ConnectTarget::Tcp(target) => request_export_over_tcp(&target)
+                .with_context(|| format!("failed to connect to tcp server {target}")),
+        };
     }
 
+    #[cfg(not(unix))]
     request_export_over_tcp(addr).with_context(|| format!("failed to connect to tcp server {addr}"))
 }
 
@@ -825,45 +824,100 @@ fn is_valid_default_socket_name(name: &str) -> bool {
 
 #[cfg(unix)]
 fn request_export_over_unix_socket(socket: &str) -> Result<RecordingExport> {
-    use std::os::unix::net::UnixStream;
-
-    let mut stream = UnixStream::connect(socket)?;
-    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
-    request_export_over_stream(&mut stream)
+    let deadline = OneShotDeadline::start(one_shot_export_timeout());
+    let address = SockAddr::unix(socket)
+        .context("connect stage failed while building unix socket address")?;
+    let stream = Socket::new(Domain::UNIX, Type::STREAM, None)
+        .context("connect stage failed while creating unix socket")?;
+    stream
+        .connect_timeout(&address, deadline.remaining_timeout("connect stage")?)
+        .context("connect stage failed while connecting to unix socket")?;
+    request_export_over_stream_with_deadline(stream, &deadline)
 }
 
 fn request_export_over_tcp(addr: &str) -> Result<RecordingExport> {
-    let mut stream = std::net::TcpStream::connect(addr)?;
-    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
-    request_export_over_stream(&mut stream)
+    use std::net::ToSocketAddrs;
+
+    let deadline = OneShotDeadline::start(one_shot_export_timeout());
+    deadline.remaining_timeout("connect stage")?;
+    let targets = addr
+        .to_socket_addrs()
+        .with_context(|| format!("connect stage failed while resolving tcp target {addr}"))?
+        .collect::<Vec<_>>();
+
+    if targets.is_empty() {
+        bail!("connect stage failed because tcp target {addr} resolved to no addresses");
+    }
+
+    let mut last_error = None;
+    for target in targets {
+        let stream =
+            Socket::new(Domain::for_address(target), Type::STREAM, None).with_context(|| {
+                format!("connect stage failed while creating tcp socket for {target}")
+            })?;
+        match stream.connect_timeout(
+            &SockAddr::from(target),
+            deadline.remaining_timeout("connect stage")?,
+        ) {
+            Ok(()) => return request_export_over_stream_with_deadline(stream, &deadline),
+            Err(err) => last_error = Some((target, err)),
+        }
+    }
+
+    let (target, err) = last_error.expect("tcp targets should produce at least one connect error");
+    Err(err).with_context(|| format!("connect stage failed while connecting to {target}"))
 }
 
-fn request_export_over_stream<S: Read + Write>(stream: &mut S) -> Result<RecordingExport> {
+fn one_shot_export_timeout() -> Duration {
+    ONE_SHOT_EXPORT_TIMEOUT
+}
+
+fn request_export_over_stream<S: TimeoutStream>(stream: S) -> Result<RecordingExport> {
+    request_export_over_stream_with_timeout(stream, one_shot_export_timeout())
+}
+
+fn request_export_over_stream_with_timeout<S: TimeoutStream>(
+    stream: S,
+    timeout: Duration,
+) -> Result<RecordingExport> {
+    let deadline = OneShotDeadline::start(timeout);
+    request_export_over_stream_with_deadline(stream, &deadline)
+}
+
+fn request_export_over_stream_with_deadline<S: TimeoutStream>(
+    mut stream: S,
+    deadline: &OneShotDeadline,
+) -> Result<RecordingExport> {
     let mut total_payload_bytes = 0usize;
 
-    let hello_payload = read_len_prefixed(stream)?;
+    let hello_payload = read_len_prefixed_with_deadline(&mut stream, deadline, "hello stage")
+        .context("hello stage failed while waiting for handshake")?;
     add_payload_budget(&mut total_payload_bytes, hello_payload.len())?;
-    let hello: serde_json::Value = serde_json::from_slice(&hello_payload)?;
+    let hello: serde_json::Value = serde_json::from_slice(&hello_payload)
+        .context("hello stage failed while parsing payload")?;
     if hello.get("type").and_then(|v| v.as_str()) != Some("hello") {
-        bail!("unexpected first server message: {hello}");
+        bail!("hello stage expected first server message to be hello, got: {hello}");
     }
 
     let request = serde_json::json!({ "type": "request_export" });
-    let bytes = serde_json::to_vec(&request)?;
-    write_len_prefixed(stream, &bytes)?;
+    let bytes = serde_json::to_vec(&request)
+        .context("request_export stage failed while serializing command")?;
+    write_len_prefixed_with_deadline(&mut stream, deadline, "request_export stage", &bytes)
+        .context("request_export stage failed while writing command")?;
+    flush_with_deadline(&mut stream, deadline, "request_export stage")
+        .context("request_export stage failed while flushing command")?;
 
     for _ in 0..MAX_SERVER_MESSAGES_TO_PARSE {
-        let payload = read_len_prefixed(stream)?;
+        let payload = read_len_prefixed_with_deadline(&mut stream, deadline, "export stage")
+            .context("export stage failed while waiting for response")?;
         add_payload_budget(&mut total_payload_bytes, payload.len())?;
-        let value: serde_json::Value = serde_json::from_slice(&payload)?;
+        let value: serde_json::Value = serde_json::from_slice(&payload)
+            .context("export stage failed while parsing response")?;
         match value.get("type").and_then(|v| v.as_str()) {
             Some("export") => {
-                let export_value = value
-                    .get("export")
-                    .cloned()
-                    .ok_or_else(|| anyhow!("missing export field in server response"))?;
+                let export_value = value.get("export").cloned().ok_or_else(|| {
+                    anyhow!("export stage missing export field in server response")
+                })?;
                 return serde_json::from_value(export_value).map_err(Into::into);
             }
             Some("error") => {
@@ -871,13 +925,106 @@ fn request_export_over_stream<S: Read + Write>(stream: &mut S) -> Result<Recordi
                     .get("message")
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown server error");
-                bail!("server error: {message}");
+                bail!("export stage server error: {message}");
             }
             _ => continue,
         }
     }
 
     bail!("did not receive export payload from server")
+}
+
+fn read_len_prefixed_with_deadline<S: TimeoutStream>(
+    stream: &mut S,
+    deadline: &OneShotDeadline,
+    stage: &'static str,
+) -> Result<Vec<u8>> {
+    let remaining = deadline.remaining_timeout(stage)?;
+    stream
+        .set_read_timeout(Some(remaining))
+        .with_context(|| format!("{stage} failed while configuring read timeout"))?;
+    let payload = read_len_prefixed(stream)?;
+    deadline.remaining_timeout(stage)?;
+    Ok(payload)
+}
+
+fn write_len_prefixed_with_deadline<S: TimeoutStream>(
+    stream: &mut S,
+    deadline: &OneShotDeadline,
+    stage: &'static str,
+    payload: &[u8],
+) -> Result<()> {
+    let remaining = deadline.remaining_timeout(stage)?;
+    stream
+        .set_write_timeout(Some(remaining))
+        .with_context(|| format!("{stage} failed while configuring write timeout"))?;
+    write_len_prefixed(stream, payload)?;
+    deadline.remaining_timeout(stage)?;
+    Ok(())
+}
+
+fn flush_with_deadline<S: TimeoutStream>(
+    stream: &mut S,
+    deadline: &OneShotDeadline,
+    stage: &'static str,
+) -> Result<()> {
+    let remaining = deadline.remaining_timeout(stage)?;
+    stream
+        .set_write_timeout(Some(remaining))
+        .with_context(|| format!("{stage} failed while configuring write timeout"))?;
+    stream.flush()?;
+    deadline.remaining_timeout(stage)?;
+    Ok(())
+}
+
+trait TimeoutStream: Read + Write {
+    fn set_read_timeout(&self, timeout: Option<Duration>) -> std::io::Result<()>;
+    fn set_write_timeout(&self, timeout: Option<Duration>) -> std::io::Result<()>;
+}
+
+impl<T: TimeoutStream + ?Sized> TimeoutStream for &mut T {
+    fn set_read_timeout(&self, timeout: Option<Duration>) -> std::io::Result<()> {
+        (**self).set_read_timeout(timeout)
+    }
+
+    fn set_write_timeout(&self, timeout: Option<Duration>) -> std::io::Result<()> {
+        (**self).set_write_timeout(timeout)
+    }
+}
+
+impl TimeoutStream for Socket {
+    fn set_read_timeout(&self, timeout: Option<Duration>) -> std::io::Result<()> {
+        Socket::set_read_timeout(self, timeout)
+    }
+
+    fn set_write_timeout(&self, timeout: Option<Duration>) -> std::io::Result<()> {
+        Socket::set_write_timeout(self, timeout)
+    }
+}
+
+struct OneShotDeadline {
+    started_at: Instant,
+    total_timeout: Duration,
+}
+
+impl OneShotDeadline {
+    fn start(total_timeout: Duration) -> Self {
+        Self {
+            started_at: Instant::now(),
+            total_timeout,
+        }
+    }
+
+    fn remaining_timeout(&self, stage: &'static str) -> Result<Duration> {
+        let elapsed = self.started_at.elapsed();
+        if elapsed >= self.total_timeout {
+            bail!(
+                "{stage} exceeded one-shot timeout budget of {}ms",
+                self.total_timeout.as_millis()
+            );
+        }
+        Ok(self.total_timeout - elapsed)
+    }
 }
 
 fn add_payload_budget(total_payload_bytes: &mut usize, payload_len: usize) -> Result<()> {

--- a/crates/blinc_debugger/tests/connect_budget.rs
+++ b/crates/blinc_debugger/tests/connect_budget.rs
@@ -1,0 +1,175 @@
+#![allow(dead_code, unused_imports)]
+
+#[path = "../src/panels/mod.rs"]
+mod panels;
+
+#[path = "../src/theme.rs"]
+mod theme;
+
+mod app {
+    include!("../src/app.rs");
+
+    use std::collections::VecDeque;
+    use std::io;
+    use std::thread;
+    use std::time::Duration as StdDuration;
+
+    struct ScriptedStream {
+        reads: VecDeque<io::Result<Vec<u8>>>,
+        writes: Vec<Vec<u8>>,
+        read_delay: StdDuration,
+        write_delay: StdDuration,
+    }
+
+    impl ScriptedStream {
+        fn new(reads: impl IntoIterator<Item = io::Result<Vec<u8>>>) -> Self {
+            Self {
+                reads: reads.into_iter().collect(),
+                writes: Vec::new(),
+                read_delay: StdDuration::ZERO,
+                write_delay: StdDuration::ZERO,
+            }
+        }
+
+        fn with_read_delay(mut self, delay: StdDuration) -> Self {
+            self.read_delay = delay;
+            self
+        }
+
+        fn with_write_delay(mut self, delay: StdDuration) -> Self {
+            self.write_delay = delay;
+            self
+        }
+    }
+
+    impl io::Read for ScriptedStream {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let Some(result) = self.reads.pop_front() else {
+                return Ok(0);
+            };
+
+            if !self.read_delay.is_zero() {
+                thread::sleep(self.read_delay);
+            }
+
+            let chunk = result?;
+            let len = chunk.len().min(buf.len());
+            buf[..len].copy_from_slice(&chunk[..len]);
+            if len < chunk.len() {
+                self.reads.push_front(Ok(chunk[len..].to_vec()));
+            }
+            Ok(len)
+        }
+    }
+
+    impl io::Write for ScriptedStream {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if !self.write_delay.is_zero() {
+                thread::sleep(self.write_delay);
+            }
+            self.writes.push(buf.to_vec());
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl TimeoutStream for ScriptedStream {
+        fn set_read_timeout(&self, _timeout: Option<StdDuration>) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn set_write_timeout(&self, _timeout: Option<StdDuration>) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn len_prefixed_json(value: serde_json::Value) -> Vec<u8> {
+        let payload = serde_json::to_vec(&value).expect("json payload should serialize");
+        let mut bytes = Vec::with_capacity(4 + payload.len());
+        bytes.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(&payload);
+        bytes
+    }
+
+    #[test]
+    fn connect_reports_handshake_stage_in_error_message() {
+        let mut stream = ScriptedStream::new([Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "hello timed out",
+        ))]);
+
+        let err =
+            request_export_over_stream(&mut stream).expect_err("handshake failure should surface");
+
+        assert!(
+            err.to_string().contains("hello stage"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn connect_reports_export_stage_in_error_message() {
+        let hello = len_prefixed_json(serde_json::json!({
+            "type": "hello",
+            "app_name": "test",
+            "protocol_version": 1
+        }));
+        let mut stream = ScriptedStream::new([
+            Ok(hello),
+            Err(io::Error::new(io::ErrorKind::TimedOut, "export timed out")),
+        ]);
+
+        let err = request_export_over_stream(&mut stream)
+            .expect_err("export stage failure should include stage context");
+
+        assert!(
+            err.to_string().contains("export stage"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn connect_enforces_total_one_shot_budget_across_stages() {
+        let hello = len_prefixed_json(serde_json::json!({
+            "type": "hello",
+            "app_name": "test",
+            "protocol_version": 1
+        }));
+        let export = len_prefixed_json(serde_json::json!({
+            "type": "export",
+            "export": {
+                "app_name": "test",
+                "protocol_version": 1,
+                "events": [],
+                "stats": {
+                    "total_events": 0,
+                    "duration_ms": 0.0,
+                    "platform": "test"
+                },
+                "trace_entries": []
+            }
+        }));
+        let mut stream = ScriptedStream::new([Ok(hello), Ok(export)])
+            .with_read_delay(StdDuration::from_millis(120))
+            .with_write_delay(StdDuration::from_millis(120));
+
+        let err =
+            request_export_over_stream_with_timeout(&mut stream, StdDuration::from_millis(350))
+                .expect_err(
+                    "combined hello/write/export latency should exceed the single one-shot budget",
+                );
+
+        assert!(
+            format!("{err:#}").contains("one-shot timeout"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn connect_uses_single_fixed_one_shot_timeout() {
+        assert_eq!(one_shot_export_timeout(), StdDuration::from_millis(350));
+    }
+}

--- a/crates/blinc_recorder/src/server/local.rs
+++ b/crates/blinc_recorder/src/server/local.rs
@@ -9,8 +9,13 @@ use serde_json::json;
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
+
+const ACCEPT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+const CLIENT_IDLE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(5);
+const CLIENT_WRITE_RETRY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Configuration for the debug server.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -173,12 +178,30 @@ impl DebugServer {
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_clone = shutdown.clone();
         let socket_path_clone = socket_path.clone();
+        let (ready_tx, ready_rx) = mpsc::channel();
 
         let thread = thread::spawn(move || {
-            if let Err(e) = self.run_server(&socket_path_clone, shutdown_clone) {
+            if let Err(e) = self.run_server(&socket_path_clone, shutdown_clone, ready_tx) {
                 tracing::error!("Debug server error: {}", e);
             }
         });
+
+        match ready_rx.recv() {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                shutdown.store(true, Ordering::SeqCst);
+                let _ = thread.join();
+                return Err(e);
+            }
+            Err(_) => {
+                shutdown.store(true, Ordering::SeqCst);
+                let _ = thread.join();
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "debug server failed before signaling readiness",
+                ));
+            }
+        }
 
         Ok(ServerHandle {
             shutdown,
@@ -188,14 +211,34 @@ impl DebugServer {
     }
 
     #[cfg(unix)]
-    fn run_server(&self, socket_path: &PathBuf, shutdown: Arc<AtomicBool>) -> io::Result<()> {
+    fn run_server(
+        &self,
+        socket_path: &PathBuf,
+        shutdown: Arc<AtomicBool>,
+        ready_tx: mpsc::Sender<io::Result<()>>,
+    ) -> io::Result<()> {
         use std::os::unix::fs::PermissionsExt;
         use std::os::unix::net::UnixListener;
         use std::time::Duration;
 
-        let listener = UnixListener::bind(socket_path)?;
-        std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o600))?;
-        listener.set_nonblocking(true)?;
+        let listener = match UnixListener::bind(socket_path) {
+            Ok(listener) => listener,
+            Err(e) => {
+                let _ = ready_tx.send(Err(io::Error::new(e.kind(), e.to_string())));
+                return Err(e);
+            }
+        };
+        if let Err(e) =
+            std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o600))
+        {
+            let _ = ready_tx.send(Err(io::Error::new(e.kind(), e.to_string())));
+            return Err(e);
+        }
+        if let Err(e) = listener.set_nonblocking(true) {
+            let _ = ready_tx.send(Err(io::Error::new(e.kind(), e.to_string())));
+            return Err(e);
+        }
+        let _ = ready_tx.send(Ok(()));
 
         tracing::info!("Debug server listening on {}", socket_path.display());
 
@@ -219,7 +262,7 @@ impl DebugServer {
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                     // No pending connection, sleep briefly
-                    thread::sleep(Duration::from_millis(100));
+                    thread::sleep(ACCEPT_POLL_INTERVAL);
                 }
                 Err(e) => {
                     tracing::error!("Accept error: {}", e);
@@ -232,14 +275,35 @@ impl DebugServer {
     }
 
     #[cfg(windows)]
-    fn run_server(&self, _socket_path: &PathBuf, shutdown: Arc<AtomicBool>) -> io::Result<()> {
+    fn run_server(
+        &self,
+        _socket_path: &PathBuf,
+        shutdown: Arc<AtomicBool>,
+        ready_tx: mpsc::Sender<io::Result<()>>,
+    ) -> io::Result<()> {
         use std::net::TcpListener;
         use std::time::Duration;
 
         // Fallback to TCP on Windows (TODO: implement named pipes)
-        let listener = TcpListener::bind("127.0.0.1:0")?;
-        let local_addr = listener.local_addr()?;
-        listener.set_nonblocking(true)?;
+        let listener = match TcpListener::bind("127.0.0.1:0") {
+            Ok(listener) => listener,
+            Err(e) => {
+                let _ = ready_tx.send(Err(io::Error::new(e.kind(), e.to_string())));
+                return Err(e);
+            }
+        };
+        let local_addr = match listener.local_addr() {
+            Ok(addr) => addr,
+            Err(e) => {
+                let _ = ready_tx.send(Err(io::Error::new(e.kind(), e.to_string())));
+                return Err(e);
+            }
+        };
+        if let Err(e) = listener.set_nonblocking(true) {
+            let _ = ready_tx.send(Err(io::Error::new(e.kind(), e.to_string())));
+            return Err(e);
+        }
+        let _ = ready_tx.send(Ok(()));
 
         tracing::info!("Debug server listening on {} (TCP fallback)", local_addr);
 
@@ -261,7 +325,7 @@ impl DebugServer {
                     });
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                    thread::sleep(Duration::from_millis(100));
+                    thread::sleep(ACCEPT_POLL_INTERVAL);
                 }
                 Err(e) => {
                     tracing::error!("Accept error: {}", e);
@@ -491,6 +555,58 @@ fn handle_command(cmd: ClientCommand, session: &Arc<SharedRecordingSession>) -> 
     }
 }
 
+fn write_server_frame<W: Write>(writer: &mut W, payload: &[u8]) -> io::Result<()> {
+    let deadline = std::time::Instant::now() + CLIENT_WRITE_RETRY_TIMEOUT;
+    let mut written = 0usize;
+
+    while written < payload.len() {
+        match writer.write(&payload[written..]) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write full server frame",
+                ));
+            }
+            Ok(n) => written += n,
+            Err(ref e)
+                if matches!(
+                    e.kind(),
+                    io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+                ) =>
+            {
+                if std::time::Instant::now() >= deadline {
+                    return Err(io::Error::new(
+                        e.kind(),
+                        format!("timed out writing server frame after {} bytes", written),
+                    ));
+                }
+                thread::sleep(CLIENT_IDLE_POLL_INTERVAL);
+            }
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+
+    loop {
+        match writer.flush() {
+            Ok(()) => return Ok(()),
+            Err(ref e)
+                if matches!(
+                    e.kind(),
+                    io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+                ) =>
+            {
+                if std::time::Instant::now() >= deadline {
+                    return Err(io::Error::new(e.kind(), "timed out flushing server frame"));
+                }
+                thread::sleep(CLIENT_IDLE_POLL_INTERVAL);
+            }
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 #[cfg(unix)]
 fn handle_client(
     mut stream: std::os::unix::net::UnixStream,
@@ -507,7 +623,8 @@ fn handle_client(
         app_name,
         protocol_version: 1,
     };
-    stream.write_all(&hello.to_bytes())?;
+    let hello_bytes = hello.to_bytes();
+    write_server_frame(&mut stream, &hello_bytes)?;
 
     // Track last state to avoid sending redundant updates
     let mut last_recording = session.is_recording();
@@ -529,13 +646,15 @@ fn handle_client(
                     match decode_next_stream_command(&mut pending) {
                         StreamCommand::Ready(cmd) => {
                             let response = handle_command(cmd, &session);
-                            stream.write_all(&response.to_bytes())?;
+                            let response_bytes = response.to_bytes();
+                            write_server_frame(&mut stream, &response_bytes)?;
                         }
                         StreamCommand::Invalid => {
                             let error = ServerMessage::Error {
                                 message: "invalid command frame".to_string(),
                             };
-                            stream.write_all(&error.to_bytes())?;
+                            let error_bytes = error.to_bytes();
+                            write_server_frame(&mut stream, &error_bytes)?;
                         }
                         StreamCommand::Incomplete => break,
                     }
@@ -557,12 +676,13 @@ fn handle_client(
                 is_recording,
                 is_paused,
             };
-            stream.write_all(&state.to_bytes())?;
+            let state_bytes = state.to_bytes();
+            write_server_frame(&mut stream, &state_bytes)?;
             last_recording = is_recording;
             last_paused = is_paused;
         }
 
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(CLIENT_IDLE_POLL_INTERVAL);
     }
 }
 
@@ -581,7 +701,8 @@ fn handle_client_tcp(
         app_name,
         protocol_version: 1,
     };
-    stream.write_all(&hello.to_bytes())?;
+    let hello_bytes = hello.to_bytes();
+    write_server_frame(&mut stream, &hello_bytes)?;
 
     // Track last state to avoid sending redundant updates
     let mut last_recording = session.is_recording();
@@ -598,13 +719,15 @@ fn handle_client_tcp(
                     match decode_next_stream_command(&mut pending) {
                         StreamCommand::Ready(cmd) => {
                             let response = handle_command(cmd, &session);
-                            stream.write_all(&response.to_bytes())?;
+                            let response_bytes = response.to_bytes();
+                            write_server_frame(&mut stream, &response_bytes)?;
                         }
                         StreamCommand::Invalid => {
                             let error = ServerMessage::Error {
                                 message: "invalid command frame".to_string(),
                             };
-                            stream.write_all(&error.to_bytes())?;
+                            let error_bytes = error.to_bytes();
+                            write_server_frame(&mut stream, &error_bytes)?;
                         }
                         StreamCommand::Incomplete => break,
                     }
@@ -622,12 +745,13 @@ fn handle_client_tcp(
                 is_recording,
                 is_paused,
             };
-            stream.write_all(&state.to_bytes())?;
+            let state_bytes = state.to_bytes();
+            write_server_frame(&mut stream, &state_bytes)?;
             last_recording = is_recording;
             last_paused = is_paused;
         }
 
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(CLIENT_IDLE_POLL_INTERVAL);
     }
 }
 
@@ -651,6 +775,7 @@ pub fn start_local_server_named(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
 
     #[test]
     fn test_socket_path_unix() {
@@ -836,5 +961,62 @@ mod tests {
         assert!(result.is_err(), "non-socket path should be rejected");
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    struct FlakyWriter {
+        writes: VecDeque<io::Result<usize>>,
+        flushes: VecDeque<io::Result<()>>,
+        data: Vec<u8>,
+    }
+
+    impl FlakyWriter {
+        fn new(
+            writes: impl IntoIterator<Item = io::Result<usize>>,
+            flushes: impl IntoIterator<Item = io::Result<()>>,
+        ) -> Self {
+            Self {
+                writes: writes.into_iter().collect(),
+                flushes: flushes.into_iter().collect(),
+                data: Vec::new(),
+            }
+        }
+    }
+
+    impl Write for FlakyWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            match self.writes.pop_front().unwrap_or(Ok(buf.len()))? {
+                len if len <= buf.len() => {
+                    self.data.extend_from_slice(&buf[..len]);
+                    Ok(len)
+                }
+                len => panic!("scripted write length {len} exceeded input {}", buf.len()),
+            }
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.flushes.pop_front().unwrap_or(Ok(()))
+        }
+    }
+
+    #[test]
+    fn write_server_frame_retries_would_block_until_payload_is_complete() {
+        let payload = b"abcdefghijklmnopqrstuvwxyz";
+        let mut writer = FlakyWriter::new(
+            [
+                Ok(8),
+                Err(io::Error::new(io::ErrorKind::WouldBlock, "buffer full")),
+                Ok(10),
+                Ok(payload.len() - 18),
+            ],
+            [
+                Err(io::Error::new(io::ErrorKind::TimedOut, "flush timeout")),
+                Ok(()),
+            ],
+        );
+
+        write_server_frame(&mut writer, payload)
+            .expect("frame write should recover from temporary backpressure");
+
+        assert_eq!(writer.data, payload);
     }
 }

--- a/crates/blinc_recorder/tests/one_shot_export.rs
+++ b/crates/blinc_recorder/tests/one_shot_export.rs
@@ -1,0 +1,258 @@
+#![cfg(unix)]
+
+use blinc_recorder::{start_local_server_named, RecordingConfig, SharedRecordingSession};
+use serde_json::Value;
+use std::io::{Read, Write};
+use std::os::unix::net::UnixListener;
+use std::os::unix::net::UnixStream;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+fn unique_app_name(label: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    format!("blinc-{label}-{}-{nanos}", std::process::id())
+}
+
+fn read_len_prefixed(stream: &mut UnixStream) -> Vec<u8> {
+    let mut len_bytes = [0u8; 4];
+    stream
+        .read_exact(&mut len_bytes)
+        .expect("length prefix should be readable");
+    let len = u32::from_le_bytes(len_bytes) as usize;
+    let mut payload = vec![0u8; len];
+    stream
+        .read_exact(&mut payload)
+        .expect("payload should be readable");
+    payload
+}
+
+fn write_len_prefixed(stream: &mut UnixStream, payload: &[u8]) {
+    let len = payload.len() as u32;
+    stream
+        .write_all(&len.to_le_bytes())
+        .expect("length prefix should be writable");
+    stream
+        .write_all(payload)
+        .expect("payload should be writable");
+}
+
+fn read_json_message(stream: &mut UnixStream) -> Value {
+    serde_json::from_slice(&read_len_prefixed(stream)).expect("message should be valid json")
+}
+
+fn request_export(stream: &mut UnixStream) {
+    write_len_prefixed(stream, br#"{"type":"request_export"}"#);
+}
+
+fn measure_one_shot_fetch(stream: &mut UnixStream) -> Duration {
+    let start = Instant::now();
+    let hello = read_json_message(stream);
+    assert_eq!(hello["type"], "hello");
+    request_export(stream);
+    let export = read_json_message(stream);
+    assert_eq!(export["type"], "export");
+    start.elapsed()
+}
+
+fn format_duration_stats(label: &str, samples: &mut [Duration]) -> String {
+    samples.sort_unstable();
+    let len = samples.len();
+    let min = samples.first().copied().unwrap_or_default();
+    let median = samples[len / 2];
+    let p95_index = ((len.saturating_sub(1) as f64) * 0.95).round() as usize;
+    let p95 = samples[p95_index.min(len - 1)];
+    let max = samples.last().copied().unwrap_or_default();
+    format!("{label}: n={len}, min={min:?}, median={median:?}, p95={p95:?}, max={max:?}")
+}
+
+#[test]
+fn one_shot_attach_returns_empty_export_before_any_events() {
+    let session = Arc::new(SharedRecordingSession::new(RecordingConfig::minimal()));
+    let handle = start_local_server_named(unique_app_name("empty-export"), session)
+        .expect("server should start");
+    let socket_path = handle.socket_path().clone();
+
+    let mut stream = UnixStream::connect(&socket_path).expect("client should connect");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .expect("read timeout should be set");
+
+    let hello = read_json_message(&mut stream);
+    assert_eq!(hello["type"], "hello");
+
+    request_export(&mut stream);
+    let export = read_json_message(&mut stream);
+    assert_eq!(export["type"], "export");
+    assert_eq!(export["export"]["events"].as_array().unwrap().len(), 0);
+    assert_eq!(export["export"]["snapshots"].as_array().unwrap().len(), 0);
+    assert_eq!(
+        export["export"]["trace_entries"].as_array().unwrap().len(),
+        0
+    );
+
+    handle.shutdown();
+    handle.join();
+}
+
+#[test]
+fn one_shot_attach_stays_responsive_after_hello_during_busy_session() {
+    let session = Arc::new(SharedRecordingSession::new(RecordingConfig::debug()));
+    session.start();
+
+    let busy_session = session.clone();
+    let busy_thread = std::thread::spawn(move || {
+        for _ in 0..64 {
+            busy_session.record_event(blinc_recorder::RecordedEvent::WindowFocus(true));
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    });
+
+    let handle = start_local_server_named(unique_app_name("busy-export"), session)
+        .expect("server should start");
+    let socket_path = handle.socket_path().clone();
+
+    let mut stream = UnixStream::connect(&socket_path).expect("client should connect");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .expect("read timeout should be set");
+
+    let hello = read_json_message(&mut stream);
+    assert_eq!(hello["type"], "hello");
+
+    std::thread::sleep(Duration::from_millis(20));
+    let start = Instant::now();
+    request_export(&mut stream);
+    let export = read_json_message(&mut stream);
+    let elapsed = start.elapsed();
+
+    assert_eq!(export["type"], "export");
+    assert!(
+        elapsed < Duration::from_millis(80),
+        "request_export should not be delayed by the server loop sleep; observed {:?}",
+        elapsed
+    );
+
+    busy_thread.join().expect("busy thread should join");
+    handle.shutdown();
+    handle.join();
+}
+
+#[test]
+fn server_restart_removes_stale_socket_from_prior_crash_like_run() {
+    let app_name = unique_app_name("stale-restart");
+    let stale_socket_path = std::path::PathBuf::from(format!("/tmp/blinc/{app_name}.sock"));
+
+    if stale_socket_path.exists() {
+        std::fs::remove_file(&stale_socket_path).expect("pre-existing stale socket should clear");
+    }
+    std::fs::create_dir_all(
+        stale_socket_path
+            .parent()
+            .expect("default socket path should have a parent directory"),
+    )
+    .expect("socket parent directory should exist");
+
+    let stale_listener =
+        UnixListener::bind(&stale_socket_path).expect("stale socket should be creatable");
+    drop(stale_listener);
+
+    assert!(
+        stale_socket_path.exists(),
+        "dropping the listener should leave the socket path behind as stale state"
+    );
+
+    let session = Arc::new(SharedRecordingSession::new(RecordingConfig::minimal()));
+    let handle =
+        start_local_server_named(&app_name, session).expect("server should replace stale socket");
+    let socket_path = handle.socket_path().clone();
+
+    let mut stream =
+        UnixStream::connect(&socket_path).expect("client should connect after restart");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .expect("read timeout should be set");
+
+    let hello = read_json_message(&mut stream);
+    assert_eq!(hello["type"], "hello");
+
+    request_export(&mut stream);
+    let export = read_json_message(&mut stream);
+    assert_eq!(export["type"], "export");
+
+    handle.shutdown();
+    handle.join();
+}
+
+#[test]
+#[ignore = "manual benchmark used to choose the fixed debugger one-shot timeout"]
+fn benchmark_one_shot_fetch_latency_profiles() {
+    const ITERATIONS: usize = 50;
+
+    let empty_session = Arc::new(SharedRecordingSession::new(RecordingConfig::minimal()));
+    let empty_handle = start_local_server_named(unique_app_name("bench-empty"), empty_session)
+        .expect("empty benchmark server should start");
+    let empty_socket = empty_handle.socket_path().clone();
+    let mut empty_samples = Vec::with_capacity(ITERATIONS);
+    for _ in 0..ITERATIONS {
+        let mut stream =
+            UnixStream::connect(&empty_socket).expect("empty benchmark should connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("read timeout should be set");
+        empty_samples.push(measure_one_shot_fetch(&mut stream));
+    }
+    empty_handle.shutdown();
+    empty_handle.join();
+
+    let mut busy_samples = Vec::with_capacity(ITERATIONS);
+    for _ in 0..ITERATIONS {
+        let busy_session = Arc::new(SharedRecordingSession::new(RecordingConfig::debug()));
+        busy_session.start();
+        let busy_handle =
+            start_local_server_named(unique_app_name("bench-busy"), busy_session.clone())
+                .expect("busy benchmark server should start");
+        let busy_socket = busy_handle.socket_path().clone();
+        let busy_thread = std::thread::spawn(move || {
+            for _ in 0..64 {
+                busy_session.record_event(blinc_recorder::RecordedEvent::WindowFocus(true));
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        });
+        let mut stream = UnixStream::connect(&busy_socket).expect("busy benchmark should connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("read timeout should be set");
+        busy_samples.push(measure_one_shot_fetch(&mut stream));
+        busy_thread
+            .join()
+            .expect("busy benchmark thread should join");
+        busy_handle.shutdown();
+        busy_handle.join();
+    }
+
+    let mut fresh_start_samples = Vec::with_capacity(ITERATIONS);
+    for _ in 0..ITERATIONS {
+        let session = Arc::new(SharedRecordingSession::new(RecordingConfig::minimal()));
+        let handle = start_local_server_named(unique_app_name("bench-fresh"), session)
+            .expect("fresh-start benchmark server should start");
+        let socket = handle.socket_path().clone();
+        let mut stream =
+            UnixStream::connect(&socket).expect("fresh-start benchmark should connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("read timeout should be set");
+        fresh_start_samples.push(measure_one_shot_fetch(&mut stream));
+        handle.shutdown();
+        handle.join();
+    }
+
+    println!("{}", format_duration_stats("empty", &mut empty_samples));
+    println!("{}", format_duration_stats("busy", &mut busy_samples));
+    println!(
+        "{}",
+        format_duration_stats("fresh-start", &mut fresh_start_samples)
+    );
+}


### PR DESCRIPTION
## Summary
- harden recorder/debugger one-shot export fetch so attach works reliably regardless of session timing
- enforce a single 350ms debugger budget across connect, hello, request_export, and export stages with clearer stage-specific failures
- make recorder server writes resilient to Unix socket backpressure and add request_export integration coverage plus busy-export smoke coverage

## Test Plan
- [x] cargo fmt --all
- [x] cargo fmt --all -- --check
- [x] cargo test -p blinc_recorder
- [x] cargo test -p blinc_debugger --test connect_budget -- --nocapture
- [x] manual generated-app smoke for empty export, stale-socket restart, and non-empty busy export

## Residual Risk
- TCP hostname resolution still depends on std address resolution, so DNS lookup itself is only checked against the one-shot budget after resolution returns.