### PR TITLE
Improve native runtime readiness and token-driven cn defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ div()
 │  Brush/Color Types    │  Timelines           │  Asset Loading        │
 ├─────────────────────────────────────────────────────────────────────┤
 │     blinc_platform_desktop    │  blinc_platform_android  │   _ios   │
-│     winit + wgpu              │  NDK + Vulkan            │  UIKit   │
+│     winit + wgpu              │  NDK + JNI bridge        │  UIKit   │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -514,8 +514,8 @@ Easing::EaseOutBounce    // Bounce effect
 | macOS | Stable | wgpu (Metal) |
 | Windows | Stable | wgpu (DX12/Vulkan) |
 | Linux | Stable | wgpu (Vulkan) |
-| Android | Stable | wgpu (Vulkan), ~530KB |
-| iOS | Stable | wgpu (Metal) |
+| Android | Preview | NDK + JNI bridge |
+| iOS | Preview | UIKit + native bridge |
 | Fuschia | In progress | wgpu (Vulkan/Scenic) |
 | HarmonyOS | In progress | wgpu (Vulkan/OpenGL ES) |
 

--- a/crates/blinc_cn/README.md
+++ b/crates/blinc_cn/README.md
@@ -5,19 +5,15 @@
 > This crate is a component of Blinc, a GPU-accelerated UI framework for Rust.
 > For full documentation and guides, visit the [Blinc documentation](https://project-blinc.github.io/Blinc).
 
-Component library for Blinc UI - shadcn/ui-style themed components.
+Component library for Blinc UI with themed, token-driven components built on top of `blinc_layout`.
 
 ## Overview
 
-`blinc_cn` provides a comprehensive set of production-ready UI components built on top of `blinc_layout`. Inspired by [shadcn/ui](https://ui.shadcn.com/), it offers beautifully designed, accessible components with consistent theming.
-
-## Features
-
-- **40+ Components**: Buttons, cards, dialogs, menus, forms, and more
-- **Theme Integration**: Automatic dark/light mode support
-- **Variants & Sizes**: Multiple visual variants for each component
-- **Accessibility**: Keyboard navigation and ARIA support
-- **Customizable**: Override styles and behaviors as needed
+`blinc_cn` provides a broad set of reusable UI components on top of the Blinc theme system.
+It is best used with an explicit bootstrap step so theme tokens and component styles are available
+before the first render.
+The default stylesheet is now driven by semantic component tokens from `blinc_theme`, so presets
+control control sizing, container spacing, overlay chrome, and typography roles more consistently.
 
 ## Installation
 
@@ -27,17 +23,33 @@ blinc_cn = { path = "../blinc_cn" }
 blinc_theme = { path = "../blinc_theme" }
 ```
 
-## Use Theme Presets
+## Recommended Setup
 
-`blinc_cn` components read tokens from `blinc_theme::ThemeState`.
-Initialize `ThemeState` with a preset bundle once at app startup:
+Initialize theme state once at startup:
 
 ```rust
-use blinc_theme::{ColorScheme, ThemePreset, ThemeState};
+use blinc_cn::ensure_default_theme;
 
-fn init_theme() {
-    ThemeState::init(ThemePreset::Slate.bundle(), ColorScheme::Light);
+fn init_ui() {
+    ensure_default_theme();
 }
+```
+
+Or choose a specific preset:
+
+```rust
+use blinc_cn::ensure_theme;
+use blinc_theme::{ColorScheme, ThemePreset};
+
+fn init_ui() {
+    ensure_theme(ThemePreset::Slate.bundle(), ColorScheme::Light);
+}
+```
+
+When using CSS stylesheets in a `WindowedContext`, load the default component stylesheet once:
+
+```rust
+ctx.add_css(blinc_cn::default_styles());
 ```
 
 ## Quick Start
@@ -46,318 +58,116 @@ fn init_theme() {
 use blinc_cn::prelude::*;
 
 fn build_ui() -> impl ElementBuilder {
-    div()
-        .flex_col()
-        .gap(16.0)
-        .p(24.0)
+    card()
+        .w(360.0)
         .child(
-            card()
-                .child(card_header()
-                    .child(card_title("Welcome"))
-                    .child(card_description("Get started with Blinc")))
-                .child(card_content()
-                    .child(text("Your content here")))
-                .child(card_footer()
-                    .child(button("Continue").variant(ButtonVariant::Primary)))
+            card_header()
+                .title("Welcome")
+                .description("Get started with blinc_cn"),
+        )
+        .child(
+            card_content().child(
+                text("Theme-aware components with sensible defaults."),
+            ),
+        )
+        .child(
+            card_footer().child(
+                button("Continue").variant(ButtonVariant::Primary),
+            ),
         )
 }
 ```
 
-## Components
-
-### Buttons
+## Buttons
 
 ```rust
-// Variants
-button("Primary").variant(ButtonVariant::Primary)
-button("Secondary").variant(ButtonVariant::Secondary)
-button("Destructive").variant(ButtonVariant::Destructive)
+button("Primary")
 button("Outline").variant(ButtonVariant::Outline)
-button("Ghost").variant(ButtonVariant::Ghost)
-button("Link").variant(ButtonVariant::Link)
-
-// Sizes
-button("Small").size(ButtonSize::Sm)
-button("Default").size(ButtonSize::Default)
-button("Large").size(ButtonSize::Lg)
-button("Icon").size(ButtonSize::Icon)
-
-// With icon
-button("Settings").icon(icons::SETTINGS)
+button("Danger").variant(ButtonVariant::Destructive)
+button("Small").size(ButtonSize::Small)
+button("Large").size(ButtonSize::Large)
+button("").size(ButtonSize::Icon).icon(icons::SETTINGS)
 ```
 
-### Cards
+## Form Components
 
 ```rust
-card()
-    .child(card_header()
-        .child(card_title("Card Title"))
-        .child(card_description("Card description")))
-    .child(card_content()
-        .child(/* content */))
-    .child(card_footer()
-        .child(/* actions */))
-```
-
-### Dialogs
-
-```rust
-dialog()
-    .open(is_open)
-    .on_open_change(|open| println!("dialog open: {}", open))
-    .child(dialog_trigger()
-        .child(button("Open Dialog")))
-    .child(dialog_content()
-        .child(dialog_header()
-            .child(dialog_title("Dialog Title"))
-            .child(dialog_description("Dialog description")))
-        .child(/* content */)
-        .child(dialog_footer()
-            .child(button("Cancel").variant(ButtonVariant::Outline))
-            .child(button("Continue"))))
-```
-
-### Form Components
-
-```rust
-use blinc_layout::widgets::text_input::text_input_data;
 use blinc_layout::widgets::text_area::text_area_state;
+use blinc_layout::widgets::text_input::text_input_data;
 
 let email = text_input_data();
-let message = text_area_state();
+let notes = text_area_state();
 
-// Input
-input(&email)
-    .placeholder("Enter email...")
-    .on_change(|v| println!("email: {}", v))
-
-// Textarea
-textarea(&message)
-    .placeholder("Enter message...")
-    .rows(4)
-
-// Checkbox
-checkbox()
-    .checked(is_checked)
-    .on_change(|c| println!("checked: {}", c))
-    .child(label("Accept terms"))
-
-// Switch
-switch_()
-    .checked(is_enabled)
-    .on_change(|e| println!("enabled: {}", e))
-
-// Radio Group
-radio_group()
-    .value(selected)
-    .on_change(|v| println!("selected: {}", v))
-    .child(radio_item("option1").child(label("Option 1")))
-    .child(radio_item("option2").child(label("Option 2")))
-
-// Select
-select()
-    .value(selected)
-    .on_change(|v| println!("selected: {}", v))
-    .child(select_trigger()
-        .child(select_value()))
-    .child(select_content()
-        .child(select_item("opt1").child(text("Option 1")))
-        .child(select_item("opt2").child(text("Option 2"))))
-
-// Slider
-slider()
-    .value(volume)
-    .min(0.0)
-    .max(100.0)
-    .on_change(|v| println!("volume: {}", v))
-
-// Field + Form wrappers
 form()
-    .spacing(16.0)
+    .max_w(420.0)
     .child(
         field("Email")
             .required()
-            .child(input(&email).placeholder("name@example.com"))
+            .child(input(&email).placeholder("name@example.com")),
+    )
+    .child(
+        field("Notes")
+            .description("Optional")
+            .child(textarea(&notes).rows(4).placeholder("Write a short note")),
     )
 ```
 
-### Navigation
-
 ```rust
-// Tabs
-tabs()
-    .value(active_tab)
-    .on_change(|t| println!("active tab: {}", t))
-    .child(tabs_list()
-        .child(tabs_trigger("tab1").child(text("Tab 1")))
-        .child(tabs_trigger("tab2").child(text("Tab 2"))))
-    .child(tabs_content("tab1").child(/* content */))
-    .child(tabs_content("tab2").child(/* content */))
-
-// Dropdown Menu
-dropdown_menu()
-    .child(dropdown_menu_trigger()
-        .child(button("Menu")))
-    .child(dropdown_menu_content()
-        .child(dropdown_menu_item("edit").child(text("Edit")))
-        .child(dropdown_menu_separator())
-        .child(dropdown_menu_item("delete").child(text("Delete"))))
-
-// Breadcrumb
-breadcrumb()
-    .child(breadcrumb_list()
-        .child(breadcrumb_item().child(breadcrumb_link("Home")))
-        .child(breadcrumb_separator())
-        .child(breadcrumb_item().child(breadcrumb_link("Products")))
-        .child(breadcrumb_separator())
-        .child(breadcrumb_item().child(breadcrumb_page("Details"))))
-
-// Sidebar
-sidebar()
-    .child(sidebar_header()
-        .child(text("App Name")))
-    .child(sidebar_content()
-        .child(sidebar_group()
-            .child(sidebar_group_label("Menu"))
-            .child(sidebar_menu()
-                .child(sidebar_menu_item("Dashboard").icon(icons::HOME))
-                .child(sidebar_menu_item("Settings").icon(icons::SETTINGS)))))
+let enabled = blinc_core::State::new(false);
+switch(&enabled).on_change(|value| println!("enabled: {value}"));
 ```
 
-### Feedback
-
 ```rust
-// Alert
-alert()
-    .variant(AlertVariant::Destructive)
-    .child(alert_title("Error"))
-    .child(alert_description("Something went wrong"))
+let selected = blinc_core::State::new(String::new());
 
-// Badge
-badge("New").variant(BadgeVariant::Default)
-badge("Beta").variant(BadgeVariant::Secondary)
-
-// Progress
-progress().value(75.0)
-
-// Spinner
-spinner().size(SpinnerSize::Lg)
-
-// Skeleton
-skeleton().w(200.0).h(20.0)
-
-// Toast
-toast()
-    .title("Success")
-    .description("Your changes have been saved")
-    .variant(ToastVariant::Success)
+select(&selected)
+    .label("Framework")
+    .placeholder("Choose one")
+    .option("react", "React")
+    .option("svelte", "Svelte")
+    .on_change(|value| println!("selected: {value}"));
 ```
 
-### Layout
+## Dialogs
+
+`dialog()` and `alert_dialog()` are imperative builders that display overlays with `.show()`.
 
 ```rust
-// Avatar
-avatar()
-    .src("user.jpg")
-    .fallback("JD")
-    .size(AvatarSize::Lg)
-
-// Avatar Group
-avatar_group()
-    .max(3)
-    .child(avatar().src("user1.jpg"))
-    .child(avatar().src("user2.jpg"))
-    .child(avatar().src("user3.jpg"))
-    .child(avatar().src("user4.jpg"))
-
-// Separator
-separator().orientation(Orientation::Horizontal)
-
-// Aspect Ratio
-aspect_ratio(16.0 / 9.0)
-    .child(img("video-thumbnail.jpg"))
-
-// Scroll Area
-scroll_area()
-    .h(400.0)
-    .child(/* scrollable content */)
-
-// Collapsible
-collapsible()
-    .open(is_open)
-    .child(collapsible_trigger()
-        .child(button("Toggle")))
-    .child(collapsible_content()
-        .child(/* hidden content */))
-
-// Accordion
-accordion()
-    .child(accordion_item("item1")
-        .child(accordion_trigger().child(text("Section 1")))
-        .child(accordion_content().child(text("Content 1"))))
+button("Open Dialog").on_click(|_| {
+    dialog()
+        .title("Confirm")
+        .description("Apply these changes?")
+        .confirm_text("Apply")
+        .on_confirm(|| println!("confirmed"))
+        .show();
+});
 ```
 
-### Data Display
+## Navigation
 
 ```rust
-// Tooltip
-tooltip()
-    .child(tooltip_trigger()
-        .child(button("Hover me")))
-    .child(tooltip_content()
-        .child(text("Tooltip text")))
+let tab_state = blinc_core::State::new(String::new());
 
-// Hover Card
-hover_card()
-    .child(hover_card_trigger()
-        .child(text("@username")))
-    .child(hover_card_content()
-        .child(/* user profile card */))
-
-// Popover
-popover()
-    .child(popover_trigger()
-        .child(button("Open")))
-    .child(popover_content()
-        .child(/* popover content */))
-
-// Charts
-chart()
-    .chart_type(ChartType::Line)
-    .data(&data_points)
-    .x_axis("Date")
-    .y_axis("Value")
+tabs(&tab_state)
+    .tab("account", "Account", || div().child(text("Account settings")))
+    .tab("billing", "Billing", || div().child(text("Billing settings")));
 ```
-
-## Theming
-
-Components automatically use theme tokens:
 
 ```rust
-use blinc_theme::ThemeState;
+let collapsed = blinc_core::State::new(false);
 
-// Set theme
-ThemeState::set_color_scheme(ColorScheme::Dark);
-
-// Components automatically update
-button("Themed Button") // Uses theme colors
+sidebar(&collapsed)
+    .section("Main")
+    .item_active("Dashboard", icons::HOME, || {})
+    .item("Settings", icons::SETTINGS, || {});
 ```
 
-## Component List
+## Components
 
-| Category | Components |
-|----------|------------|
-| **Buttons** | Button |
-| **Cards** | Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter |
-| **Dialogs** | Dialog, AlertDialog, Sheet, Drawer |
-| **Forms** | Input, Textarea, Checkbox, Switch, Radio, Select, Combobox, Slider |
-| **Navigation** | Tabs, DropdownMenu, ContextMenu, Menubar, NavigationMenu, Breadcrumb, Pagination, Sidebar |
-| **Feedback** | Alert, Badge, Progress, Spinner, Skeleton, Toast |
-| **Layout** | Avatar, Separator, AspectRatio, ScrollArea, Collapsible, Accordion, Resizable |
-| **Data** | Tooltip, HoverCard, Popover, Chart, Tree |
-| **Typography** | Typography (H1-H6, P, Blockquote, etc.) |
-| **Misc** | Icon, Kbd, Label |
-
-## License
-
-MIT OR Apache-2.0
+- Buttons: `button`
+- Cards: `card`, `card_header`, `card_content`, `card_footer`
+- Feedback: `alert`, `badge`, `progress`, `spinner`, `skeleton`, `toast`
+- Forms: `input`, `textarea`, `checkbox`, `switch`, `radio_group`, `select`, `combobox`, `slider`, `field`, `form`
+- Navigation: `tabs`, `dropdown_menu`, `context_menu`, `breadcrumb`, `sidebar`, `navigation_menu`, `pagination`, `menubar`
+- Overlays: `dialog`, `alert_dialog`, `sheet`, `drawer`, `tooltip`, `popover`, `hover_card`
+- Layout and display: `avatar`, `separator`, `scroll_area`, `accordion`, `aspect_ratio`, `chart`, `tree_view`

--- a/crates/blinc_cn/README.md
+++ b/crates/blinc_cn/README.md
@@ -13,7 +13,8 @@ Component library for Blinc UI with themed, token-driven components built on top
 It is best used with an explicit bootstrap step so theme tokens and component styles are available
 before the first render.
 The default stylesheet is now driven by semantic component tokens from `blinc_theme`, so presets
-control control sizing, container spacing, overlay chrome, and typography roles more consistently.
+control sizing, container spacing, overlay chrome, typography roles, and newer CSS defaults such as
+`corner-shape`, `backdrop-filter`, truncation, and CSS link decoration more consistently.
 
 ## Installation
 

--- a/crates/blinc_cn/src/cn_styles.rs
+++ b/crates/blinc_cn/src/cn_styles.rs
@@ -24,23 +24,50 @@
 /// Each component defines `var(--cn-component-prop, var(--fallback))` for overridability.
 pub const CN_STYLES: &str = r#"
 /* ============================================================================
+   Utilities
+   ============================================================================ */
+
+.cn-truncate {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.cn-decorative {
+    pointer-events: none;
+    cursor: default;
+}
+
+/* ============================================================================
    Button
    ============================================================================ */
 
 /* Button: visual states (hover, active, disabled) handled by Stateful FSM.
    CSS defines border-radius and padding per size. User CSS can override these classes. */
-.cn-button { border-radius: var(--cn-button-radius, var(--control-radius-md)); }
+.cn-button {
+    border-radius: var(--cn-button-radius, var(--control-radius-md));
+    corner-shape: var(--cn-button-corner-shape, var(--control-corner-shape));
+    transition: corner-shape 180ms, box-shadow 180ms;
+}
+.cn-button:hover {
+    corner-shape: var(--cn-button-corner-shape-hover, var(--control-corner-shape-hover));
+}
 .cn-button--primary { }
 .cn-button--secondary { }
 .cn-button--destructive { }
 .cn-button--outline { }
 .cn-button--ghost { }
-.cn-button--link { }
+.cn-button--link {
+    text-decoration: underline;
+    text-decoration-color: var(--primary);
+    text-decoration-thickness: 1.5px;
+}
 .cn-button--disabled { }
 .cn-button--sm { border-radius: var(--cn-button-radius-sm, var(--control-radius-sm)); }
 .cn-button--md { border-radius: var(--cn-button-radius-md, var(--control-radius-md)); }
 .cn-button--lg { border-radius: var(--cn-button-radius-lg, var(--control-radius-lg)); }
 .cn-button--icon { border-radius: var(--cn-button-radius-icon, var(--control-radius-md)); }
+.cn-button__label { max-width: 100%; }
 
 /* ============================================================================
    Card
@@ -52,6 +79,8 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-card-radius, var(--container-radius));
     padding: var(--cn-card-padding, var(--container-padding));
     gap: var(--cn-card-gap, var(--container-section-gap));
+    corner-shape: var(--cn-card-corner-shape, var(--container-corner-shape));
+    transition: corner-shape 180ms, box-shadow 180ms;
 }
 
 .cn-card-header {
@@ -70,6 +99,7 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-badge-radius, var(--compact-badge-radius));
     font-size: var(--cn-badge-font-size, var(--type-badge));
     padding: var(--cn-badge-py, var(--compact-badge-py)) var(--cn-badge-px, var(--compact-badge-px));
+    corner-shape: var(--cn-badge-corner-shape, 2);
 }
 .cn-badge--default {
     background: var(--primary);
@@ -108,6 +138,7 @@ pub const CN_STYLES: &str = r#"
     color: var(--text-primary);
     font-size: var(--cn-alert-font-size, var(--type-body-md));
     padding: var(--cn-alert-padding, var(--container-padding-compact));
+    corner-shape: var(--cn-alert-corner-shape, var(--container-corner-shape));
 }
 .cn-alert-box {
     background: var(--cn-alert-bg, var(--surface));
@@ -117,6 +148,7 @@ pub const CN_STYLES: &str = r#"
     font-size: var(--cn-alert-font-size, var(--type-body-md));
     padding: var(--cn-alert-padding, var(--container-padding-compact));
     gap: var(--cn-alert-gap, var(--overlay-gap));
+    corner-shape: var(--cn-alert-corner-shape, var(--container-corner-shape));
 }
 .cn-alert--success {
     background: var(--success-bg);
@@ -154,6 +186,8 @@ pub const CN_STYLES: &str = r#"
 .cn-skeleton {
     background: var(--cn-skeleton-bg, var(--surface-elevated));
     border-radius: var(--cn-skeleton-radius, var(--control-radius-sm));
+    corner-shape: var(--cn-skeleton-corner-shape, var(--control-corner-shape));
+    mix-blend-mode: overlay;
 }
 
 /* ============================================================================
@@ -165,14 +199,18 @@ pub const CN_STYLES: &str = r#"
     border: 1px solid var(--cn-input-border, var(--border));
     border-radius: var(--cn-input-radius, var(--control-radius-md));
     color: var(--text-primary);
+    corner-shape: var(--cn-input-corner-shape, var(--control-corner-shape));
+    transition: border-color 150ms, background 150ms, corner-shape 180ms;
 }
 .cn-input:hover {
     border-color: var(--border-hover);
     background: var(--input-bg-hover);
+    corner-shape: var(--cn-input-corner-shape-hover, var(--control-corner-shape-hover));
 }
 .cn-input:focus {
     border-color: var(--border-focus);
     background: var(--input-bg-focus);
+    corner-shape: var(--cn-input-corner-shape-hover, var(--control-corner-shape-hover));
 }
 .cn-input--error {
     border-color: var(--border-error);
@@ -191,14 +229,18 @@ pub const CN_STYLES: &str = r#"
     border: 1px solid var(--cn-textarea-border, var(--border));
     border-radius: var(--cn-textarea-radius, var(--control-radius-md));
     color: var(--text-primary);
+    corner-shape: var(--cn-textarea-corner-shape, var(--control-corner-shape));
+    transition: border-color 150ms, background 150ms, corner-shape 180ms;
 }
 .cn-textarea:hover {
     border-color: var(--border-hover);
     background: var(--input-bg-hover);
+    corner-shape: var(--cn-textarea-corner-shape-hover, var(--control-corner-shape-hover));
 }
 .cn-textarea:focus {
     border-color: var(--border-focus);
     background: var(--input-bg-focus);
+    corner-shape: var(--cn-textarea-corner-shape-hover, var(--control-corner-shape-hover));
 }
 
 /* ============================================================================
@@ -221,6 +263,7 @@ pub const CN_STYLES: &str = r#"
     border-color: var(--cn-kbd-border, var(--border));
     border-radius: var(--cn-kbd-radius, var(--compact-kbd-radius));
     color: var(--text-secondary);
+    corner-shape: var(--cn-kbd-corner-shape, 1.2);
 }
 
 /* ============================================================================
@@ -233,6 +276,7 @@ pub const CN_STYLES: &str = r#"
     background: var(--cn-checkbox-bg, var(--input-bg));
     cursor: pointer;
     transition: background 150ms, border-color 150ms, transform 100ms;
+    corner-shape: var(--cn-checkbox-corner-shape, var(--control-corner-shape));
 }
 .cn-checkbox:hover {
     border-color: var(--border-hover);
@@ -307,16 +351,19 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-tabs-list-radius, var(--container-radius));
     padding: var(--cn-tabs-list-padding, var(--overlay-gap));
     gap: var(--cn-tabs-list-gap, var(--overlay-gap));
+    corner-shape: var(--cn-tabs-list-corner-shape, var(--container-corner-shape));
 }
 .cn-tabs-trigger {
     border-radius: var(--cn-tabs-trigger-radius, var(--control-radius-md));
     cursor: pointer;
     color: var(--text-secondary);
-    transition: background 150ms, color 150ms;
+    corner-shape: var(--cn-tabs-trigger-corner-shape, var(--control-corner-shape));
+    transition: background 150ms, color 150ms, corner-shape 180ms;
 }
 .cn-tabs-trigger:hover {
     color: var(--text-primary);
     background: var(--surface-overlay);
+    corner-shape: var(--cn-tabs-trigger-corner-shape-hover, var(--control-corner-shape-hover));
 }
 .cn-tabs-trigger--active {
     background: var(--cn-tabs-active-bg, var(--background));
@@ -342,11 +389,13 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-select-trigger-radius, var(--control-radius-md));
     cursor: pointer;
     color: var(--text-primary);
-    transition: border-color 150ms, background 150ms;
+    corner-shape: var(--cn-select-trigger-corner-shape, var(--control-corner-shape));
+    transition: border-color 150ms, background 150ms, corner-shape 180ms;
 }
 .cn-select-trigger:hover {
     border-color: var(--border-hover);
     background: var(--input-bg-hover);
+    corner-shape: var(--cn-select-trigger-corner-shape-hover, var(--control-corner-shape-hover));
 }
 
 .cn-select-content {
@@ -355,6 +404,8 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-select-content-radius, var(--overlay-radius));
     padding: var(--cn-select-content-py, var(--overlay-gap));
     box-shadow: var(--cn-select-shadow, var(--overlay-shadow));
+    corner-shape: var(--cn-select-content-corner-shape, var(--overlay-corner-shape));
+    backdrop-filter: glass;
 }
 
 .cn-select-item {
@@ -362,14 +413,17 @@ pub const CN_STYLES: &str = r#"
     cursor: pointer;
     color: var(--text-primary);
     border-radius: var(--cn-select-item-radius, var(--control-radius-sm));
-    transition: background 100ms;
+    corner-shape: var(--cn-select-item-corner-shape, var(--control-corner-shape));
+    transition: background 100ms, corner-shape 180ms;
 }
 .cn-select-item:hover {
     background: var(--surface-elevated);
+    corner-shape: var(--cn-select-item-corner-shape-hover, var(--control-corner-shape-hover));
 }
 .cn-select-item--selected {
     background: var(--surface-elevated);
 }
+.cn-select-value { max-width: 100%; }
 
 /* ============================================================================
    Slider
@@ -440,6 +494,7 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-tooltip-radius, var(--control-radius-sm));
     font-size: var(--cn-tooltip-font-size, var(--type-helper));
     padding: var(--cn-tooltip-py, var(--overlay-item-py)) var(--cn-tooltip-px, var(--overlay-item-px));
+    corner-shape: var(--cn-tooltip-corner-shape, var(--control-corner-shape));
 }
 
 /* ============================================================================
@@ -452,6 +507,8 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-dialog-radius, var(--container-radius));
     padding: var(--cn-dialog-padding, var(--container-padding));
     gap: var(--cn-dialog-gap, var(--container-section-gap));
+    corner-shape: var(--cn-dialog-corner-shape, var(--overlay-corner-shape));
+    backdrop-filter: glass;
 }
 
 /* ============================================================================
@@ -461,6 +518,8 @@ pub const CN_STYLES: &str = r#"
 .cn-drawer {
     background: var(--cn-drawer-bg, var(--surface));
     border: 1px solid var(--cn-drawer-border, var(--border));
+    corner-shape: var(--cn-drawer-corner-shape, var(--overlay-corner-shape));
+    backdrop-filter: glass;
 }
 .cn-drawer-header {
     border-bottom: 1px solid var(--border);
@@ -477,6 +536,8 @@ pub const CN_STYLES: &str = r#"
 .cn-sheet {
     background: var(--cn-sheet-bg, var(--surface));
     border: 1px solid var(--cn-sheet-border, var(--border));
+    corner-shape: var(--cn-sheet-corner-shape, var(--overlay-corner-shape));
+    backdrop-filter: glass;
 }
 
 /* ============================================================================
@@ -488,6 +549,8 @@ pub const CN_STYLES: &str = r#"
     border: 1px solid var(--cn-toast-border, var(--border));
     border-radius: var(--cn-toast-radius, var(--container-radius));
     color: var(--text-primary);
+    corner-shape: var(--cn-toast-corner-shape, var(--overlay-corner-shape));
+    backdrop-filter: glass;
 }
 .cn-toast--success {
     border-left: 4px solid var(--success);
@@ -510,12 +573,14 @@ pub const CN_STYLES: &str = r#"
     background: var(--cn-accordion-bg, var(--surface-elevated));
     border: 1.5px solid var(--cn-accordion-border, var(--border));
     border-radius: var(--cn-accordion-radius, var(--container-radius));
+    corner-shape: var(--cn-accordion-corner-shape, var(--container-corner-shape));
 }
 .cn-accordion-trigger {
     padding: var(--cn-accordion-trigger-py, var(--overlay-item-py)) var(--cn-accordion-trigger-px, var(--overlay-item-px));
     cursor: pointer;
     color: var(--text-primary);
     font-size: var(--cn-accordion-trigger-font-size, var(--type-action-md));
+    text-overflow: ellipsis;
 }
 .cn-accordion-trigger:hover {
     background: var(--surface-overlay);
@@ -537,13 +602,19 @@ pub const CN_STYLES: &str = r#"
 .cn-breadcrumb-item {
     color: var(--text-secondary);
     cursor: pointer;
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    text-decoration-thickness: 1.5px;
 }
 .cn-breadcrumb-item:hover {
     color: var(--text-primary);
+    text-decoration-color: var(--primary);
 }
 .cn-breadcrumb-item--active {
     color: var(--text-primary);
+    text-decoration-color: var(--primary);
 }
+.cn-breadcrumb-label { max-width: 100%; }
 
 /* ============================================================================
    Pagination
@@ -557,10 +628,12 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-pagination-radius, var(--control-radius-md));
     cursor: pointer;
     color: var(--text-primary);
-    transition: background 150ms;
+    corner-shape: var(--cn-pagination-corner-shape, var(--control-corner-shape));
+    transition: background 150ms, corner-shape 180ms;
 }
 .cn-pagination-btn:hover {
     background: var(--surface-elevated);
+    corner-shape: var(--cn-pagination-corner-shape-hover, var(--control-corner-shape-hover));
 }
 .cn-pagination-btn--active {
     background: var(--primary);
@@ -584,16 +657,22 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-nav-link-radius, var(--control-radius-md));
     cursor: pointer;
     color: var(--text-secondary);
-    transition: background 150ms, color 150ms;
+    corner-shape: var(--cn-nav-link-corner-shape, var(--control-corner-shape));
+    transition: background 150ms, color 150ms, corner-shape 180ms;
 }
 .cn-nav-link:hover {
     background: var(--surface-elevated);
     color: var(--text-primary);
+    corner-shape: var(--cn-nav-link-corner-shape-hover, var(--control-corner-shape-hover));
 }
 .cn-nav-link--active {
     background: var(--surface-elevated);
     color: var(--text-primary);
+    text-decoration: underline;
+    text-decoration-color: var(--primary);
+    text-decoration-thickness: 1.5px;
 }
+.cn-nav-link__label { max-width: 100%; }
 
 /* ============================================================================
    Sidebar
@@ -608,16 +687,19 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-sidebar-item-radius, var(--control-radius-md));
     cursor: pointer;
     color: var(--text-secondary);
-    transition: background 150ms, color 150ms;
+    corner-shape: var(--cn-sidebar-item-corner-shape, var(--control-corner-shape));
+    transition: background 150ms, color 150ms, corner-shape 180ms;
 }
 .cn-sidebar-item:hover {
     background: var(--surface-elevated);
     color: var(--text-primary);
+    corner-shape: var(--cn-sidebar-item-corner-shape-hover, var(--control-corner-shape-hover));
 }
 .cn-sidebar-item--active {
     background: var(--primary);
     color: var(--text-inverse);
 }
+.cn-sidebar-item__label { max-width: 100%; }
 
 /* ============================================================================
    Scroll Area
@@ -637,6 +719,8 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-dropdown-radius, var(--overlay-radius));
     padding: var(--cn-dropdown-padding, var(--overlay-gap));
     box-shadow: var(--cn-dropdown-shadow, var(--overlay-shadow));
+    corner-shape: var(--cn-dropdown-corner-shape, var(--overlay-corner-shape));
+    backdrop-filter: glass;
 }
 .cn-dropdown-item {
     padding: var(--cn-dropdown-item-py, var(--overlay-item-py)) var(--cn-dropdown-item-px, var(--overlay-item-px));
@@ -644,10 +728,12 @@ pub const CN_STYLES: &str = r#"
     cursor: pointer;
     color: var(--text-primary);
     font-size: var(--cn-dropdown-font-size, var(--type-body-md));
-    transition: background 100ms;
+    corner-shape: var(--cn-dropdown-item-corner-shape, var(--control-corner-shape));
+    transition: background 100ms, corner-shape 180ms;
 }
 .cn-dropdown-item:hover {
     background: var(--surface-elevated);
+    corner-shape: var(--cn-dropdown-item-corner-shape-hover, var(--control-corner-shape-hover));
 }
 .cn-dropdown-item--disabled {
     opacity: 0.5;
@@ -655,6 +741,12 @@ pub const CN_STYLES: &str = r#"
 }
 .cn-dropdown-item--destructive {
     color: var(--error);
+}
+.cn-dropdown-item__label { max-width: 100%; }
+.cn-menu-shortcut {
+    text-decoration: underline;
+    text-decoration-color: var(--text-tertiary);
+    text-decoration-thickness: 1px;
 }
 
 /* ============================================================================
@@ -667,6 +759,8 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-context-menu-radius, var(--overlay-radius));
     padding: var(--cn-context-menu-padding, var(--overlay-gap));
     box-shadow: var(--cn-context-menu-shadow, var(--overlay-shadow));
+    corner-shape: var(--cn-context-menu-corner-shape, var(--overlay-corner-shape));
+    backdrop-filter: glass;
 }
 .cn-context-menu-item {
     padding: var(--cn-context-menu-item-py, var(--overlay-item-py)) var(--cn-context-menu-item-px, var(--overlay-item-px));
@@ -674,11 +768,14 @@ pub const CN_STYLES: &str = r#"
     cursor: pointer;
     color: var(--text-primary);
     font-size: var(--cn-context-menu-font-size, var(--type-body-md));
-    transition: background 100ms;
+    corner-shape: var(--cn-context-menu-item-corner-shape, var(--control-corner-shape));
+    transition: background 100ms, corner-shape 180ms;
 }
 .cn-context-menu-item:hover {
     background: var(--surface-elevated);
+    corner-shape: var(--cn-context-menu-item-corner-shape-hover, var(--control-corner-shape-hover));
 }
+.cn-context-menu-item__label { max-width: 100%; }
 
 /* ============================================================================
    Menubar
@@ -690,6 +787,8 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-menubar-radius, var(--overlay-radius));
     padding: var(--cn-menubar-padding, var(--overlay-gap));
     gap: var(--cn-menubar-gap, var(--overlay-gap));
+    corner-shape: var(--cn-menubar-corner-shape, var(--overlay-corner-shape));
+    backdrop-filter: glass;
 }
 .cn-menubar-trigger {
     padding: var(--cn-menubar-trigger-py, var(--overlay-item-py)) var(--cn-menubar-trigger-px, var(--overlay-item-px));
@@ -697,11 +796,14 @@ pub const CN_STYLES: &str = r#"
     cursor: pointer;
     color: var(--text-primary);
     font-size: var(--cn-menubar-font-size, var(--type-action-md));
-    transition: background 100ms;
+    corner-shape: var(--cn-menubar-trigger-corner-shape, var(--control-corner-shape));
+    transition: background 100ms, corner-shape 180ms;
 }
 .cn-menubar-trigger:hover {
     background: var(--surface-elevated);
+    corner-shape: var(--cn-menubar-trigger-corner-shape-hover, var(--control-corner-shape-hover));
 }
+.cn-menubar-trigger__label { max-width: 100%; }
 
 /* ============================================================================
    Popover
@@ -713,6 +815,8 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-popover-radius, var(--overlay-radius));
     padding: var(--cn-popover-padding, var(--container-padding-compact));
     box-shadow: var(--cn-popover-shadow, var(--overlay-shadow));
+    corner-shape: var(--cn-popover-corner-shape, var(--overlay-corner-shape));
+    backdrop-filter: glass;
 }
 
 /* ============================================================================
@@ -725,6 +829,8 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-hover-card-radius, var(--overlay-radius));
     padding: var(--cn-hover-card-padding, var(--container-padding-compact));
     box-shadow: var(--cn-hover-card-shadow, var(--overlay-shadow));
+    corner-shape: var(--cn-hover-card-corner-shape, var(--overlay-corner-shape));
+    backdrop-filter: glass;
 }
 
 /* ============================================================================
@@ -736,10 +842,12 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-tree-node-radius, var(--control-radius-sm));
     cursor: pointer;
     color: var(--text-primary);
-    transition: background 100ms;
+    corner-shape: var(--cn-tree-node-corner-shape, var(--control-corner-shape));
+    transition: background 100ms, corner-shape 180ms;
 }
 .cn-tree-node:hover {
     background: var(--surface-elevated);
+    corner-shape: var(--cn-tree-node-corner-shape-hover, var(--control-corner-shape-hover));
 }
 .cn-tree-node--selected {
     background: var(--primary);
@@ -777,10 +885,12 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-combobox-trigger-radius, var(--control-radius-md));
     cursor: pointer;
     color: var(--text-primary);
-    transition: border-color 150ms;
+    corner-shape: var(--cn-combobox-trigger-corner-shape, var(--control-corner-shape));
+    transition: border-color 150ms, background 150ms, corner-shape 180ms;
 }
 .cn-combobox-trigger:hover {
     border-color: var(--border-hover);
+    corner-shape: var(--cn-combobox-trigger-corner-shape-hover, var(--control-corner-shape-hover));
 }
 .cn-combobox-content {
     background: var(--surface);
@@ -788,15 +898,21 @@ pub const CN_STYLES: &str = r#"
     border-radius: var(--cn-combobox-content-radius, var(--overlay-radius));
     padding: var(--cn-combobox-content-py, var(--overlay-gap));
     box-shadow: var(--cn-combobox-shadow, var(--overlay-shadow));
+    corner-shape: var(--cn-combobox-content-corner-shape, var(--overlay-corner-shape));
+    backdrop-filter: glass;
 }
 .cn-combobox-item {
     padding: var(--cn-combobox-item-py, var(--overlay-item-py)) var(--cn-combobox-item-px, var(--overlay-item-px));
     cursor: pointer;
     color: var(--text-primary);
     border-radius: var(--cn-combobox-item-radius, var(--control-radius-sm));
-    transition: background 100ms;
+    corner-shape: var(--cn-combobox-item-corner-shape, var(--control-corner-shape));
+    transition: background 100ms, corner-shape 180ms;
 }
 .cn-combobox-item:hover {
     background: var(--surface-elevated);
+    corner-shape: var(--cn-combobox-item-corner-shape-hover, var(--control-corner-shape-hover));
 }
+.cn-combobox-value { max-width: 100%; }
+.cn-combobox-item__label { max-width: 100%; }
 "#;

--- a/crates/blinc_cn/src/cn_styles.rs
+++ b/crates/blinc_cn/src/cn_styles.rs
@@ -29,7 +29,7 @@ pub const CN_STYLES: &str = r#"
 
 /* Button: visual states (hover, active, disabled) handled by Stateful FSM.
    CSS defines border-radius and padding per size. User CSS can override these classes. */
-.cn-button { border-radius: 6px; }
+.cn-button { border-radius: var(--cn-button-radius, var(--control-radius-md)); }
 .cn-button--primary { }
 .cn-button--secondary { }
 .cn-button--destructive { }
@@ -37,10 +37,10 @@ pub const CN_STYLES: &str = r#"
 .cn-button--ghost { }
 .cn-button--link { }
 .cn-button--disabled { }
-.cn-button--sm { border-radius: 4px; }
-.cn-button--md { border-radius: 6px; }
-.cn-button--lg { border-radius: 8px; }
-.cn-button--icon { border-radius: 6px; }
+.cn-button--sm { border-radius: var(--cn-button-radius-sm, var(--control-radius-sm)); }
+.cn-button--md { border-radius: var(--cn-button-radius-md, var(--control-radius-md)); }
+.cn-button--lg { border-radius: var(--cn-button-radius-lg, var(--control-radius-lg)); }
+.cn-button--icon { border-radius: var(--cn-button-radius-icon, var(--control-radius-md)); }
 
 /* ============================================================================
    Card
@@ -49,17 +49,17 @@ pub const CN_STYLES: &str = r#"
 .cn-card {
     background: var(--cn-card-bg, var(--surface));
     border: 1px solid var(--cn-card-border, var(--border));
-    border-radius: var(--cn-card-radius, 12px);
-    padding: 24px;
-    gap: 16px;
+    border-radius: var(--cn-card-radius, var(--container-radius));
+    padding: var(--cn-card-padding, var(--container-padding));
+    gap: var(--cn-card-gap, var(--container-section-gap));
 }
 
 .cn-card-header {
-    gap: 6px;
+    gap: var(--cn-card-header-gap, var(--container-header-gap));
 }
 
 .cn-card-footer {
-    gap: 8px;
+    gap: var(--cn-card-footer-gap, var(--container-footer-gap));
 }
 
 /* ============================================================================
@@ -67,9 +67,9 @@ pub const CN_STYLES: &str = r#"
    ============================================================================ */
 
 .cn-badge {
-    border-radius: 9999px;
-    font-size: 12px;
-    padding: 2px 10px;
+    border-radius: var(--cn-badge-radius, var(--compact-badge-radius));
+    font-size: var(--cn-badge-font-size, var(--type-badge));
+    padding: var(--cn-badge-py, var(--compact-badge-py)) var(--cn-badge-px, var(--compact-badge-px));
 }
 .cn-badge--default {
     background: var(--primary);
@@ -104,19 +104,19 @@ pub const CN_STYLES: &str = r#"
 .cn-alert {
     background: var(--cn-alert-bg, var(--surface));
     border: 1px solid var(--cn-alert-border, var(--border));
-    border-radius: 6px;
+    border-radius: var(--cn-alert-radius, var(--container-radius));
     color: var(--text-primary);
-    font-size: 14px;
-    padding: 16px;
+    font-size: var(--cn-alert-font-size, var(--type-body-md));
+    padding: var(--cn-alert-padding, var(--container-padding-compact));
 }
 .cn-alert-box {
     background: var(--cn-alert-bg, var(--surface));
     border: 1px solid var(--cn-alert-border, var(--border));
-    border-radius: 6px;
+    border-radius: var(--cn-alert-radius, var(--container-radius));
     color: var(--text-primary);
-    font-size: 14px;
-    padding: 16px;
-    gap: 12px;
+    font-size: var(--cn-alert-font-size, var(--type-body-md));
+    padding: var(--cn-alert-padding, var(--container-padding-compact));
+    gap: var(--cn-alert-gap, var(--overlay-gap));
 }
 .cn-alert--success {
     background: var(--success-bg);
@@ -153,7 +153,7 @@ pub const CN_STYLES: &str = r#"
 
 .cn-skeleton {
     background: var(--cn-skeleton-bg, var(--surface-elevated));
-    border-radius: 4px;
+    border-radius: var(--cn-skeleton-radius, var(--control-radius-sm));
 }
 
 /* ============================================================================
@@ -163,7 +163,7 @@ pub const CN_STYLES: &str = r#"
 .cn-input {
     background: var(--cn-input-bg, var(--input-bg));
     border: 1px solid var(--cn-input-border, var(--border));
-    border-radius: 6px;
+    border-radius: var(--cn-input-radius, var(--control-radius-md));
     color: var(--text-primary);
 }
 .cn-input:hover {
@@ -178,9 +178,9 @@ pub const CN_STYLES: &str = r#"
     border-color: var(--border-error);
 }
 
-.cn-input--sm { font-size: 12px; }
-.cn-input--md { font-size: 14px; }
-.cn-input--lg { font-size: 16px; }
+.cn-input--sm { font-size: var(--cn-input-font-size-sm, var(--type-body-sm)); }
+.cn-input--md { font-size: var(--cn-input-font-size-md, var(--type-body-md)); }
+.cn-input--lg { font-size: var(--cn-input-font-size-lg, var(--type-body-lg)); }
 
 /* ============================================================================
    Textarea
@@ -189,7 +189,7 @@ pub const CN_STYLES: &str = r#"
 .cn-textarea {
     background: var(--cn-textarea-bg, var(--input-bg));
     border: 1px solid var(--cn-textarea-border, var(--border));
-    border-radius: 6px;
+    border-radius: var(--cn-textarea-radius, var(--control-radius-md));
     color: var(--text-primary);
 }
 .cn-textarea:hover {
@@ -219,7 +219,7 @@ pub const CN_STYLES: &str = r#"
 .cn-kbd {
     background: var(--cn-kbd-bg, var(--surface));
     border-color: var(--cn-kbd-border, var(--border));
-    border-radius: 4px;
+    border-radius: var(--cn-kbd-radius, var(--compact-kbd-radius));
     color: var(--text-secondary);
 }
 
@@ -229,7 +229,7 @@ pub const CN_STYLES: &str = r#"
 
 .cn-checkbox {
     border: 2px solid var(--cn-checkbox-border, var(--border));
-    border-radius: 4px;
+    border-radius: var(--cn-checkbox-radius, var(--control-radius-sm));
     background: var(--cn-checkbox-bg, var(--input-bg));
     cursor: pointer;
     transition: background 150ms, border-color 150ms, transform 100ms;
@@ -304,12 +304,12 @@ pub const CN_STYLES: &str = r#"
 
 .cn-tabs-list {
     background: var(--cn-tabs-list-bg, var(--surface-elevated));
-    border-radius: 8px;
-    padding: 4px;
-    gap: 4px;
+    border-radius: var(--cn-tabs-list-radius, var(--container-radius));
+    padding: var(--cn-tabs-list-padding, var(--overlay-gap));
+    gap: var(--cn-tabs-list-gap, var(--overlay-gap));
 }
 .cn-tabs-trigger {
-    border-radius: 6px;
+    border-radius: var(--cn-tabs-trigger-radius, var(--control-radius-md));
     cursor: pointer;
     color: var(--text-secondary);
     transition: background 150ms, color 150ms;
@@ -328,37 +328,40 @@ pub const CN_STYLES: &str = r#"
     cursor: not-allowed;
 }
 
-.cn-tabs-trigger--sm { height: 32px; padding: 4px 12px; font-size: 13px; }
-.cn-tabs-trigger--md { height: 40px; padding: 8px 16px; font-size: 14px; }
-.cn-tabs-trigger--lg { height: 48px; padding: 12px 20px; font-size: 16px; }
+.cn-tabs-trigger--sm { height: var(--control-height-sm); padding: var(--control-py-sm) var(--control-px-sm); font-size: var(--type-action-sm); }
+.cn-tabs-trigger--md { height: var(--control-height-md); padding: var(--control-py-md) var(--control-px-md); font-size: var(--type-action-md); }
+.cn-tabs-trigger--lg { height: var(--control-height-lg); padding: var(--control-py-lg) var(--control-px-lg); font-size: var(--type-action-lg); }
 
 /* ============================================================================
    Select
    ============================================================================ */
 
 .cn-select-trigger {
-    background: var(--cn-select-bg, var(--surface));
+    background: var(--cn-select-bg, var(--input-bg));
     border: 1px solid var(--cn-select-border, var(--border));
-    border-radius: 6px;
+    border-radius: var(--cn-select-trigger-radius, var(--control-radius-md));
     cursor: pointer;
     color: var(--text-primary);
-    transition: border-color 150ms;
+    transition: border-color 150ms, background 150ms;
 }
 .cn-select-trigger:hover {
     border-color: var(--border-hover);
+    background: var(--input-bg-hover);
 }
 
 .cn-select-content {
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 8px;
+    border-radius: var(--cn-select-content-radius, var(--overlay-radius));
+    padding: var(--cn-select-content-py, var(--overlay-gap));
+    box-shadow: var(--cn-select-shadow, var(--overlay-shadow));
 }
 
 .cn-select-item {
-    padding: 8px 12px;
+    padding: var(--cn-select-item-py, var(--overlay-item-py)) var(--cn-select-item-px, var(--overlay-item-px));
     cursor: pointer;
     color: var(--text-primary);
-    border-radius: 4px;
+    border-radius: var(--cn-select-item-radius, var(--control-radius-sm));
     transition: background 100ms;
 }
 .cn-select-item:hover {
@@ -392,7 +395,7 @@ pub const CN_STYLES: &str = r#"
    ============================================================================ */
 
 .cn-progress {
-    background: var(--cn-progress-track, var(--secondary));
+    background: var(--cn-progress-track, var(--accent-subtle));
     border-radius: 9999px;
     overflow: hidden;
 }
@@ -401,21 +404,22 @@ pub const CN_STYLES: &str = r#"
     border-radius: 9999px;
     transition: width 300ms;
 }
-.cn-progress--sm { height: 4px; }
-.cn-progress--md { height: 8px; }
-.cn-progress--lg { height: 12px; }
+.cn-progress--sm { height: var(--cn-progress-height-sm, var(--compact-progress-height-sm)); }
+.cn-progress--md { height: var(--cn-progress-height-md, var(--compact-progress-height-md)); }
+.cn-progress--lg { height: var(--cn-progress-height-lg, var(--compact-progress-height-lg)); }
 
 /* ============================================================================
    Avatar
    ============================================================================ */
 
 .cn-avatar {
-    background: var(--cn-avatar-bg, var(--surface));
+    background: var(--cn-avatar-bg, var(--surface-elevated));
+    border: 1px solid var(--cn-avatar-border, var(--border));
     border-radius: 9999px;
     overflow: hidden;
 }
 .cn-avatar--square {
-    border-radius: 6px;
+    border-radius: var(--cn-avatar-square-radius, var(--control-radius-md));
 }
 
 /* ============================================================================
@@ -433,9 +437,9 @@ pub const CN_STYLES: &str = r#"
 .cn-tooltip {
     background: var(--cn-tooltip-bg, var(--tooltip-bg));
     color: var(--cn-tooltip-text, var(--tooltip-text));
-    border-radius: 4px;
-    font-size: 12px;
-    padding: 6px 12px;
+    border-radius: var(--cn-tooltip-radius, var(--control-radius-sm));
+    font-size: var(--cn-tooltip-font-size, var(--type-helper));
+    padding: var(--cn-tooltip-py, var(--overlay-item-py)) var(--cn-tooltip-px, var(--overlay-item-px));
 }
 
 /* ============================================================================
@@ -445,9 +449,9 @@ pub const CN_STYLES: &str = r#"
 .cn-dialog {
     background: var(--cn-dialog-bg, var(--surface));
     border: 1px solid var(--cn-dialog-border, var(--border));
-    border-radius: 12px;
-    padding: 24px;
-    gap: 16px;
+    border-radius: var(--cn-dialog-radius, var(--container-radius));
+    padding: var(--cn-dialog-padding, var(--container-padding));
+    gap: var(--cn-dialog-gap, var(--container-section-gap));
 }
 
 /* ============================================================================
@@ -460,10 +464,10 @@ pub const CN_STYLES: &str = r#"
 }
 .cn-drawer-header {
     border-bottom: 1px solid var(--border);
-    padding: 16px;
+    padding: var(--cn-drawer-header-padding, var(--container-padding-compact));
 }
 .cn-drawer-footer {
-    padding: 16px;
+    padding: var(--cn-drawer-footer-padding, var(--container-padding-compact));
 }
 
 /* ============================================================================
@@ -482,7 +486,7 @@ pub const CN_STYLES: &str = r#"
 .cn-toast {
     background: var(--cn-toast-bg, var(--surface));
     border: 1px solid var(--cn-toast-border, var(--border));
-    border-radius: 12px;
+    border-radius: var(--cn-toast-radius, var(--container-radius));
     color: var(--text-primary);
 }
 .cn-toast--success {
@@ -505,13 +509,13 @@ pub const CN_STYLES: &str = r#"
 .cn-accordion {
     background: var(--cn-accordion-bg, var(--surface-elevated));
     border: 1.5px solid var(--cn-accordion-border, var(--border));
-    border-radius: 12px;
+    border-radius: var(--cn-accordion-radius, var(--container-radius));
 }
 .cn-accordion-trigger {
-    padding: 16px 12px;
+    padding: var(--cn-accordion-trigger-py, var(--overlay-item-py)) var(--cn-accordion-trigger-px, var(--overlay-item-px));
     cursor: pointer;
     color: var(--text-primary);
-    font-size: 14px;
+    font-size: var(--cn-accordion-trigger-font-size, var(--type-action-md));
 }
 .cn-accordion-trigger:hover {
     background: var(--surface-overlay);
@@ -527,7 +531,7 @@ pub const CN_STYLES: &str = r#"
    ============================================================================ */
 
 .cn-breadcrumb {
-    gap: 8px;
+    gap: var(--cn-breadcrumb-gap, var(--compact-cluster-gap-md));
     color: var(--text-secondary);
 }
 .cn-breadcrumb-item {
@@ -546,11 +550,11 @@ pub const CN_STYLES: &str = r#"
    ============================================================================ */
 
 .cn-pagination {
-    gap: 4px;
+    gap: var(--cn-pagination-gap, var(--compact-cluster-gap-sm));
 }
 .cn-pagination-btn {
     border: 1px solid var(--border);
-    border-radius: 6px;
+    border-radius: var(--cn-pagination-radius, var(--control-radius-md));
     cursor: pointer;
     color: var(--text-primary);
     transition: background 150ms;
@@ -573,11 +577,11 @@ pub const CN_STYLES: &str = r#"
    ============================================================================ */
 
 .cn-nav-menu {
-    gap: 4px;
+    gap: var(--cn-nav-menu-gap, var(--compact-cluster-gap-sm));
 }
 .cn-nav-link {
-    padding: 8px 12px;
-    border-radius: 6px;
+    padding: var(--cn-nav-link-py, var(--overlay-item-py)) var(--cn-nav-link-px, var(--overlay-item-px));
+    border-radius: var(--cn-nav-link-radius, var(--control-radius-md));
     cursor: pointer;
     color: var(--text-secondary);
     transition: background 150ms, color 150ms;
@@ -600,8 +604,8 @@ pub const CN_STYLES: &str = r#"
     border-right: 1px solid var(--border);
 }
 .cn-sidebar-item {
-    padding: 8px 12px;
-    border-radius: 6px;
+    padding: var(--cn-sidebar-item-py, var(--overlay-item-py)) var(--cn-sidebar-item-px, var(--overlay-item-px));
+    border-radius: var(--cn-sidebar-item-radius, var(--control-radius-md));
     cursor: pointer;
     color: var(--text-secondary);
     transition: background 150ms, color 150ms;
@@ -630,15 +634,16 @@ pub const CN_STYLES: &str = r#"
 .cn-dropdown-menu {
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 4px;
+    border-radius: var(--cn-dropdown-radius, var(--overlay-radius));
+    padding: var(--cn-dropdown-padding, var(--overlay-gap));
+    box-shadow: var(--cn-dropdown-shadow, var(--overlay-shadow));
 }
 .cn-dropdown-item {
-    padding: 8px 12px;
-    border-radius: 4px;
+    padding: var(--cn-dropdown-item-py, var(--overlay-item-py)) var(--cn-dropdown-item-px, var(--overlay-item-px));
+    border-radius: var(--cn-dropdown-item-radius, var(--control-radius-sm));
     cursor: pointer;
     color: var(--text-primary);
-    font-size: 14px;
+    font-size: var(--cn-dropdown-font-size, var(--type-body-md));
     transition: background 100ms;
 }
 .cn-dropdown-item:hover {
@@ -659,15 +664,16 @@ pub const CN_STYLES: &str = r#"
 .cn-context-menu {
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 4px;
+    border-radius: var(--cn-context-menu-radius, var(--overlay-radius));
+    padding: var(--cn-context-menu-padding, var(--overlay-gap));
+    box-shadow: var(--cn-context-menu-shadow, var(--overlay-shadow));
 }
 .cn-context-menu-item {
-    padding: 8px 12px;
-    border-radius: 4px;
+    padding: var(--cn-context-menu-item-py, var(--overlay-item-py)) var(--cn-context-menu-item-px, var(--overlay-item-px));
+    border-radius: var(--cn-context-menu-item-radius, var(--control-radius-sm));
     cursor: pointer;
     color: var(--text-primary);
-    font-size: 14px;
+    font-size: var(--cn-context-menu-font-size, var(--type-body-md));
     transition: background 100ms;
 }
 .cn-context-menu-item:hover {
@@ -681,16 +687,16 @@ pub const CN_STYLES: &str = r#"
 .cn-menubar {
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 4px;
-    gap: 4px;
+    border-radius: var(--cn-menubar-radius, var(--overlay-radius));
+    padding: var(--cn-menubar-padding, var(--overlay-gap));
+    gap: var(--cn-menubar-gap, var(--overlay-gap));
 }
 .cn-menubar-trigger {
-    padding: 6px 12px;
-    border-radius: 4px;
+    padding: var(--cn-menubar-trigger-py, var(--overlay-item-py)) var(--cn-menubar-trigger-px, var(--overlay-item-px));
+    border-radius: var(--cn-menubar-trigger-radius, var(--control-radius-sm));
     cursor: pointer;
     color: var(--text-primary);
-    font-size: 14px;
+    font-size: var(--cn-menubar-font-size, var(--type-action-md));
     transition: background 100ms;
 }
 .cn-menubar-trigger:hover {
@@ -704,8 +710,9 @@ pub const CN_STYLES: &str = r#"
 .cn-popover-content {
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 16px;
+    border-radius: var(--cn-popover-radius, var(--overlay-radius));
+    padding: var(--cn-popover-padding, var(--container-padding-compact));
+    box-shadow: var(--cn-popover-shadow, var(--overlay-shadow));
 }
 
 /* ============================================================================
@@ -715,8 +722,9 @@ pub const CN_STYLES: &str = r#"
 .cn-hover-card-content {
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 16px;
+    border-radius: var(--cn-hover-card-radius, var(--overlay-radius));
+    padding: var(--cn-hover-card-padding, var(--container-padding-compact));
+    box-shadow: var(--cn-hover-card-shadow, var(--overlay-shadow));
 }
 
 /* ============================================================================
@@ -724,8 +732,8 @@ pub const CN_STYLES: &str = r#"
    ============================================================================ */
 
 .cn-tree-node {
-    padding: 4px 8px;
-    border-radius: 4px;
+    padding: var(--cn-tree-node-py, var(--overlay-gap)) var(--cn-tree-node-px, var(--control-px-sm));
+    border-radius: var(--cn-tree-node-radius, var(--control-radius-sm));
     cursor: pointer;
     color: var(--text-primary);
     transition: background 100ms;
@@ -766,7 +774,7 @@ pub const CN_STYLES: &str = r#"
 .cn-combobox-trigger {
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 6px;
+    border-radius: var(--cn-combobox-trigger-radius, var(--control-radius-md));
     cursor: pointer;
     color: var(--text-primary);
     transition: border-color 150ms;
@@ -777,12 +785,15 @@ pub const CN_STYLES: &str = r#"
 .cn-combobox-content {
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 8px;
+    border-radius: var(--cn-combobox-content-radius, var(--overlay-radius));
+    padding: var(--cn-combobox-content-py, var(--overlay-gap));
+    box-shadow: var(--cn-combobox-shadow, var(--overlay-shadow));
 }
 .cn-combobox-item {
-    padding: 8px 12px;
+    padding: var(--cn-combobox-item-py, var(--overlay-item-py)) var(--cn-combobox-item-px, var(--overlay-item-px));
     cursor: pointer;
     color: var(--text-primary);
+    border-radius: var(--cn-combobox-item-radius, var(--control-radius-sm));
     transition: background 100ms;
 }
 .cn-combobox-item:hover {

--- a/crates/blinc_cn/src/components/avatar.rs
+++ b/crates/blinc_cn/src/components/avatar.rs
@@ -194,7 +194,7 @@ impl BuiltAvatar {
             // Fallback initials
             let bg = config
                 .fallback_bg
-                .unwrap_or_else(|| theme.color(ColorToken::Surface));
+                .unwrap_or_else(|| theme.color(ColorToken::AccentSubtle));
             let fg = config
                 .fallback_color
                 .unwrap_or_else(|| theme.color(ColorToken::TextPrimary));
@@ -210,10 +210,10 @@ impl BuiltAvatar {
             // Empty fallback - show placeholder
             let bg = config
                 .fallback_bg
-                .unwrap_or_else(|| theme.color(ColorToken::Surface));
+                .unwrap_or_else(|| theme.color(ColorToken::SurfaceElevated));
             let fg = config
                 .fallback_color
-                .unwrap_or_else(|| theme.color(ColorToken::TextTertiary));
+                .unwrap_or_else(|| theme.color(ColorToken::TextSecondary));
 
             // Default user icon placeholder
             let placeholder = text("?")
@@ -230,6 +230,7 @@ impl BuiltAvatar {
             .class("cn-avatar")
             .w(size_px)
             .h(size_px)
+            .border(1.0, theme.color(ColorToken::Border))
             .rounded(radius)
             .overflow_clip()
             .flex_row()

--- a/crates/blinc_cn/src/components/breadcrumb.rs
+++ b/crates/blinc_cn/src/components/breadcrumb.rs
@@ -169,45 +169,51 @@ impl Breadcrumb {
                 let icon = item.icon.clone();
                 let on_click = item.on_click.clone();
 
-                let clickable_item =
-                    stateful_with_key::<ButtonState>(&item_key)
-                        .on_state(move |ctx| {
-                            let state = ctx.state();
-                            let theme = ThemeState::get();
+                let clickable_item = stateful_with_key::<ButtonState>(&item_key)
+                    .on_state(move |ctx| {
+                        let state = ctx.state();
+                        let theme = ThemeState::get();
 
-                            let text_color = match state {
-                                ButtonState::Hovered | ButtonState::Pressed => {
-                                    theme.color(ColorToken::Primary)
-                                }
-                                _ => theme.color(ColorToken::TextSecondary),
-                            };
-
-                            let mut item_div = div()
-                                .class("cn-breadcrumb-item")
-                                .flex_row()
-                                .items_center()
-                                .gap(4.0);
-
-                            // Add icon if present
-                            if let Some(ref icon_svg) = icon {
-                                item_div = item_div.child(div().self_center().child(
-                                    svg(icon_svg).size(icon_size, icon_size).color(text_color),
-                                ));
+                        let text_color = match state {
+                            ButtonState::Hovered | ButtonState::Pressed => {
+                                theme.color(ColorToken::Primary)
                             }
+                            _ => theme.color(ColorToken::TextSecondary),
+                        };
 
-                            // Add label
+                        let mut item_div = div()
+                            .class("cn-breadcrumb-item")
+                            .flex_row()
+                            .items_center()
+                            .gap(4.0);
+
+                        // Add icon if present
+                        if let Some(ref icon_svg) = icon {
                             item_div =
                                 item_div.child(div().self_center().child(
-                                    text(&label).size(font_size).color(text_color).no_cursor(),
+                                    svg(icon_svg).size(icon_size, icon_size).color(text_color),
                                 ));
+                        }
 
-                            item_div.cursor(CursorStyle::Pointer)
-                        })
-                        .on_click(move |_| {
-                            if let Some(ref handler) = on_click {
-                                handler();
-                            }
-                        });
+                        // Add label
+                        item_div = item_div.child(
+                            div().self_center().child(
+                                text(&label)
+                                    .class("cn-breadcrumb-label")
+                                    .class("cn-truncate")
+                                    .size(font_size)
+                                    .color(text_color)
+                                    .no_cursor(),
+                            ),
+                        );
+
+                        item_div.cursor(CursorStyle::Pointer)
+                    })
+                    .on_click(move |_| {
+                        if let Some(ref handler) = on_click {
+                            handler();
+                        }
+                    });
 
                 container = container.child(clickable_item);
             } else {
@@ -232,6 +238,8 @@ impl Breadcrumb {
                 item_div = item_div.child(
                     div().self_center().child(
                         text(&item.label)
+                            .class("cn-breadcrumb-label")
+                            .class("cn-truncate")
                             .size(font_size)
                             .color(text_primary)
                             .medium(),

--- a/crates/blinc_cn/src/components/button.rs
+++ b/crates/blinc_cn/src/components/button.rs
@@ -405,7 +405,7 @@ impl Button {
 
                 let pad_x = btn_size.padding_x(theme);
                 let pad_y = btn_size.padding_y(theme);
-                let content_gap = theme.components().container.header_gap;
+                let content_gap = theme.components().compact.cluster_gap_md;
                 let mut content = div()
                     .flex_row()
                     .items_center()

--- a/crates/blinc_cn/src/components/button.rs
+++ b/crates/blinc_cn/src/components/button.rs
@@ -394,6 +394,8 @@ impl Button {
             } else {
                 // With label: use content wrapper for flex_row layout
                 let label_text = text(&label)
+                    .class("cn-button__label")
+                    .class("cn-truncate")
                     .size(font_size)
                     .color(fg)
                     .no_wrap()
@@ -417,13 +419,17 @@ impl Button {
                     let icon_size = custom_icon_size.unwrap_or(font_size + 2.0);
                     let svg_str = blinc_icons::to_svg(icon_str, icon_size);
                     let icon_svg = svg(&svg_str).size(icon_size, icon_size).color(fg);
+                    let icon_box = div()
+                        .class("cn-button__icon")
+                        .class("cn-decorative")
+                        .child(icon_svg);
 
                     match icon_position {
                         IconPosition::Start => {
-                            content = content.child(icon_svg).child(label_text);
+                            content = content.child(icon_box).child(label_text);
                         }
                         IconPosition::End => {
-                            content = content.child(label_text).child(icon_svg);
+                            content = content.child(label_text).child(icon_box);
                         }
                     }
                 } else {

--- a/crates/blinc_cn/src/components/button.rs
+++ b/crates/blinc_cn/src/components/button.rs
@@ -169,52 +169,57 @@ impl ButtonSize {
     }
 
     /// Get height
-    fn height(&self) -> f32 {
+    fn height(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            ButtonSize::Small => 32.0,
-            ButtonSize::Medium => 40.0,
-            ButtonSize::Large => 44.0,
-            ButtonSize::Icon => 40.0,
+            ButtonSize::Small => tokens.control.height_sm,
+            ButtonSize::Medium => tokens.control.height_md,
+            ButtonSize::Large => tokens.control.height_lg,
+            ButtonSize::Icon => tokens.control.height_md,
         }
     }
 
     /// Get horizontal padding (raw pixels)
-    fn padding_x(&self) -> f32 {
+    fn padding_x(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            ButtonSize::Small => 12.0,
-            ButtonSize::Medium => 16.0,
-            ButtonSize::Large => 24.0,
-            ButtonSize::Icon => 8.0,
+            ButtonSize::Small => tokens.control.padding_x_sm,
+            ButtonSize::Medium => tokens.control.padding_x_md,
+            ButtonSize::Large => tokens.control.padding_x_lg,
+            ButtonSize::Icon => tokens.control.padding_y_md,
         }
     }
 
     /// Get vertical padding (raw pixels)
-    fn padding_y(&self) -> f32 {
+    fn padding_y(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            ButtonSize::Small => 4.0,
-            ButtonSize::Medium => 8.0,
-            ButtonSize::Large => 12.0,
-            ButtonSize::Icon => 8.0,
+            ButtonSize::Small => tokens.control.padding_y_sm,
+            ButtonSize::Medium => tokens.control.padding_y_md,
+            ButtonSize::Large => tokens.control.padding_y_lg,
+            ButtonSize::Icon => tokens.control.padding_y_md,
         }
     }
 
     /// Get font size for text/icon sizing
-    fn font_size(&self) -> f32 {
+    fn font_size(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            ButtonSize::Small => 13.0,
-            ButtonSize::Medium => 14.0,
-            ButtonSize::Large => 16.0,
-            ButtonSize::Icon => 14.0,
+            ButtonSize::Small => tokens.typography.action_sm,
+            ButtonSize::Medium => tokens.typography.action_md,
+            ButtonSize::Large => tokens.typography.action_lg,
+            ButtonSize::Icon => tokens.typography.action_md,
         }
     }
 
     /// Get default border radius (inline fallback — CSS overrides this)
-    fn border_radius(&self) -> f32 {
+    fn border_radius(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            ButtonSize::Small => 4.0,
-            ButtonSize::Medium => 6.0,
-            ButtonSize::Large => 8.0,
-            ButtonSize::Icon => 6.0,
+            ButtonSize::Small => tokens.control.radius_sm,
+            ButtonSize::Medium => tokens.control.radius_md,
+            ButtonSize::Large => tokens.control.radius_lg,
+            ButtonSize::Icon => tokens.control.radius_md,
         }
     }
 }
@@ -309,7 +314,7 @@ impl Button {
     /// Build from a config with the instance key
     fn from_config(instance_key: &str, config: ButtonConfig) -> Self {
         let theme = ThemeState::get();
-        let font_size = config.btn_size.font_size();
+        let font_size = config.btn_size.font_size(theme);
         let variant = config.variant;
         let disabled = config.disabled;
 
@@ -349,7 +354,7 @@ impl Button {
             .bg_color(bg)
             .hover_color(hover_bg)
             .pressed_color(pressed_bg)
-            .rounded(config.btn_size.border_radius())
+            .rounded(config.btn_size.border_radius(theme))
             .items_center()
             .justify_center()
             // CSS classes for user overrides
@@ -360,8 +365,11 @@ impl Button {
         // Icon-only: explicit square dimensions so items_center/justify_center
         // can center the icon. With-label: shrink-wrap to content.
         if is_icon_only {
-            let pad = config.btn_size.padding_y();
-            let dim = resolved_icon_size + pad * 2.0;
+            let pad = config.btn_size.padding_y(theme);
+            let dim = config
+                .btn_size
+                .height(theme)
+                .max(resolved_icon_size + pad * 2.0);
             btn = btn.w(dim).h(dim);
         } else {
             btn = btn.w_fit();
@@ -393,13 +401,14 @@ impl Button {
                     .pointer_events_none()
                     .no_cursor();
 
-                let pad_x = btn_size.padding_x();
-                let pad_y = btn_size.padding_y();
+                let pad_x = btn_size.padding_x(theme);
+                let pad_y = btn_size.padding_y(theme);
+                let content_gap = theme.components().container.header_gap;
                 let mut content = div()
                     .flex_row()
                     .items_center()
                     .justify_center()
-                    .gap_px(6.0)
+                    .gap_px(content_gap)
                     .padding_x_px(pad_x)
                     .padding_y_px(pad_y)
                     .pointer_events_none();

--- a/crates/blinc_cn/src/components/combobox.rs
+++ b/crates/blinc_cn/src/components/combobox.rs
@@ -50,7 +50,7 @@ use blinc_layout::stateful::{stateful_with_key, ButtonState};
 use blinc_layout::tree::{LayoutNodeId, LayoutTree};
 use blinc_layout::widgets::scroll::scroll;
 use blinc_layout::widgets::text_input::SharedTextInputData;
-use blinc_theme::{ColorToken, RadiusToken, SpacingToken, ThemeState};
+use blinc_theme::{ColorToken, SpacingToken, ThemeState};
 
 use super::label::{label, LabelSize};
 use blinc_layout::InstanceKey;
@@ -69,29 +69,41 @@ pub enum ComboboxSize {
 
 impl ComboboxSize {
     /// Get the height for this size
-    fn height(&self) -> f32 {
+    fn height(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            ComboboxSize::Small => 32.0,
-            ComboboxSize::Medium => 40.0,
-            ComboboxSize::Large => 48.0,
+            ComboboxSize::Small => tokens.control.height_sm,
+            ComboboxSize::Medium => tokens.control.height_md,
+            ComboboxSize::Large => tokens.control.height_lg,
         }
     }
 
     /// Get the font size for this size
-    fn font_size(&self) -> f32 {
+    fn font_size(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            ComboboxSize::Small => 13.0,
-            ComboboxSize::Medium => 14.0,
-            ComboboxSize::Large => 16.0,
+            ComboboxSize::Small => tokens.typography.body_sm,
+            ComboboxSize::Medium => tokens.typography.body_md,
+            ComboboxSize::Large => tokens.typography.body_lg,
         }
     }
 
     /// Get the padding for this size
-    fn padding(&self) -> f32 {
+    fn padding_x(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            ComboboxSize::Small => 8.0,
-            ComboboxSize::Medium => 12.0,
-            ComboboxSize::Large => 16.0,
+            ComboboxSize::Small => tokens.control.padding_x_sm,
+            ComboboxSize::Medium => tokens.control.padding_x_md,
+            ComboboxSize::Large => tokens.control.padding_x_lg,
+        }
+    }
+
+    fn padding_y(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
+        match self {
+            ComboboxSize::Small => tokens.control.padding_y_sm,
+            ComboboxSize::Medium => tokens.control.padding_y_md,
+            ComboboxSize::Large => tokens.control.padding_y_lg,
         }
     }
 }
@@ -176,10 +188,11 @@ impl Combobox {
     /// Create from a full configuration
     fn from_config(instance_key: &str, config: ComboboxConfig) -> Self {
         let theme = ThemeState::get();
-        let height = config.size.height();
-        let font_size = config.size.font_size();
-        let padding = config.size.padding();
-        let radius = theme.radius(RadiusToken::Sm);
+        let height = config.size.height(theme);
+        let font_size = config.size.font_size(theme);
+        let padding_x = config.size.padding_x(theme);
+        let padding_y = config.size.padding_y(theme);
+        let radius = theme.components().control.radius_md;
 
         // Colors
         let bg = theme.color(ColorToken::Surface);
@@ -335,7 +348,8 @@ impl Combobox {
                     .w_full()
                     .items_center()
                     .h(height)
-                    .p_px(padding)
+                    .padding_x_px(padding_x)
+                    .padding_y_px(padding_y)
                     .bg(bg)
                     .border(1.0, bdr)
                     .rounded(radius)
@@ -383,7 +397,7 @@ impl Combobox {
                         dropdown_width,
                         height,
                         font_size,
-                        padding,
+                        padding_x,
                         radius,
                         bg,
                         border,
@@ -904,16 +918,35 @@ mod tests {
 
     #[test]
     fn test_combobox_sizes() {
-        assert_eq!(ComboboxSize::Small.height(), 32.0);
-        assert_eq!(ComboboxSize::Medium.height(), 40.0);
-        assert_eq!(ComboboxSize::Large.height(), 48.0);
+        if ThemeState::try_get().is_none() {
+            ThemeState::init_default();
+        }
+        let theme = ThemeState::get();
+        let tokens = theme.components();
+        assert_eq!(ComboboxSize::Small.height(theme), tokens.control.height_sm);
+        assert_eq!(ComboboxSize::Medium.height(theme), tokens.control.height_md);
+        assert_eq!(ComboboxSize::Large.height(theme), tokens.control.height_lg);
     }
 
     #[test]
     fn test_combobox_font_sizes() {
-        assert_eq!(ComboboxSize::Small.font_size(), 13.0);
-        assert_eq!(ComboboxSize::Medium.font_size(), 14.0);
-        assert_eq!(ComboboxSize::Large.font_size(), 16.0);
+        if ThemeState::try_get().is_none() {
+            ThemeState::init_default();
+        }
+        let theme = ThemeState::get();
+        let tokens = theme.components();
+        assert_eq!(
+            ComboboxSize::Small.font_size(theme),
+            tokens.typography.body_sm
+        );
+        assert_eq!(
+            ComboboxSize::Medium.font_size(theme),
+            tokens.typography.body_md
+        );
+        assert_eq!(
+            ComboboxSize::Large.font_size(theme),
+            tokens.typography.body_lg
+        );
     }
 
     #[test]

--- a/crates/blinc_cn/src/components/combobox.rs
+++ b/crates/blinc_cn/src/components/combobox.rs
@@ -324,6 +324,8 @@ impl Combobox {
 
                 let display_content = div().flex_1().overflow_clip().child(
                     text(&display_text)
+                        .class("cn-combobox-value")
+                        .class("cn-truncate")
                         .size(font_size)
                         .no_cursor()
                         .color(text_clr),
@@ -799,6 +801,8 @@ fn build_dropdown_content(
                         .child(
                             div().child(
                                 text(format!("Use \"{}\"", custom_value))
+                                    .class("cn-combobox-item__label")
+                                    .class("cn-truncate")
                                     .size(font_size)
                                     .no_cursor()
                                     .color(text_color),
@@ -871,6 +875,8 @@ fn build_dropdown_content(
                         } else {
                             div().child(
                                 text(&opt_label)
+                                    .class("cn-combobox-item__label")
+                                    .class("cn-truncate")
                                     .size(font_size)
                                     .no_cursor()
                                     .color(option_text_color),

--- a/crates/blinc_cn/src/components/context_menu.rs
+++ b/crates/blinc_cn/src/components/context_menu.rs
@@ -632,6 +632,8 @@ fn build_submenu_content(
 
                     left_side = left_side.child(
                         text(&item_label)
+                            .class("cn-context-menu-item__label")
+                            .class("cn-truncate")
                             .size(font_size)
                             .color(text_col)
                             .no_cursor().pointer_events_none(),
@@ -640,13 +642,19 @@ fn build_submenu_content(
                     let right_side: Option<Div> = if let Some(ref shortcut) = item_shortcut {
                         Some(div().child(
                             text(shortcut)
+                                .class("cn-menu-shortcut")
                                 .size(font_size - 2.0)
                                 .color(shortcut_color)
                                 .no_cursor(),
                         ))
                     } else if has_submenu {
                         let chevron_right = r#"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>"#;
-                        Some(div().child(svg(chevron_right).size(12.0, 12.0).color(text_tertiary)).pointer_events_none())
+                        Some(
+                            div()
+                                .class("cn-decorative")
+                                .child(svg(chevron_right).size(12.0, 12.0).color(text_tertiary))
+                                .pointer_events_none(),
+                        )
                     } else {
                         None
                     };
@@ -856,6 +864,8 @@ fn build_menu_content(
 
                     left_side = left_side.child(
                         text(&item_label)
+                            .class("cn-context-menu-item__label")
+                            .class("cn-truncate")
                             .size(font_size)
                             .color(text_col)
                             .no_cursor(),
@@ -865,13 +875,18 @@ fn build_menu_content(
                     let right_side: Option<Div> = if let Some(ref shortcut) = item_shortcut {
                         Some(div().child(
                             text(shortcut)
+                                .class("cn-menu-shortcut")
                                 .size(font_size - 2.0)
                                 .color(shortcut_color)
                                 .no_cursor(),
                         ))
                     } else if has_submenu {
                         let chevron_right = r#"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>"#;
-                        Some(div().child(svg(chevron_right).size(12.0, 12.0).color(text_tertiary)))
+                        Some(
+                            div()
+                                .class("cn-decorative")
+                                .child(svg(chevron_right).size(12.0, 12.0).color(text_tertiary)),
+                        )
                     } else {
                         None
                     };

--- a/crates/blinc_cn/src/components/context_menu.rs
+++ b/crates/blinc_cn/src/components/context_menu.rs
@@ -338,11 +338,10 @@ impl ContextMenuBuilder {
         let text_secondary = theme.color(ColorToken::TextSecondary);
         let text_tertiary = theme.color(ColorToken::TextTertiary);
         let surface_elevated = theme.color(ColorToken::SurfaceElevated);
-        let radius = theme.radius(RadiusToken::Md);
-
-        // Use same sizing as Select dropdown for consistency
-        let font_size = 14.0; // Medium size font
-        let padding = 12.0; // Medium size padding
+        let components = theme.components();
+        let radius = components.overlay.radius;
+        let font_size = components.typography.body_md;
+        let padding = components.overlay.item_padding_x;
 
         let items = self.items;
         let width = self.min_width;
@@ -496,9 +495,10 @@ fn show_context_submenu(
     let text_secondary = theme.color(ColorToken::TextSecondary);
     let text_tertiary = theme.color(ColorToken::TextTertiary);
     let surface_elevated = theme.color(ColorToken::SurfaceElevated);
-    let radius = theme.radius(RadiusToken::Md);
-    let font_size = 14.0;
-    let padding = 12.0;
+    let components = theme.components();
+    let radius = components.overlay.radius;
+    let font_size = components.typography.body_md;
+    let padding = components.overlay.item_padding_x;
 
     let items = items.to_vec();
 

--- a/crates/blinc_cn/src/components/dropdown_menu.rs
+++ b/crates/blinc_cn/src/components/dropdown_menu.rs
@@ -705,6 +705,8 @@ fn build_submenu_content(
 
                     left_side = left_side.child(
                         text(&item_label)
+                            .class("cn-dropdown-item__label")
+                            .class("cn-truncate")
                             .size(font_size)
                             .color(text_col)
                             .no_cursor().pointer_events_none(),
@@ -713,13 +715,19 @@ fn build_submenu_content(
                     let right_side: Option<Div> = if let Some(ref shortcut) = item_shortcut {
                         Some(div().child(
                             text(shortcut)
+                                .class("cn-menu-shortcut")
                                 .size(font_size - 2.0)
                                 .color(shortcut_color)
                                 .no_cursor(),
                         ))
                     } else if has_submenu {
                         let chevron_right = r#"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>"#;
-                        Some(div().child(svg(chevron_right).size(12.0, 12.0).color(text_tertiary)).pointer_events_none())
+                        Some(
+                            div()
+                                .class("cn-decorative")
+                                .child(svg(chevron_right).size(12.0, 12.0).color(text_tertiary))
+                                .pointer_events_none(),
+                        )
                     } else {
                         None
                     };
@@ -927,6 +935,8 @@ fn build_dropdown_content(
 
                     left_side = left_side.child(
                         text(&item_label)
+                            .class("cn-dropdown-item__label")
+                            .class("cn-truncate")
                             .size(font_size)
                             .color(text_col)
                             .no_cursor().pointer_events_none(),
@@ -936,13 +946,19 @@ fn build_dropdown_content(
                     let right_side: Option<Div> = if let Some(ref shortcut) = item_shortcut {
                         Some(div().child(
                             text(shortcut)
+                                .class("cn-menu-shortcut")
                                 .size(font_size - 2.0)
                                 .color(shortcut_color)
                                 .no_cursor(),
                         ))
                     } else if has_submenu {
                         let chevron_right = r#"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>"#;
-                        Some(div().child(svg(chevron_right).size(12.0, 12.0).color(text_tertiary)).pointer_events_none())
+                        Some(
+                            div()
+                                .class("cn-decorative")
+                                .child(svg(chevron_right).size(12.0, 12.0).color(text_tertiary))
+                                .pointer_events_none(),
+                        )
                     } else {
                         None
                     };

--- a/crates/blinc_cn/src/components/dropdown_menu.rs
+++ b/crates/blinc_cn/src/components/dropdown_menu.rs
@@ -502,9 +502,10 @@ fn show_dropdown_menu(
     let text_secondary = theme.color(ColorToken::TextSecondary);
     let text_tertiary = theme.color(ColorToken::TextTertiary);
     let surface_elevated = theme.color(ColorToken::SurfaceElevated);
-    let radius = theme.radius(RadiusToken::Md);
-    let font_size = 14.0;
-    let padding = 12.0;
+    let components = theme.components();
+    let radius = components.overlay.radius;
+    let font_size = components.typography.body_md;
+    let padding = components.overlay.item_padding_x;
 
     let items = items.to_vec();
 
@@ -566,9 +567,10 @@ fn show_submenu(
     let text_secondary = theme.color(ColorToken::TextSecondary);
     let text_tertiary = theme.color(ColorToken::TextTertiary);
     let surface_elevated = theme.color(ColorToken::SurfaceElevated);
-    let radius = theme.radius(RadiusToken::Md);
-    let font_size = 14.0;
-    let padding = 12.0;
+    let components = theme.components();
+    let radius = components.overlay.radius;
+    let font_size = components.typography.body_md;
+    let padding = components.overlay.item_padding_x;
 
     let items = items.to_vec();
 

--- a/crates/blinc_cn/src/components/input.rs
+++ b/crates/blinc_cn/src/components/input.rs
@@ -92,19 +92,20 @@ pub enum InputSize {
 
 impl InputSize {
     fn height(&self, theme: &ThemeState) -> f32 {
-        // Use spacing tokens for consistent sizing
+        let tokens = theme.components();
         match self {
-            InputSize::Small => theme.spacing_value(SpacingToken::Space8), // 32px
-            InputSize::Medium => theme.spacing_value(SpacingToken::Space10), // 40px
-            InputSize::Large => theme.spacing_value(SpacingToken::Space12), // 48px
+            InputSize::Small => tokens.control.height_sm,
+            InputSize::Medium => tokens.control.height_md,
+            InputSize::Large => tokens.control.height_lg,
         }
     }
 
-    fn font_size(&self, typography: &TypographyTokens) -> f32 {
+    fn font_size(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            InputSize::Small => typography.text_xs,   // 12px
-            InputSize::Medium => typography.text_sm,  // 14px
-            InputSize::Large => typography.text_base, // 16px
+            InputSize::Small => tokens.typography.body_sm,
+            InputSize::Medium => tokens.typography.body_md,
+            InputSize::Large => tokens.typography.body_lg,
         }
     }
 }
@@ -129,7 +130,6 @@ impl Input {
     /// Create from a full configuration
     fn with_config(config: InputConfig) -> Self {
         let theme = ThemeState::get();
-        let typography = theme.typography();
 
         // Sync visual error state to underlying data's is_valid field
         if config.error_state {
@@ -139,7 +139,7 @@ impl Input {
         }
 
         // Build the text input element
-        let text_input = Self::build_text_input(&config, theme, &typography);
+        let text_input = Self::build_text_input(&config, theme);
 
         // Determine the size-specific class
         let size_class = match config.size {
@@ -193,24 +193,20 @@ impl Input {
         container = container.child(text_input);
 
         // Error or description
+        let helper_size = theme.components().typography.helper;
         if let Some(ref error_text) = config.error {
             let error_color = theme.color(ColorToken::Error);
-            container =
-                container.child(text(error_text).size(typography.text_xs).color(error_color));
+            container = container.child(text(error_text).size(helper_size).color(error_color));
         } else if let Some(ref desc_text) = config.description {
             let desc_color = theme.color(ColorToken::TextTertiary);
-            container = container.child(text(desc_text).size(typography.text_xs).color(desc_color));
+            container = container.child(text(desc_text).size(helper_size).color(desc_color));
         }
 
         Self { inner: container }
     }
 
     /// Build the text input element from config
-    fn build_text_input(
-        config: &InputConfig,
-        theme: &ThemeState,
-        typography: &TypographyTokens,
-    ) -> TextInput {
+    fn build_text_input(config: &InputConfig, theme: &ThemeState) -> TextInput {
         // Get default theme colors for fallbacks
         let default_border = theme.color(ColorToken::Border);
         let default_border_hover = theme.color(ColorToken::BorderHover);
@@ -226,11 +222,11 @@ impl Input {
 
         let radius = config
             .corner_radius
-            .unwrap_or_else(|| theme.radius(RadiusToken::Md));
+            .unwrap_or_else(|| theme.components().control.radius_md);
 
         let mut input = blinc_layout::widgets::text_input::text_input(&config.data)
             .h(config.size.height(theme))
-            .text_size(config.size.font_size(typography))
+            .text_size(config.size.font_size(theme))
             .rounded(radius)
             .input_type(config.input_type)
             .disabled(config.disabled)
@@ -688,20 +684,19 @@ mod tests {
     fn test_input_size_values() {
         init_theme();
         let theme = ThemeState::get();
-        let typography = TypographyTokens::default();
 
         // Sizes use spacing tokens
         assert!(InputSize::Small.height(theme) > 0.0);
         assert!(InputSize::Medium.height(theme) > InputSize::Small.height(theme));
         assert!(InputSize::Large.height(theme) > InputSize::Medium.height(theme));
 
-        // Font sizes use typography tokens
-        assert_eq!(InputSize::Small.font_size(&typography), typography.text_xs);
-        assert_eq!(InputSize::Medium.font_size(&typography), typography.text_sm);
+        let tokens = theme.components();
+        assert_eq!(InputSize::Small.font_size(theme), tokens.typography.body_sm);
         assert_eq!(
-            InputSize::Large.font_size(&typography),
-            typography.text_base
+            InputSize::Medium.font_size(theme),
+            tokens.typography.body_md
         );
+        assert_eq!(InputSize::Large.font_size(theme), tokens.typography.body_lg);
     }
 
     #[test]

--- a/crates/blinc_cn/src/components/label.rs
+++ b/crates/blinc_cn/src/components/label.rs
@@ -33,11 +33,12 @@ pub enum LabelSize {
 }
 
 impl LabelSize {
-    fn font_size(&self, typography: &TypographyTokens) -> f32 {
+    fn font_size(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            LabelSize::Small => typography.text_xs,
-            LabelSize::Medium => typography.text_sm,
-            LabelSize::Large => typography.text_base,
+            LabelSize::Small => tokens.typography.label_sm,
+            LabelSize::Medium => tokens.typography.label_md,
+            LabelSize::Large => tokens.typography.label_lg,
         }
     }
 }
@@ -57,7 +58,6 @@ impl Label {
     /// Create from a full configuration
     fn with_config(config: LabelConfig) -> Self {
         let theme = ThemeState::get();
-        let typography = theme.typography();
 
         let text_color = if config.disabled {
             theme.color(ColorToken::TextTertiary)
@@ -65,7 +65,7 @@ impl Label {
             theme.color(ColorToken::TextPrimary)
         };
 
-        let font_size = config.size.font_size(&typography);
+        let font_size = config.size.font_size(theme);
 
         let disabled_class = if config.disabled {
             "cn-label--disabled"
@@ -234,16 +234,24 @@ pub fn label(text: impl Into<String>) -> LabelBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use blinc_theme::TypographyTokens;
 
     #[test]
     fn test_label_size_values() {
-        let typography = TypographyTokens::default();
-        assert_eq!(LabelSize::Small.font_size(&typography), typography.text_xs);
-        assert_eq!(LabelSize::Medium.font_size(&typography), typography.text_sm);
+        if ThemeState::try_get().is_none() {
+            ThemeState::init_default();
+        }
+        let theme = ThemeState::get();
         assert_eq!(
-            LabelSize::Large.font_size(&typography),
-            typography.text_base
+            LabelSize::Small.font_size(theme),
+            theme.components().typography.label_sm
+        );
+        assert_eq!(
+            LabelSize::Medium.font_size(theme),
+            theme.components().typography.label_md
+        );
+        assert_eq!(
+            LabelSize::Large.font_size(theme),
+            theme.components().typography.label_lg
         );
     }
 

--- a/crates/blinc_cn/src/components/menubar.rs
+++ b/crates/blinc_cn/src/components/menubar.rs
@@ -629,9 +629,10 @@ fn show_menubar_dropdown(
     let text_color = theme.color(ColorToken::TextPrimary);
     let text_secondary = theme.color(ColorToken::TextSecondary);
     let text_tertiary = theme.color(ColorToken::TextTertiary);
-    let radius = theme.radius(RadiusToken::Md);
-    let font_size = 14.0;
-    let padding = 12.0;
+    let components = theme.components();
+    let radius = components.overlay.radius;
+    let font_size = components.typography.action_md;
+    let padding = components.overlay.item_padding_x;
 
     let items = items.to_vec();
     let item_count = items.len();
@@ -701,9 +702,10 @@ fn show_menubar_hover_dropdown(
     let text_color = theme.color(ColorToken::TextPrimary);
     let text_secondary = theme.color(ColorToken::TextSecondary);
     let text_tertiary = theme.color(ColorToken::TextTertiary);
-    let radius = theme.radius(RadiusToken::Md);
-    let font_size = 14.0;
-    let padding = 12.0;
+    let components = theme.components();
+    let radius = components.overlay.radius;
+    let font_size = components.typography.action_md;
+    let padding = components.overlay.item_padding_x;
 
     let items = items.to_vec();
     let item_count = items.len();

--- a/crates/blinc_cn/src/components/menubar.rs
+++ b/crates/blinc_cn/src/components/menubar.rs
@@ -456,6 +456,8 @@ impl MenubarBuilder {
                                 .py(1.0)
                                 .child(
                                     text(label)
+                                        .class("cn-menubar-trigger__label")
+                                        .class("cn-truncate")
                                         .size(style_font_size)
                                         .color(text_col)
                                         .no_cursor()
@@ -894,6 +896,8 @@ fn build_menubar_hover_dropdown_content(
                     left_side = left_side
                         .child(
                             text(&item_label)
+                                .class("cn-dropdown-item__label")
+                                .class("cn-truncate")
                                 .size(font_size)
                                 .color(text_col)
                                 .no_cursor()
@@ -905,6 +909,7 @@ fn build_menubar_hover_dropdown_content(
                     let right_side: Option<Div> = if let Some(ref shortcut) = item_shortcut {
                         Some(div().child(
                             text(shortcut)
+                                .class("cn-menu-shortcut")
                                 .size(font_size - 2.0)
                                 .color(shortcut_color)
                                 .no_cursor(),
@@ -913,6 +918,7 @@ fn build_menubar_hover_dropdown_content(
                         let chevron_right = r#"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>"#;
                         Some(
                             div()
+                                .class("cn-decorative")
                                 .child(svg(chevron_right).size(12.0, 12.0).color(text_tertiary))
                                 .pointer_events_none(),
                         )
@@ -1210,6 +1216,8 @@ fn build_menubar_submenu_content(
 
                     left_side = left_side.child(
                         text(&item_label)
+                            .class("cn-dropdown-item__label")
+                            .class("cn-truncate")
                             .size(font_size)
                             .color(text_col)
                             .no_cursor().pointer_events_none(),
@@ -1218,13 +1226,19 @@ fn build_menubar_submenu_content(
                     let right_side: Option<Div> = if let Some(ref shortcut) = item_shortcut {
                         Some(div().child(
                             text(shortcut)
+                                .class("cn-menu-shortcut")
                                 .size(font_size - 2.0)
                                 .color(shortcut_color)
                                 .no_cursor(),
                         ))
                     } else if has_submenu {
                         let chevron_right = r#"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>"#;
-                        Some(div().child(svg(chevron_right).size(12.0, 12.0).color(text_tertiary)).pointer_events_none())
+                        Some(
+                            div()
+                                .class("cn-decorative")
+                                .child(svg(chevron_right).size(12.0, 12.0).color(text_tertiary))
+                                .pointer_events_none(),
+                        )
                     } else {
                         None
                     };
@@ -1422,6 +1436,8 @@ fn build_menubar_dropdown_content(
                     left_side = left_side
                         .child(
                             text(&item_label)
+                                .class("cn-dropdown-item__label")
+                                .class("cn-truncate")
                                 .size(font_size)
                                 .color(text_col)
                                 .no_cursor()
@@ -1433,6 +1449,7 @@ fn build_menubar_dropdown_content(
                     let right_side: Option<Div> = if let Some(ref shortcut) = item_shortcut {
                         Some(div().child(
                             text(shortcut)
+                                .class("cn-menu-shortcut")
                                 .size(font_size - 2.0)
                                 .color(shortcut_color)
                                 .no_cursor(),
@@ -1441,6 +1458,7 @@ fn build_menubar_dropdown_content(
                         let chevron_right = r#"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>"#;
                         Some(
                             div()
+                                .class("cn-decorative")
                                 .child(svg(chevron_right).size(12.0, 12.0).color(text_tertiary))
                                 .pointer_events_none(),
                         )

--- a/crates/blinc_cn/src/components/navigation_menu.rs
+++ b/crates/blinc_cn/src/components/navigation_menu.rs
@@ -99,7 +99,14 @@ impl NavigationMenu {
             .deps([active_menu.signal_id()])
             .on_state(move |_ctx| {
                 let current_active = active_menu_for_container.get();
-                let mut nav = div().class("cn-nav-menu").flex_row().items_center().h_fit().gap(1.0);
+                let compact = ThemeState::get().components().compact;
+                let typography = ThemeState::get().components().typography;
+                let mut nav = div()
+                    .class("cn-nav-menu")
+                    .flex_row()
+                    .items_center()
+                    .h_fit()
+                    .gap_px(compact.cluster_gap_sm);
 
                 for (idx, item) in items.iter().enumerate() {
                     let item_key = format!("{}_{}", key_base, idx);
@@ -129,14 +136,14 @@ impl NavigationMenu {
                                         .flex_row()
                                         .items_center()
                                         .h_fit()
-                                        .px(3.0)
-                                        .py(2.0)
+                                        .px(ThemeState::get().components().overlay.item_padding_x)
+                                        .py(ThemeState::get().components().overlay.item_padding_y)
                                         .rounded(radius)
                                         .bg(bg)
                                         .cursor(CursorStyle::Pointer)
                                         .child(
                                             text(&label)
-                                                .size(14.0)
+                                                .size(typography.action_md)
                                                 .medium()
                                                 .color(text_color)
                                                 .no_cursor()
@@ -201,15 +208,15 @@ impl NavigationMenu {
                                             .flex_row()
                                             .items_center()
                                             .h_fit()
-                                            .gap(1.0)
-                                            .px(3.0)
-                                            .py(2.0)
+                                            .gap_px(compact.cluster_gap_sm)
+                                            .px(ThemeState::get().components().overlay.item_padding_x)
+                                            .py(ThemeState::get().components().overlay.item_padding_y)
                                             .rounded(radius)
                                             .bg(bg)
                                             .cursor(CursorStyle::Pointer)
                                             .child(
                                                 text(&label)
-                                                    .size(14.0)
+                                                    .size(typography.action_md)
                                                     .medium()
                                                     .color(text_color)
                                                     .no_cursor()
@@ -591,15 +598,15 @@ impl NavigationLink {
                     .class("cn-nav-link")
                     .flex_col()
                     .w_full()
-                    .gap(1.0)
-                    .px(3.0) // Horizontal padding on item
-                    .py(2.0) // Vertical padding on item
+                    .gap_px(theme.components().compact.cluster_gap_sm)
+                    .px(theme.components().overlay.item_padding_x)
+                    .py(theme.components().overlay.item_padding_y)
                     .rounded(radius)
                     .bg(bg)
                     .cursor(CursorStyle::Pointer)
                     .child(
                         text(&label)
-                            .size(14.0)
+                            .size(theme.components().typography.action_md)
                             .medium()
                             .color(text_primary)
                             .no_cursor()

--- a/crates/blinc_cn/src/components/navigation_menu.rs
+++ b/crates/blinc_cn/src/components/navigation_menu.rs
@@ -143,6 +143,8 @@ impl NavigationMenu {
                                         .cursor(CursorStyle::Pointer)
                                         .child(
                                             text(&label)
+                                                .class("cn-nav-link__label")
+                                                .class("cn-truncate")
                                                 .size(typography.action_md)
                                                 .medium()
                                                 .color(text_color)
@@ -216,13 +218,24 @@ impl NavigationMenu {
                                             .cursor(CursorStyle::Pointer)
                                             .child(
                                                 text(&label)
+                                                    .class("cn-nav-link__label")
+                                                    .class("cn-truncate")
                                                     .size(typography.action_md)
                                                     .medium()
                                                     .color(text_color)
                                                     .no_cursor()
                                                     .pointer_events_none(),
                                             )
-                                            .child(div().pointer_events_none().child(svg(chevron).size(12.0, 12.0).color(text_color)));
+                                            .child(
+                                                div()
+                                                    .class("cn-decorative")
+                                                    .pointer_events_none()
+                                                    .child(
+                                                        svg(chevron)
+                                                            .size(12.0, 12.0)
+                                                            .color(text_color),
+                                                    ),
+                                            );
                                         if is_active {
                                             trigger_div = trigger_div.class("cn-nav-link--active");
                                         }

--- a/crates/blinc_cn/src/components/progress.rs
+++ b/crates/blinc_cn/src/components/progress.rs
@@ -118,7 +118,7 @@ impl Progress {
             .unwrap_or_else(|| theme.color(ColorToken::Primary));
         let track_color = config
             .track_color
-            .unwrap_or_else(|| theme.color(ColorToken::Secondary));
+            .unwrap_or_else(|| theme.color(ColorToken::AccentSubtle));
 
         // Calculate fill width in pixels
         let fill_ratio = config.value / 100.0;

--- a/crates/blinc_cn/src/components/select.rs
+++ b/crates/blinc_cn/src/components/select.rs
@@ -43,9 +43,7 @@ use blinc_layout::element::{CursorStyle, RenderProps};
 use blinc_layout::prelude::*;
 use blinc_layout::stateful::{stateful_with_key, ButtonState};
 use blinc_layout::tree::{LayoutNodeId, LayoutTree};
-use blinc_theme::{ColorToken, RadiusToken, SpacingToken, ThemeState};
-
-use crate::ButtonVariant;
+use blinc_theme::{ColorToken, SpacingToken, ThemeState};
 
 use super::label::{label, LabelSize};
 use blinc_layout::InstanceKey;
@@ -64,29 +62,40 @@ pub enum SelectSize {
 
 impl SelectSize {
     /// Get the height for this size
-    fn height(&self) -> f32 {
+    fn height(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            SelectSize::Small => 32.0,
-            SelectSize::Medium => 40.0,
-            SelectSize::Large => 48.0,
+            SelectSize::Small => tokens.control.height_sm,
+            SelectSize::Medium => tokens.control.height_md,
+            SelectSize::Large => tokens.control.height_lg,
         }
     }
 
     /// Get the font size for this size
-    fn font_size(&self) -> f32 {
+    fn font_size(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            SelectSize::Small => 13.0,
-            SelectSize::Medium => 14.0,
-            SelectSize::Large => 16.0,
+            SelectSize::Small => tokens.typography.body_sm,
+            SelectSize::Medium => tokens.typography.body_md,
+            SelectSize::Large => tokens.typography.body_lg,
         }
     }
 
-    /// Get the padding for this size
-    fn padding(&self) -> f32 {
+    fn padding_x(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            SelectSize::Small => 8.0,
-            SelectSize::Medium => 12.0,
-            SelectSize::Large => 16.0,
+            SelectSize::Small => tokens.control.padding_x_sm,
+            SelectSize::Medium => tokens.control.padding_x_md,
+            SelectSize::Large => tokens.control.padding_x_lg,
+        }
+    }
+
+    fn padding_y(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
+        match self {
+            SelectSize::Small => tokens.control.padding_y_sm,
+            SelectSize::Medium => tokens.control.padding_y_md,
+            SelectSize::Large => tokens.control.padding_y_lg,
         }
     }
 }
@@ -161,15 +170,19 @@ impl Select {
     /// Create from a full configuration
     fn from_config(instance_key: &str, config: SelectConfig) -> Self {
         let theme = ThemeState::get();
-        let height = config.size.height();
-        let font_size = config.size.font_size();
-        let padding = config.size.padding();
-        let radius = theme.radius(RadiusToken::Md);
+        let height = config.size.height(theme);
+        let font_size = config.size.font_size(theme);
+        let padding_x = config.size.padding_x(theme);
+        let padding_y = config.size.padding_y(theme);
+        let radius = theme.components().control.radius_md;
 
         // Colors
-        let bg = theme.color(ColorToken::Surface);
+        let input_bg = theme.color(ColorToken::InputBg);
+        let input_bg_hover = theme.color(ColorToken::InputBgHover);
+        let input_bg_focus = theme.color(ColorToken::InputBgFocus);
         let border = theme.color(ColorToken::Border);
         let border_hover = theme.color(ColorToken::BorderHover);
+        let border_focus = theme.color(ColorToken::BorderFocus);
         let text_color = theme.color(ColorToken::TextPrimary);
         let text_tertiary = theme.color(ColorToken::TextTertiary);
         let surface_elevated = theme.color(ColorToken::SurfaceElevated);
@@ -195,7 +208,6 @@ impl Select {
         // Chevron SVG (down arrow)
         let chevron_svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>"#;
 
-        let btn_variant = ButtonVariant::Outline;
         let select_btn_key = format!("{}_btn", instance_key);
         let instance_key_owned = instance_key.to_string();
         // Unique element ID for click-outside detection
@@ -223,7 +235,15 @@ impl Select {
                     click_outside::unregister_click_outside(&wrapper_id_for_state);
                 }
 
-                let bg = btn_variant.background(theme, state);
+                let bg = if disabled {
+                    input_bg
+                } else if is_open {
+                    input_bg_focus
+                } else if matches!(state, ButtonState::Hovered | ButtonState::Pressed) {
+                    input_bg_hover
+                } else {
+                    input_bg
+                };
                 let current_val = value_state_for_display.get();
                 let selected_option = options_for_display
                     .iter()
@@ -235,7 +255,13 @@ impl Select {
                 } else {
                     text_color
                 };
-                let bdr = if is_open { border_hover } else { border };
+                let bdr = if is_open {
+                    border_focus
+                } else if matches!(state, ButtonState::Hovered | ButtonState::Pressed) {
+                    border_hover
+                } else {
+                    border
+                };
 
                 let display_content: Div = if let Some(opt) = selected_option {
                     if let Some(ref content_fn) = opt.content {
@@ -278,7 +304,8 @@ impl Select {
                     .items_center()
                     .justify_between()
                     .h(height)
-                    .p_px(padding)
+                    .padding_x_px(padding_x)
+                    .padding_y_px(padding_y)
                     .bg(bg)
                     .border(1.0, bdr)
                     .rounded(radius)
@@ -317,9 +344,9 @@ impl Select {
                         dropdown_width,
                         height,
                         font_size,
-                        padding,
+                        padding_x,
                         radius,
-                        bg,
+                        input_bg,
                         border,
                         text_color,
                         text_tertiary,
@@ -577,7 +604,7 @@ fn build_dropdown_content(
     width: f32,
     trigger_height: f32,
     font_size: f32,
-    padding: f32,
+    padding_x: f32,
     radius: f32,
     bg: blinc_core::Color,
     border: blinc_core::Color,
@@ -595,7 +622,7 @@ fn build_dropdown_content(
         .bg(bg)
         .border(1.0, border)
         .rounded(radius)
-        .shadow_lg()
+        .shadow_md()
         .overflow_clip()
         .h_fit()
         // Absolutely positioned below the trigger, rendered in foreground pass
@@ -678,16 +705,35 @@ mod tests {
 
     #[test]
     fn test_select_sizes() {
-        assert_eq!(SelectSize::Small.height(), 32.0);
-        assert_eq!(SelectSize::Medium.height(), 40.0);
-        assert_eq!(SelectSize::Large.height(), 48.0);
+        if ThemeState::try_get().is_none() {
+            ThemeState::init_default();
+        }
+        let theme = ThemeState::get();
+        let tokens = theme.components();
+        assert_eq!(SelectSize::Small.height(theme), tokens.control.height_sm);
+        assert_eq!(SelectSize::Medium.height(theme), tokens.control.height_md);
+        assert_eq!(SelectSize::Large.height(theme), tokens.control.height_lg);
     }
 
     #[test]
     fn test_select_font_sizes() {
-        assert_eq!(SelectSize::Small.font_size(), 13.0);
-        assert_eq!(SelectSize::Medium.font_size(), 14.0);
-        assert_eq!(SelectSize::Large.font_size(), 16.0);
+        if ThemeState::try_get().is_none() {
+            ThemeState::init_default();
+        }
+        let theme = ThemeState::get();
+        let tokens = theme.components();
+        assert_eq!(
+            SelectSize::Small.font_size(theme),
+            tokens.typography.body_sm
+        );
+        assert_eq!(
+            SelectSize::Medium.font_size(theme),
+            tokens.typography.body_md
+        );
+        assert_eq!(
+            SelectSize::Large.font_size(theme),
+            tokens.typography.body_lg
+        );
     }
 
     #[test]

--- a/crates/blinc_cn/src/components/select.rs
+++ b/crates/blinc_cn/src/components/select.rs
@@ -267,10 +267,14 @@ impl Select {
                     if let Some(ref content_fn) = opt.content {
                         content_fn()
                     } else {
-                        div()
-                            .h_fit()
-                            .overflow_clip()
-                            .child(text(&opt.label).size(font_size).no_cursor().color(text_clr))
+                        div().h_fit().overflow_clip().child(
+                            text(&opt.label)
+                                .class("cn-select-value")
+                                .class("cn-truncate")
+                                .size(font_size)
+                                .no_cursor()
+                                .color(text_clr),
+                        )
                     }
                 } else {
                     let placeholder_text = placeholder_for_display
@@ -278,6 +282,8 @@ impl Select {
                         .unwrap_or_else(|| "Select...".to_string());
                     div().h_fit().overflow_clip().child(
                         text(&placeholder_text)
+                            .class("cn-select-value")
+                            .class("cn-truncate")
                             .size(font_size)
                             .no_cursor()
                             .color(text_clr),
@@ -318,6 +324,7 @@ impl Select {
                         svg(chevron_svg)
                             .size(16.0, 16.0)
                             .tint(text_tertiary)
+                            .class("cn-decorative")
                             .ml(1.0)
                             .flex_shrink_0(),
                     )
@@ -673,6 +680,8 @@ fn build_dropdown_content(
             } else {
                 div().child(
                     text(&opt_label)
+                        .class("cn-select-value")
+                        .class("cn-truncate")
                         .size(font_size)
                         .no_cursor()
                         .color(option_text_color),

--- a/crates/blinc_cn/src/components/sidebar.rs
+++ b/crates/blinc_cn/src/components/sidebar.rs
@@ -110,6 +110,10 @@ impl Sidebar {
         let text_secondary = theme.color(ColorToken::TextSecondary);
         let text_tertiary = theme.color(ColorToken::TextTertiary);
         let primary = theme.color(ColorToken::Primary);
+        let item_gap = theme.spacing().space_2;
+        let item_px = theme.spacing().space_3;
+        let item_py = theme.spacing().space_2;
+        let section_pad_y = theme.spacing().space_1_5;
 
         let key = builder.key.get().to_string();
         let sections = builder.sections.clone();
@@ -177,9 +181,9 @@ impl Sidebar {
                                     .w_fit()
                                     .flex_row()
                                     .items_center()
-                                    .gap(3.0)
-                                    .px(3.0)
-                                    .py(2.0)
+                                    .gap(item_gap)
+                                    .px(item_px)
+                                    .py(item_py)
                                     .bg(bg)
                                     .cursor(CursorStyle::Pointer)
                                     .animate_bounds(
@@ -215,7 +219,7 @@ impl Sidebar {
                     .h_full()
                     .w_fit()
                     .overflow_clip() // Critical for animation clipping
-                    .py(2.0)
+                    .py(section_pad_y)
                     .animate_bounds(
                         VisualAnimationConfig::all()
                             .with_key(&layout_anim_key)
@@ -247,7 +251,7 @@ impl Sidebar {
                                     .snappy(),
                             )
                             .when(!is_collapsed, |d| {
-                                d.px(3.0).py(2.0).child(
+                                d.px(item_px).py(item_py).child(
                                     text(title.to_uppercase())
                                         .size(11.0)
                                         .color(text_tertiary)
@@ -313,9 +317,9 @@ impl Sidebar {
                                     .h_fit()
                                     .flex_row()
                                     .items_center()
-                                    .gap(3.0)
-                                    .px(3.0)
-                                    .py(2.0)
+                                    .gap(item_gap)
+                                    .px(item_px)
+                                    .py(item_py)
                                     .bg(bg)
                                     .cursor(CursorStyle::Pointer)
                                     .overflow_clip()

--- a/crates/blinc_cn/src/components/sidebar.rs
+++ b/crates/blinc_cn/src/components/sidebar.rs
@@ -336,6 +336,8 @@ impl Sidebar {
                                         .child(
                                             div().child(
                                                 text(&item_label)
+                                                    .class("cn-sidebar-item__label")
+                                                    .class("cn-truncate")
                                                     .size(14.0)
                                                     .color(text_col)
                                                     .no_cursor()

--- a/crates/blinc_cn/src/components/switch.rs
+++ b/crates/blinc_cn/src/components/switch.rs
@@ -117,7 +117,7 @@ impl Switch {
         let track_width = config.size.track_width();
         let track_height = config.size.track_height();
         let thumb_size = config.size.thumb_size();
-        let padding = 2.0; // Padding from track edge
+        let padding = theme.components().compact.switch_inset;
         let thumb_travel = track_width - thumb_size - (padding * 2.0);
         let radius = track_height / 2.0; // Fully rounded track
 
@@ -305,7 +305,9 @@ struct SwitchConfig {
 impl SwitchConfig {
     fn new(on_state: State<bool>) -> Self {
         let size = SwitchSize::default();
-        let padding = 2.0;
+        let padding = ThemeState::try_get()
+            .map(|theme| theme.components().compact.switch_inset)
+            .unwrap_or(2.0);
         let thumb_travel = size.track_width() - size.thumb_size() - (padding * 2.0);
         let is_on = on_state.get();
         let initial_x = if is_on { thumb_travel } else { 0.0 };
@@ -508,7 +510,10 @@ mod tests {
     #[test]
     fn test_thumb_travel() {
         let size = SwitchSize::Medium;
-        let padding = 2.0;
+        if ThemeState::try_get().is_none() {
+            ThemeState::init_default();
+        }
+        let padding = ThemeState::get().components().compact.switch_inset;
         let travel = size.track_width() - size.thumb_size() - (padding * 2.0);
         // Travel should be: 44 - 20 - 4 = 20
         assert_eq!(travel, 20.0);

--- a/crates/blinc_cn/src/components/switch.rs
+++ b/crates/blinc_cn/src/components/switch.rs
@@ -86,6 +86,11 @@ impl SwitchSize {
             SwitchSize::Large => 24.0,
         }
     }
+
+    /// Get the thumb travel distance for a given track inset.
+    fn thumb_travel(&self, inset: f32) -> f32 {
+        self.track_width() - self.thumb_size() - (inset * 2.0)
+    }
 }
 
 /// Switch component
@@ -118,7 +123,7 @@ impl Switch {
         let track_height = config.size.track_height();
         let thumb_size = config.size.thumb_size();
         let padding = theme.components().compact.switch_inset;
-        let thumb_travel = track_width - thumb_size - (padding * 2.0);
+        let thumb_travel = config.size.thumb_travel(padding);
         let radius = track_height / 2.0; // Fully rounded track
 
         // Get colors
@@ -308,7 +313,7 @@ impl SwitchConfig {
         let padding = ThemeState::try_get()
             .map(|theme| theme.components().compact.switch_inset)
             .unwrap_or(2.0);
-        let thumb_travel = size.track_width() - size.thumb_size() - (padding * 2.0);
+        let thumb_travel = size.thumb_travel(padding);
         let is_on = on_state.get();
         let initial_x = if is_on { thumb_travel } else { 0.0 };
         let initial_color_t = if is_on { 1.0 } else { 0.0 };
@@ -510,12 +515,8 @@ mod tests {
     #[test]
     fn test_thumb_travel() {
         let size = SwitchSize::Medium;
-        if ThemeState::try_get().is_none() {
-            ThemeState::init_default();
-        }
-        let padding = ThemeState::get().components().compact.switch_inset;
-        let travel = size.track_width() - size.thumb_size() - (padding * 2.0);
-        // Travel should be: 44 - 20 - 4 = 20
-        assert_eq!(travel, 20.0);
+
+        assert_eq!(size.thumb_travel(2.0), 20.0);
+        assert_eq!(size.thumb_travel(3.0), 18.0);
     }
 }

--- a/crates/blinc_cn/src/components/tabs.rs
+++ b/crates/blinc_cn/src/components/tabs.rs
@@ -146,29 +146,32 @@ pub enum TabsSize {
 
 impl TabsSize {
     /// Get the height for the tab list
-    fn height(&self) -> f32 {
+    fn height(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            TabsSize::Small => 32.0,
-            TabsSize::Medium => 40.0,
-            TabsSize::Large => 48.0,
+            TabsSize::Small => tokens.control.height_sm,
+            TabsSize::Medium => tokens.control.height_md,
+            TabsSize::Large => tokens.control.height_lg,
         }
     }
 
     /// Get the font size
-    fn font_size(&self) -> f32 {
+    fn font_size(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            TabsSize::Small => 13.0,
-            TabsSize::Medium => 14.0,
-            TabsSize::Large => 16.0,
+            TabsSize::Small => tokens.typography.action_sm,
+            TabsSize::Medium => tokens.typography.action_md,
+            TabsSize::Large => tokens.typography.action_lg,
         }
     }
 
     /// Get the horizontal padding
-    fn padding_x(&self) -> f32 {
+    fn padding_x(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            TabsSize::Small => 12.0,
-            TabsSize::Medium => 16.0,
-            TabsSize::Large => 20.0,
+            TabsSize::Small => tokens.control.padding_x_sm,
+            TabsSize::Medium => tokens.control.padding_x_md,
+            TabsSize::Large => tokens.control.padding_x_lg,
         }
     }
 
@@ -584,14 +587,13 @@ impl TabsBuilder {
             }
         }
 
-        // Theme colors - use SecondaryHover for better contrast with text
-        let tab_list_bg = theme.color(ColorToken::SurfaceOverlay);
+        let tab_list_bg = theme.color(ColorToken::SurfaceElevated);
         let _radius = theme.radius(RadiusToken::Md);
         let content_margin = theme.spacing().space_1;
         let size = config.size;
 
         let border = if matches!(theme.scheme(), ColorScheme::Dark) {
-            theme.color(ColorToken::Surface)
+            theme.color(ColorToken::Border)
         } else {
             Color::TRANSPARENT
         };
@@ -616,15 +618,15 @@ impl TabsBuilder {
 
                 let mut buttons = div()
                     .class("cn-tabs-list")
-                    .h(size.height())
+                    .h(size.height(theme))
                     .w_full()
                     .bg(tab_list_bg)
                     .rounded_md()
-                    .padding(Length::Px(6.0))
+                    .padding(Length::Px(theme.components().overlay.gap))
                     .flex_row()
                     .items_center()
                     .border(1.0, border)
-                    .gap(4.0);
+                    .gap_px(theme.components().compact.cluster_gap_sm);
 
                 for tab in tabs_for_buttons.iter() {
                     let is_active = tab.menu_item.value() == active_value;
@@ -792,7 +794,7 @@ fn build_tab_trigger(
     let disabled = menu_item.disabled;
 
     // Calculate inner height (tab list height minus padding)
-    let inner_height = size.height() - 16.0;
+    let inner_height = size.height(theme) - theme.spacing().space_4;
 
     // Clone menu_item data for closure
     let icon_svg = menu_item.icon.clone();
@@ -841,7 +843,7 @@ fn build_tab_trigger(
         if let Some(ref label) = label_text {
             content = content.child(
                 text(label)
-                    .size(size.font_size())
+                    .size(size.font_size(theme))
                     .color(text_color)
                     .weight(if is_active {
                         FontWeight::Medium
@@ -858,7 +860,7 @@ fn build_tab_trigger(
             content = content.child(
                 div()
                     .px(theme.spacing().space_1_5)
-                    .py(1.0)
+                    .py(theme.components().compact.switch_inset)
                     .bg(primary)
                     .rounded(theme.radius(RadiusToken::Full))
                     .child(
@@ -882,9 +884,9 @@ fn build_tab_trigger(
             .class("cn-tabs-trigger")
             .class(trigger_size_class)
             .h(inner_height)
-            .padding_x(Length::Px(size.padding_x()))
+            .padding_x(Length::Px(size.padding_x(theme)))
             .padding_y(Length::Px(
-                size.padding_x() / if size != TabsSize::Small { 2.0 } else { 1.0 },
+                size.padding_x(theme) / if size != TabsSize::Small { 2.0 } else { 1.0 },
             ))
             .flex_row()
             .items_center()
@@ -992,8 +994,13 @@ mod tests {
 
     #[test]
     fn test_tabs_size() {
-        assert_eq!(TabsSize::Small.height(), 32.0);
-        assert_eq!(TabsSize::Medium.height(), 40.0);
-        assert_eq!(TabsSize::Large.height(), 48.0);
+        if ThemeState::try_get().is_none() {
+            ThemeState::init_default();
+        }
+        let theme = ThemeState::get();
+        let tokens = theme.components();
+        assert_eq!(TabsSize::Small.height(theme), tokens.control.height_sm);
+        assert_eq!(TabsSize::Medium.height(theme), tokens.control.height_md);
+        assert_eq!(TabsSize::Large.height(theme), tokens.control.height_lg);
     }
 }

--- a/crates/blinc_cn/src/components/textarea.rs
+++ b/crates/blinc_cn/src/components/textarea.rs
@@ -59,11 +59,12 @@ impl TextareaSize {
         }
     }
 
-    fn font_size(&self, typography: &TypographyTokens) -> f32 {
+    fn font_size(&self, theme: &ThemeState) -> f32 {
+        let tokens = theme.components();
         match self {
-            TextareaSize::Small => typography.text_xs,   // 12px
-            TextareaSize::Medium => typography.text_sm,  // 14px
-            TextareaSize::Large => typography.text_base, // 16px
+            TextareaSize::Small => tokens.typography.body_sm,
+            TextareaSize::Medium => tokens.typography.body_md,
+            TextareaSize::Large => tokens.typography.body_lg,
         }
     }
 }
@@ -124,15 +125,14 @@ impl Textarea {
     /// Build from config
     fn from_config(config: TextareaConfig) -> Self {
         let theme = ThemeState::get();
-        let typography = theme.typography();
 
         // Build the layout TextArea
         let radius = config
             .corner_radius
-            .unwrap_or_else(|| theme.radius(RadiusToken::Md));
+            .unwrap_or_else(|| theme.components().control.radius_md);
 
         let mut ta = text_area(&config.state)
-            .font_size(config.size.font_size(&typography))
+            .font_size(config.size.font_size(theme))
             .rounded(radius)
             .disabled(config.disabled)
             .wrap(config.wrap);
@@ -178,49 +178,50 @@ impl Textarea {
         let ta = ta.class("cn-textarea");
 
         // If no label, description, or error, wrap in a minimal container
-        let inner =
-            if config.label.is_none() && config.description.is_none() && config.error.is_none() {
-                div().child(ta)
-            } else {
-                // Build a container with label, textarea, and description/error
-                let spacing = theme.spacing_value(SpacingToken::Space2);
-                let mut container = div().flex_col().gap_px(spacing).h_fit();
+        let inner = if config.label.is_none()
+            && config.description.is_none()
+            && config.error.is_none()
+        {
+            div().child(ta)
+        } else {
+            // Build a container with label, textarea, and description/error
+            let spacing = theme.spacing_value(SpacingToken::Space2);
+            let mut container = div().flex_col().gap_px(spacing).h_fit();
 
-                // Apply width to container
-                if config.full_width {
-                    container = container.w_full();
-                } else if let Some(w) = config.width {
-                    container = container.w(w);
+            // Apply width to container
+            if config.full_width {
+                container = container.w_full();
+            } else if let Some(w) = config.width {
+                container = container.w(w);
+            }
+
+            // Label
+            if let Some(ref label_text) = config.label {
+                let mut lbl = label(label_text).size(LabelSize::Medium);
+                if config.required {
+                    lbl = lbl.required();
                 }
-
-                // Label
-                if let Some(ref label_text) = config.label {
-                    let mut lbl = label(label_text).size(LabelSize::Medium);
-                    if config.required {
-                        lbl = lbl.required();
-                    }
-                    if config.disabled {
-                        lbl = lbl.disabled(true);
-                    }
-                    container = container.child(lbl);
+                if config.disabled {
+                    lbl = lbl.disabled(true);
                 }
+                container = container.child(lbl);
+            }
 
-                // Textarea (added directly — TextArea has the cn-textarea class)
-                container = container.child(ta);
+            // Textarea (added directly — TextArea has the cn-textarea class)
+            container = container.child(ta);
 
-                // Error or description
-                if let Some(ref error_text) = config.error {
-                    let error_color = theme.color(ColorToken::Error);
-                    container = container
-                        .child(text(error_text).size(typography.text_xs).color(error_color));
-                } else if let Some(ref desc_text) = config.description {
-                    let desc_color = theme.color(ColorToken::TextTertiary);
-                    container =
-                        container.child(text(desc_text).size(typography.text_xs).color(desc_color));
-                }
+            // Error or description
+            let helper_size = theme.components().typography.helper;
+            if let Some(ref error_text) = config.error {
+                let error_color = theme.color(ColorToken::Error);
+                container = container.child(text(error_text).size(helper_size).color(error_color));
+            } else if let Some(ref desc_text) = config.description {
+                let desc_color = theme.color(ColorToken::TextTertiary);
+                container = container.child(text(desc_text).size(helper_size).color(desc_color));
+            }
 
-                container
-            };
+            container
+        };
 
         Self { inner }
     }
@@ -453,7 +454,8 @@ mod tests {
 
     #[test]
     fn test_textarea_size_values() {
-        let typography = TypographyTokens::default();
+        init_theme();
+        let theme = ThemeState::get();
 
         // Default rows for each size
         assert_eq!(TextareaSize::Small.default_rows(), 3);
@@ -462,16 +464,16 @@ mod tests {
 
         // Font sizes
         assert_eq!(
-            TextareaSize::Small.font_size(&typography),
-            typography.text_xs
+            TextareaSize::Small.font_size(theme),
+            theme.components().typography.body_sm
         );
         assert_eq!(
-            TextareaSize::Medium.font_size(&typography),
-            typography.text_sm
+            TextareaSize::Medium.font_size(theme),
+            theme.components().typography.body_md
         );
         assert_eq!(
-            TextareaSize::Large.font_size(&typography),
-            typography.text_base
+            TextareaSize::Large.font_size(theme),
+            theme.components().typography.body_lg
         );
     }
 

--- a/crates/blinc_cn/src/lib.rs
+++ b/crates/blinc_cn/src/lib.rs
@@ -48,6 +48,30 @@ pub use components::*;
 
 // Re-export InstanceKey from blinc_layout (the canonical location)
 pub use blinc_layout::InstanceKey;
+use blinc_theme::{ColorScheme, ThemeBundle, ThemeState};
+
+/// Ensure a default platform-aware theme is initialized and return the active theme state.
+pub fn ensure_default_theme() -> &'static ThemeState {
+    ThemeState::try_get().unwrap_or_else(|| {
+        ThemeState::init_default();
+        ThemeState::get()
+    })
+}
+
+/// Ensure a specific theme bundle is initialized and return the active theme state.
+///
+/// If theme state is already initialized, the existing singleton is preserved.
+pub fn ensure_theme(bundle: ThemeBundle, scheme: ColorScheme) -> &'static ThemeState {
+    ThemeState::try_get().unwrap_or_else(|| {
+        ThemeState::init(bundle, scheme);
+        ThemeState::get()
+    })
+}
+
+/// Return the default stylesheet used by `blinc_cn` components.
+pub fn default_styles() -> &'static str {
+    cn_styles::CN_STYLES
+}
 
 /// Convenience module for accessing components with `cn::` prefix
 pub mod cn {
@@ -248,4 +272,20 @@ pub mod prelude {
     pub use blinc_theme::{ColorToken, RadiusToken, ShadowToken, SpacingToken, ThemeState};
     // Re-export icons module for easy access
     pub use blinc_icons::icons;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{default_styles, ensure_default_theme};
+
+    #[test]
+    fn bootstrap_default_styles_are_exposed() {
+        assert!(default_styles().contains(".cn-button"));
+    }
+
+    #[test]
+    fn bootstrap_ensure_default_theme_initializes_theme_state() {
+        let theme = ensure_default_theme();
+        assert!(theme.color(blinc_theme::ColorToken::Background).a > 0.0);
+    }
 }

--- a/crates/blinc_debugger/src/app.rs
+++ b/crates/blinc_debugger/src/app.rs
@@ -1,4 +1,4 @@
-//! Main application module for the debugger.
+// Main application module for the debugger.
 
 use crate::panels::{
     CommandPanel, EvidencePanel, InspectorPanel, PreviewConfig, PreviewPanel, TimelinePanel,

--- a/crates/blinc_layout/README.md
+++ b/crates/blinc_layout/README.md
@@ -10,6 +10,7 @@ Flexbox layout engine for Blinc UI, powered by [Taffy](https://github.com/Dioxus
 ## Overview
 
 `blinc_layout` provides a declarative, builder-style API for constructing UI layouts. It combines Taffy's flexbox implementation with a rich set of interactive elements and rendering capabilities.
+It provides primitives and widget defaults, while polished design-system defaults are expected to live in `blinc_cn`.
 
 ## Features
 

--- a/crates/blinc_platform/README.md
+++ b/crates/blinc_platform/README.md
@@ -9,13 +9,16 @@ Platform abstraction layer for Blinc UI.
 
 ## Overview
 
-`blinc_platform` defines the traits and types for cross-platform windowing, input handling, and application lifecycle. Platform-specific implementations are provided by separate crates.
+`blinc_platform` defines the shared traits and data types used by desktop and
+mobile runtimes. Platform-specific implementations are provided by separate
+crates, and mobile support currently exposes bridge-oriented capability helpers
+in addition to the common abstractions.
 
 ## Features
 
 - **Platform Trait**: Unified API for all platforms
-- **Window Management**: Create, configure, and manage windows
-- **Event Loop**: Handle platform events and callbacks
+- **Window Management**: Shared window/config types
+- **Event Loop**: Shared event and callback types
 - **Input Events**: Mouse, keyboard, touch input
 - **Asset Loading**: Platform-agnostic asset access
 - **Platform Services**: Permissions, Clipboard, Microphone permission, BLE scan runtime
@@ -32,6 +35,12 @@ Platform abstraction layer for Blinc UI.
 - `sensors`: migrated typed API previously provided by `blinc_sensors`
 
 ## Traits
+
+## Notes
+
+- Desktop implementations are the most complete consumers of these traits today.
+- Mobile crates also use `blinc_platform` for shared event types and capability
+  wrappers even where a full trait implementation is still evolving.
 
 ### Platform
 

--- a/crates/blinc_theme/src/state.rs
+++ b/crates/blinc_theme/src/state.rs
@@ -71,6 +71,9 @@ pub struct ThemeState {
     /// Current radius tokens
     radii: RwLock<RadiusTokens>,
 
+    /// Current semantic component tokens
+    components: RwLock<ComponentTokens>,
+
     /// Current animation tokens
     animations: RwLock<AnimationTokens>,
 
@@ -100,6 +103,66 @@ pub struct ThemeState {
 }
 
 impl ThemeState {
+    fn effective_spacing_tokens(&self) -> SpacingTokens {
+        let mut spacing = self.spacing.read().unwrap().clone();
+        for (token, value) in self.spacing_overrides.read().unwrap().iter() {
+            match token {
+                SpacingToken::Space0 => spacing.space_0 = *value,
+                SpacingToken::Space0_5 => spacing.space_0_5 = *value,
+                SpacingToken::Space1 => spacing.space_1 = *value,
+                SpacingToken::Space1_5 => spacing.space_1_5 = *value,
+                SpacingToken::Space2 => spacing.space_2 = *value,
+                SpacingToken::Space2_5 => spacing.space_2_5 = *value,
+                SpacingToken::Space3 => spacing.space_3 = *value,
+                SpacingToken::Space3_5 => spacing.space_3_5 = *value,
+                SpacingToken::Space4 => spacing.space_4 = *value,
+                SpacingToken::Space5 => spacing.space_5 = *value,
+                SpacingToken::Space6 => spacing.space_6 = *value,
+                SpacingToken::Space7 => spacing.space_7 = *value,
+                SpacingToken::Space8 => spacing.space_8 = *value,
+                SpacingToken::Space9 => spacing.space_9 = *value,
+                SpacingToken::Space10 => spacing.space_10 = *value,
+                SpacingToken::Space11 => spacing.space_11 = *value,
+                SpacingToken::Space12 => spacing.space_12 = *value,
+                SpacingToken::Space14 => spacing.space_14 = *value,
+                SpacingToken::Space16 => spacing.space_16 = *value,
+                SpacingToken::Space20 => spacing.space_20 = *value,
+                SpacingToken::Space24 => spacing.space_24 = *value,
+                SpacingToken::Space28 => spacing.space_28 = *value,
+                SpacingToken::Space32 => spacing.space_32 = *value,
+            }
+        }
+        spacing
+    }
+
+    fn effective_radius_tokens(&self) -> RadiusTokens {
+        let mut radii = self.radii.read().unwrap().clone();
+        for (token, value) in self.radius_overrides.read().unwrap().iter() {
+            match token {
+                RadiusToken::None => radii.radius_none = *value,
+                RadiusToken::Sm => radii.radius_sm = *value,
+                RadiusToken::Default => radii.radius_default = *value,
+                RadiusToken::Md => radii.radius_md = *value,
+                RadiusToken::Lg => radii.radius_lg = *value,
+                RadiusToken::Xl => radii.radius_xl = *value,
+                RadiusToken::Xxl => radii.radius_2xl = *value,
+                RadiusToken::Xxxl => radii.radius_3xl = *value,
+                RadiusToken::Full => radii.radius_full = *value,
+            }
+        }
+        radii
+    }
+
+    fn recompute_component_tokens(&self) {
+        let spacing = self.effective_spacing_tokens();
+        let radii = self.effective_radius_tokens();
+        let typography = self.typography.read().unwrap().clone();
+        let shadows = self.shadows.read().unwrap().clone();
+
+        *self.components.write().unwrap() =
+            ComponentTokens::from_primitives(&spacing, &radii, &typography, &shadows);
+    }
+
     /// Initialize the global theme state (call once at app startup)
     pub fn init(bundle: ThemeBundle, scheme: ColorScheme) {
         let theme = bundle.for_scheme(scheme);
@@ -113,6 +176,7 @@ impl ThemeState {
             spacing: RwLock::new(theme.spacing().clone()),
             typography: RwLock::new(theme.typography().clone()),
             radii: RwLock::new(theme.radii().clone()),
+            components: RwLock::new(theme.components()),
             animations: RwLock::new(theme.animations().clone()),
             color_overrides: RwLock::new(FxHashMap::default()),
             spacing_overrides: RwLock::new(FxHashMap::default()),
@@ -194,6 +258,7 @@ impl ThemeState {
             *self.spacing.write().unwrap() = theme.spacing().clone();
             *self.typography.write().unwrap() = theme.typography().clone();
             *self.radii.write().unwrap() = theme.radii().clone();
+            *self.components.write().unwrap() = theme.components();
             *self.animations.write().unwrap() = theme.animations().clone();
 
             // Try to animate colors if scheduler handle is available
@@ -364,7 +429,7 @@ impl ThemeState {
             }
         }
 
-        let mut vars = HashMap::with_capacity(44);
+        let mut vars = HashMap::with_capacity(70);
 
         // Use self.color() which checks overrides first
         vars.insert("primary".into(), hex(self.color(ColorToken::Primary)));
@@ -469,7 +534,120 @@ impl ThemeState {
             hex(self.color(ColorToken::TooltipText)),
         );
 
+        let components = self.components();
+        vars.insert("control-height-sm".into(), px(components.control.height_sm));
+        vars.insert("control-height-md".into(), px(components.control.height_md));
+        vars.insert("control-height-lg".into(), px(components.control.height_lg));
+        vars.insert("control-px-sm".into(), px(components.control.padding_x_sm));
+        vars.insert("control-px-md".into(), px(components.control.padding_x_md));
+        vars.insert("control-px-lg".into(), px(components.control.padding_x_lg));
+        vars.insert("control-py-sm".into(), px(components.control.padding_y_sm));
+        vars.insert("control-py-md".into(), px(components.control.padding_y_md));
+        vars.insert("control-py-lg".into(), px(components.control.padding_y_lg));
+        vars.insert("control-radius-sm".into(), px(components.control.radius_sm));
+        vars.insert("control-radius-md".into(), px(components.control.radius_md));
+        vars.insert("control-radius-lg".into(), px(components.control.radius_lg));
+        vars.insert("container-radius".into(), px(components.container.radius));
+        vars.insert("container-padding".into(), px(components.container.padding));
+        vars.insert(
+            "container-padding-compact".into(),
+            px(components.container.padding_compact),
+        );
+        vars.insert(
+            "container-header-gap".into(),
+            px(components.container.header_gap),
+        );
+        vars.insert(
+            "container-footer-gap".into(),
+            px(components.container.footer_gap),
+        );
+        vars.insert(
+            "container-section-gap".into(),
+            px(components.container.section_gap),
+        );
+        vars.insert("overlay-radius".into(), px(components.overlay.radius));
+        vars.insert("overlay-px".into(), px(components.overlay.padding_x));
+        vars.insert("overlay-py".into(), px(components.overlay.padding_y));
+        vars.insert(
+            "overlay-item-px".into(),
+            px(components.overlay.item_padding_x),
+        );
+        vars.insert(
+            "overlay-item-py".into(),
+            px(components.overlay.item_padding_y),
+        );
+        vars.insert("overlay-gap".into(), px(components.overlay.gap));
+        vars.insert(
+            "overlay-shadow".into(),
+            css_shadow(&components.overlay.shadow),
+        );
+        vars.insert("type-action-sm".into(), px(components.typography.action_sm));
+        vars.insert("type-action-md".into(), px(components.typography.action_md));
+        vars.insert("type-action-lg".into(), px(components.typography.action_lg));
+        vars.insert("type-body-sm".into(), px(components.typography.body_sm));
+        vars.insert("type-body-md".into(), px(components.typography.body_md));
+        vars.insert("type-body-lg".into(), px(components.typography.body_lg));
+        vars.insert("type-label-sm".into(), px(components.typography.label_sm));
+        vars.insert("type-label-md".into(), px(components.typography.label_md));
+        vars.insert("type-label-lg".into(), px(components.typography.label_lg));
+        vars.insert("type-helper".into(), px(components.typography.helper));
+        vars.insert("type-badge".into(), px(components.typography.badge));
+        vars.insert("type-title".into(), px(components.typography.title));
+        vars.insert(
+            "compact-badge-radius".into(),
+            px(components.compact.badge_radius),
+        );
+        vars.insert(
+            "compact-badge-px".into(),
+            px(components.compact.badge_padding_x),
+        );
+        vars.insert(
+            "compact-badge-py".into(),
+            px(components.compact.badge_padding_y),
+        );
+        vars.insert(
+            "compact-kbd-radius".into(),
+            px(components.compact.kbd_radius),
+        );
+        vars.insert(
+            "compact-kbd-px".into(),
+            px(components.compact.kbd_padding_x),
+        );
+        vars.insert(
+            "compact-kbd-py".into(),
+            px(components.compact.kbd_padding_y),
+        );
+        vars.insert(
+            "compact-cluster-gap-sm".into(),
+            px(components.compact.cluster_gap_sm),
+        );
+        vars.insert(
+            "compact-cluster-gap-md".into(),
+            px(components.compact.cluster_gap_md),
+        );
+        vars.insert(
+            "compact-progress-height-sm".into(),
+            px(components.compact.progress_height_sm),
+        );
+        vars.insert(
+            "compact-progress-height-md".into(),
+            px(components.compact.progress_height_md),
+        );
+        vars.insert(
+            "compact-progress-height-lg".into(),
+            px(components.compact.progress_height_lg),
+        );
+        vars.insert(
+            "compact-switch-inset".into(),
+            px(components.compact.switch_inset),
+        );
+
         vars
+    }
+
+    /// Get semantic component tokens
+    pub fn components(&self) -> ComponentTokens {
+        self.components.read().unwrap().clone()
     }
 
     // ========== Opacity Access ==========
@@ -519,6 +697,7 @@ impl ThemeState {
     /// Set a spacing override (triggers layout)
     pub fn set_spacing_override(&self, token: SpacingToken, value: f32) {
         self.spacing_overrides.write().unwrap().insert(token, value);
+        self.recompute_component_tokens();
         self.needs_layout.store(true, Ordering::SeqCst);
         trigger_redraw();
     }
@@ -526,6 +705,7 @@ impl ThemeState {
     /// Remove a spacing override
     pub fn remove_spacing_override(&self, token: SpacingToken) {
         self.spacing_overrides.write().unwrap().remove(&token);
+        self.recompute_component_tokens();
         self.needs_layout.store(true, Ordering::SeqCst);
         trigger_redraw();
     }
@@ -555,6 +735,15 @@ impl ThemeState {
     /// Set a radius override (triggers repaint - radii don't affect layout)
     pub fn set_radius_override(&self, token: RadiusToken, value: f32) {
         self.radius_overrides.write().unwrap().insert(token, value);
+        self.recompute_component_tokens();
+        self.needs_repaint.store(true, Ordering::SeqCst);
+        trigger_redraw();
+    }
+
+    /// Remove a radius override
+    pub fn remove_radius_override(&self, token: RadiusToken) {
+        self.radius_overrides.write().unwrap().remove(&token);
+        self.recompute_component_tokens();
         self.needs_repaint.store(true, Ordering::SeqCst);
         trigger_redraw();
     }
@@ -603,6 +792,7 @@ impl ThemeState {
         self.spacing_overrides.write().unwrap().clear();
         self.opacity_overrides.write().unwrap().clear();
         self.radius_overrides.write().unwrap().clear();
+        self.recompute_component_tokens();
         self.needs_repaint.store(true, Ordering::SeqCst);
         self.needs_layout.store(true, Ordering::SeqCst);
         trigger_redraw();
@@ -612,4 +802,30 @@ impl ThemeState {
 /// Interpolate between two color token sets
 fn interpolate_color_tokens(from: &ColorTokens, to: &ColorTokens, t: f32) -> ColorTokens {
     ColorTokens::lerp(from, to, t)
+}
+
+fn px(value: f32) -> String {
+    if value.fract() == 0.0 {
+        format!("{value:.0}px")
+    } else {
+        format!("{value:.2}px")
+    }
+}
+
+fn css_shadow(shadow: &Shadow) -> String {
+    if shadow.color.a == 0.0 {
+        return "none".into();
+    }
+
+    format!(
+        "{} {} {} {} rgba({},{},{},{})",
+        px(shadow.offset_x),
+        px(shadow.offset_y),
+        px(shadow.blur),
+        px(shadow.spread),
+        (shadow.color.r * 255.0) as u8,
+        (shadow.color.g * 255.0) as u8,
+        (shadow.color.b * 255.0) as u8,
+        shadow.color.a
+    )
 }

--- a/crates/blinc_theme/src/state.rs
+++ b/crates/blinc_theme/src/state.rs
@@ -547,6 +547,14 @@ impl ThemeState {
         vars.insert("control-radius-sm".into(), px(components.control.radius_sm));
         vars.insert("control-radius-md".into(), px(components.control.radius_md));
         vars.insert("control-radius-lg".into(), px(components.control.radius_lg));
+        vars.insert(
+            "control-corner-shape".into(),
+            components.control.corner_shape_rest.to_string(),
+        );
+        vars.insert(
+            "control-corner-shape-hover".into(),
+            components.control.corner_shape_hover.to_string(),
+        );
         vars.insert("container-radius".into(), px(components.container.radius));
         vars.insert("container-padding".into(), px(components.container.padding));
         vars.insert(
@@ -565,6 +573,10 @@ impl ThemeState {
             "container-section-gap".into(),
             px(components.container.section_gap),
         );
+        vars.insert(
+            "container-corner-shape".into(),
+            components.container.corner_shape.to_string(),
+        );
         vars.insert("overlay-radius".into(), px(components.overlay.radius));
         vars.insert("overlay-px".into(), px(components.overlay.padding_x));
         vars.insert("overlay-py".into(), px(components.overlay.padding_y));
@@ -580,6 +592,10 @@ impl ThemeState {
         vars.insert(
             "overlay-shadow".into(),
             css_shadow(&components.overlay.shadow),
+        );
+        vars.insert(
+            "overlay-corner-shape".into(),
+            components.overlay.corner_shape.to_string(),
         );
         vars.insert("type-action-sm".into(), px(components.typography.action_sm));
         vars.insert("type-action-md".into(), px(components.typography.action_md));

--- a/crates/blinc_theme/src/theme.rs
+++ b/crates/blinc_theme/src/theme.rs
@@ -46,6 +46,16 @@ pub trait Theme: Send + Sync + std::fmt::Debug {
 
     /// Get animation tokens
     fn animations(&self) -> &AnimationTokens;
+
+    /// Get semantic component tokens derived from primitive scales.
+    fn components(&self) -> ComponentTokens {
+        ComponentTokens::from_primitives(
+            self.spacing(),
+            self.radii(),
+            self.typography(),
+            self.shadows(),
+        )
+    }
 }
 
 /// A theme bundle containing both light and dark variants

--- a/crates/blinc_theme/src/tokens/component.rs
+++ b/crates/blinc_theme/src/tokens/component.rs
@@ -17,6 +17,8 @@ pub struct ControlTokens {
     pub radius_sm: f32,
     pub radius_md: f32,
     pub radius_lg: f32,
+    pub corner_shape_rest: f32,
+    pub corner_shape_hover: f32,
 }
 
 /// Semantic defaults for cards, dialogs, drawers, and other content containers.
@@ -28,6 +30,7 @@ pub struct ContainerTokens {
     pub header_gap: f32,
     pub footer_gap: f32,
     pub section_gap: f32,
+    pub corner_shape: f32,
 }
 
 /// Semantic defaults for menus, popovers, selects, and other floating overlays.
@@ -40,6 +43,7 @@ pub struct OverlayTokens {
     pub item_padding_y: f32,
     pub gap: f32,
     pub shadow: Shadow,
+    pub corner_shape: f32,
 }
 
 /// Semantic typography roles used by components.
@@ -108,6 +112,8 @@ impl ComponentTokens {
                 radius_sm: radii.radius_sm,
                 radius_md: radii.radius_default,
                 radius_lg: radii.radius_md,
+                corner_shape_rest: 1.2,
+                corner_shape_hover: 2.0,
             },
             container: ContainerTokens {
                 radius: radii.radius_xl,
@@ -116,6 +122,7 @@ impl ComponentTokens {
                 header_gap: spacing.space_1_5,
                 footer_gap: spacing.space_2,
                 section_gap: spacing.space_4,
+                corner_shape: 1.6,
             },
             overlay: OverlayTokens {
                 radius: radii.radius_md,
@@ -125,6 +132,7 @@ impl ComponentTokens {
                 item_padding_y: spacing.space_2,
                 gap: spacing.space_1,
                 shadow: shadows.shadow_md.clone(),
+                corner_shape: 1.8,
             },
             typography: TypographyRoleTokens {
                 action_sm: typography.text_xs + 1.0,

--- a/crates/blinc_theme/src/tokens/component.rs
+++ b/crates/blinc_theme/src/tokens/component.rs
@@ -1,0 +1,159 @@
+//! Semantic component tokens derived from primitive theme scales.
+
+use crate::tokens::{RadiusTokens, Shadow, ShadowTokens, SpacingTokens, TypographyTokens};
+
+/// Semantic defaults for control-like components such as buttons and inputs.
+#[derive(Clone, Debug)]
+pub struct ControlTokens {
+    pub height_sm: f32,
+    pub height_md: f32,
+    pub height_lg: f32,
+    pub padding_x_sm: f32,
+    pub padding_x_md: f32,
+    pub padding_x_lg: f32,
+    pub padding_y_sm: f32,
+    pub padding_y_md: f32,
+    pub padding_y_lg: f32,
+    pub radius_sm: f32,
+    pub radius_md: f32,
+    pub radius_lg: f32,
+}
+
+/// Semantic defaults for cards, dialogs, drawers, and other content containers.
+#[derive(Clone, Debug)]
+pub struct ContainerTokens {
+    pub radius: f32,
+    pub padding: f32,
+    pub padding_compact: f32,
+    pub header_gap: f32,
+    pub footer_gap: f32,
+    pub section_gap: f32,
+}
+
+/// Semantic defaults for menus, popovers, selects, and other floating overlays.
+#[derive(Clone, Debug)]
+pub struct OverlayTokens {
+    pub radius: f32,
+    pub padding_x: f32,
+    pub padding_y: f32,
+    pub item_padding_x: f32,
+    pub item_padding_y: f32,
+    pub gap: f32,
+    pub shadow: Shadow,
+}
+
+/// Semantic typography roles used by components.
+#[derive(Clone, Debug)]
+pub struct TypographyRoleTokens {
+    pub action_sm: f32,
+    pub action_md: f32,
+    pub action_lg: f32,
+    pub body_sm: f32,
+    pub body_md: f32,
+    pub body_lg: f32,
+    pub label_sm: f32,
+    pub label_md: f32,
+    pub label_lg: f32,
+    pub helper: f32,
+    pub badge: f32,
+    pub title: f32,
+}
+
+/// Semantic defaults for compact surfaces such as badges and keyboard hints.
+#[derive(Clone, Debug)]
+pub struct CompactTokens {
+    pub badge_radius: f32,
+    pub badge_padding_x: f32,
+    pub badge_padding_y: f32,
+    pub kbd_radius: f32,
+    pub kbd_padding_x: f32,
+    pub kbd_padding_y: f32,
+    pub cluster_gap_sm: f32,
+    pub cluster_gap_md: f32,
+    pub progress_height_sm: f32,
+    pub progress_height_md: f32,
+    pub progress_height_lg: f32,
+    pub switch_inset: f32,
+}
+
+/// Semantic component token set.
+#[derive(Clone, Debug)]
+pub struct ComponentTokens {
+    pub control: ControlTokens,
+    pub container: ContainerTokens,
+    pub overlay: OverlayTokens,
+    pub typography: TypographyRoleTokens,
+    pub compact: CompactTokens,
+}
+
+impl ComponentTokens {
+    /// Derive semantic component tokens from primitive scales.
+    pub fn from_primitives(
+        spacing: &SpacingTokens,
+        radii: &RadiusTokens,
+        typography: &TypographyTokens,
+        shadows: &ShadowTokens,
+    ) -> Self {
+        Self {
+            control: ControlTokens {
+                height_sm: spacing.space_8,
+                height_md: spacing.space_10,
+                height_lg: spacing.space_12,
+                padding_x_sm: spacing.space_3,
+                padding_x_md: spacing.space_4,
+                padding_x_lg: spacing.space_5,
+                padding_y_sm: spacing.space_1,
+                padding_y_md: spacing.space_2,
+                padding_y_lg: spacing.space_3,
+                radius_sm: radii.radius_sm,
+                radius_md: radii.radius_default,
+                radius_lg: radii.radius_md,
+            },
+            container: ContainerTokens {
+                radius: radii.radius_xl,
+                padding: spacing.space_6,
+                padding_compact: spacing.space_4,
+                header_gap: spacing.space_1_5,
+                footer_gap: spacing.space_2,
+                section_gap: spacing.space_4,
+            },
+            overlay: OverlayTokens {
+                radius: radii.radius_md,
+                padding_x: spacing.space_3,
+                padding_y: spacing.space_2,
+                item_padding_x: spacing.space_3,
+                item_padding_y: spacing.space_2,
+                gap: spacing.space_1,
+                shadow: shadows.shadow_md.clone(),
+            },
+            typography: TypographyRoleTokens {
+                action_sm: typography.text_xs + 1.0,
+                action_md: typography.text_sm,
+                action_lg: typography.text_base,
+                body_sm: typography.text_xs + 1.0,
+                body_md: typography.text_sm,
+                body_lg: typography.text_base,
+                label_sm: typography.text_xs,
+                label_md: typography.text_sm,
+                label_lg: typography.text_base,
+                helper: typography.text_xs,
+                badge: typography.text_xs,
+                title: typography.text_lg,
+            },
+            compact: CompactTokens {
+                badge_radius: radii.radius_full,
+                badge_padding_x: spacing.space_2_5,
+                badge_padding_y: spacing.space_0_5,
+                kbd_radius: radii.radius_sm,
+                kbd_padding_x: spacing.space_1_5,
+                kbd_padding_y: spacing.space_0_5,
+                cluster_gap_sm: spacing.space_1,
+                cluster_gap_md: spacing.space_2,
+                progress_height_sm: spacing.space_1,
+                progress_height_md: spacing.space_2,
+                progress_height_lg: spacing.space_3,
+                switch_inset: spacing.space_0_5,
+            },
+        }
+    }
+}

--- a/crates/blinc_theme/src/tokens/mod.rs
+++ b/crates/blinc_theme/src/tokens/mod.rs
@@ -11,6 +11,7 @@
 
 mod animation;
 mod color;
+mod component;
 mod opacity;
 mod radius;
 mod shadow;
@@ -19,6 +20,7 @@ mod typography;
 
 pub use animation::*;
 pub use color::*;
+pub use component::*;
 pub use opacity::*;
 pub use radius::*;
 pub use shadow::*;

--- a/crates/blinc_theme/tests/presets.rs
+++ b/crates/blinc_theme/tests/presets.rs
@@ -1,4 +1,4 @@
-use blinc_theme::{ColorScheme, ColorToken, RadiusToken, ThemePreset};
+use blinc_theme::{ColorScheme, ColorToken, RadiusToken, SpacingToken, ThemePreset, ThemeState};
 
 #[test]
 fn preset_catalog_contains_expected_presets() {
@@ -63,6 +63,66 @@ fn shadcn_like_presets_use_readable_selection_text() {
             );
         }
     }
+}
+
+#[test]
+fn shadcn_like_presets_expose_component_tokens_derived_from_primitive_scales() {
+    for preset in [ThemePreset::Neutral, ThemePreset::Slate, ThemePreset::Zinc] {
+        let bundle = preset.bundle();
+        let theme = bundle.for_scheme(ColorScheme::Light);
+        let components = theme.components();
+        let spacing = theme.spacing();
+        let radii = theme.radii();
+        let typography = theme.typography();
+
+        assert_eq!(components.control.height_md, spacing.space_10);
+        assert_eq!(components.control.padding_x_md, spacing.space_4);
+        assert_eq!(components.control.radius_md, radii.radius_default);
+        assert_eq!(components.container.padding, spacing.space_6);
+        assert_eq!(components.container.radius, radii.radius_xl);
+        assert_eq!(components.overlay.radius, radii.radius_md);
+        assert_eq!(components.typography.action_md, typography.text_sm);
+        assert_eq!(components.typography.badge, typography.text_xs);
+        assert_eq!(components.compact.cluster_gap_sm, spacing.space_1);
+        assert_eq!(components.compact.progress_height_md, spacing.space_2);
+    }
+}
+
+#[test]
+fn theme_state_component_tokens_track_spacing_and_radius_overrides() {
+    if ThemeState::try_get().is_none() {
+        ThemeState::init(ThemePreset::Neutral.bundle(), ColorScheme::Light);
+    }
+
+    let theme = ThemeState::get();
+    theme.clear_overrides();
+
+    theme.set_spacing_override(SpacingToken::Space10, 52.0);
+    theme.set_radius_override(RadiusToken::Default, 11.0);
+
+    let components = theme.components();
+    let vars = theme.to_css_variable_map();
+
+    assert_eq!(components.control.height_md, 52.0);
+    assert_eq!(components.control.radius_md, 11.0);
+    assert_eq!(vars.get("control-height-md"), Some(&"52px".to_string()));
+    assert_eq!(vars.get("control-radius-md"), Some(&"11px".to_string()));
+
+    theme.remove_spacing_override(SpacingToken::Space10);
+    theme.remove_radius_override(RadiusToken::Default);
+
+    let reset_components = theme.components();
+    let reset_vars = theme.to_css_variable_map();
+
+    assert_eq!(reset_components.control.height_md, theme.spacing().space_10);
+    assert_eq!(
+        reset_components.control.radius_md,
+        theme.radii().radius_default
+    );
+    assert_eq!(
+        reset_vars.get("control-height-md"),
+        Some(&format!("{}px", theme.spacing().space_10 as i32))
+    );
 }
 
 #[test]

--- a/docs/book/src/cn/button.md
+++ b/docs/book/src/cn/button.md
@@ -8,163 +8,42 @@ Buttons trigger actions or events.
 use blinc_cn::prelude::*;
 
 button("Click me")
-    .on_click(|| println!("Clicked!"))
+    .on_click(|_| println!("clicked"));
 ```
 
 ## Variants
 
-Buttons come in several visual variants:
-
 ```rust
-// Primary (default) - Main actions
 button("Save").variant(ButtonVariant::Primary)
-
-// Secondary - Alternative actions
 button("Cancel").variant(ButtonVariant::Secondary)
-
-// Destructive - Dangerous actions
 button("Delete").variant(ButtonVariant::Destructive)
-
-// Outline - Bordered style
 button("Edit").variant(ButtonVariant::Outline)
-
-// Ghost - Minimal style
 button("More").variant(ButtonVariant::Ghost)
-
-// Link - Looks like a link
 button("Learn more").variant(ButtonVariant::Link)
 ```
 
 ## Sizes
 
 ```rust
-// Small
-button("Small").size(ButtonSize::Sm)
-
-// Default
-button("Default").size(ButtonSize::Default)
-
-// Large
-button("Large").size(ButtonSize::Lg)
-
-// Icon only (square)
+button("Small").size(ButtonSize::Small)
+button("Medium").size(ButtonSize::Medium)
+button("Large").size(ButtonSize::Large)
 button("").size(ButtonSize::Icon).icon(icons::SETTINGS)
 ```
 
-## With Icons
+## Icons
 
 ```rust
-use blinc_icons::icons;
+button("Settings").icon(icons::SETTINGS)
 
-// Icon before text
-button("Settings")
-    .icon(icons::SETTINGS)
-
-// Icon after text
 button("Next")
-    .icon_right(icons::ARROW_RIGHT)
-
-// Icon only
-button("")
-    .size(ButtonSize::Icon)
-    .icon(icons::PLUS)
+    .icon(icons::ARROW_RIGHT)
+    .icon_position(IconPosition::End);
 ```
 
-## States
+## Disabled State
 
 ```rust
-// Disabled
 button("Disabled")
-    .disabled(true)
-
-// Loading
-button("Saving...")
-    .loading(true)
-
-// Full width
-button("Submit")
-    .full_width(true)
+    .disabled(true);
 ```
-
-## Event Handling
-
-```rust
-button("Submit")
-    .on_click(|| {
-        // Handle click
-        submit_form();
-    })
-    .on_hover(|hovering| {
-        // Handle hover state
-        if hovering {
-            show_tooltip();
-        }
-    })
-```
-
-## Button Groups
-
-```rust
-div()
-    .flex_row()
-    .gap(8.0)
-    .child(button("Save").variant(ButtonVariant::Primary))
-    .child(button("Cancel").variant(ButtonVariant::Outline))
-```
-
-## Examples
-
-### Form Submit Button
-
-```rust
-button("Create Account")
-    .variant(ButtonVariant::Primary)
-    .size(ButtonSize::Lg)
-    .full_width(true)
-    .on_click(|| handle_submit())
-```
-
-### Icon Button
-
-```rust
-button("")
-    .size(ButtonSize::Icon)
-    .variant(ButtonVariant::Ghost)
-    .icon(icons::X)
-    .on_click(|| close_dialog())
-```
-
-### Loading Button
-
-```rust
-let is_loading = use_state(false);
-
-button(if is_loading { "Saving..." } else { "Save" })
-    .loading(is_loading)
-    .disabled(is_loading)
-    .on_click(|| {
-        set_loading(true);
-        save_data().then(|| set_loading(false));
-    })
-```
-
-## API Reference
-
-### Props
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `variant` | `ButtonVariant` | `Primary` | Visual style |
-| `size` | `ButtonSize` | `Default` | Button size |
-| `disabled` | `bool` | `false` | Disable interaction |
-| `loading` | `bool` | `false` | Show loading state |
-| `full_width` | `bool` | `false` | Expand to full width |
-| `icon` | `&str` | `None` | Icon before text |
-| `icon_right` | `&str` | `None` | Icon after text |
-
-### Events
-
-| Event | Type | Description |
-|-------|------|-------------|
-| `on_click` | `Fn()` | Called when clicked |
-| `on_hover` | `Fn(bool)` | Called on hover change |

--- a/docs/book/src/cn/card.md
+++ b/docs/book/src/cn/card.md
@@ -8,70 +8,23 @@ Cards group related content and actions.
 use blinc_cn::prelude::*;
 
 card()
-    .child(card_header()
-        .child(card_title("Card Title"))
-        .child(card_description("Card description text")))
-    .child(card_content()
-        .child(text("Card content goes here.")))
-    .child(card_footer()
-        .child(button("Action")))
+    .child(
+        card_header()
+            .title("Card Title")
+            .description("Card description text"),
+    )
+    .child(card_content().child(text("Card content goes here.")))
+    .child(card_footer().child(button("Action")));
 ```
 
-## Card Parts
+## Card Header
 
-### card()
-
-The container that wraps all card content.
-
-```rust
-card()
-    .w(400.0)  // Custom width
-    .child(/* card parts */)
-```
-
-### card_header()
-
-Contains the title and description.
+`card_header()` exposes convenience methods instead of separate title/description builders.
 
 ```rust
 card_header()
-    .child(card_title("Title"))
-    .child(card_description("Description"))
-```
-
-### card_title()
-
-The main heading of the card.
-
-```rust
-card_title("Account Settings")
-```
-
-### card_description()
-
-Secondary text below the title.
-
-```rust
-card_description("Manage your account preferences")
-```
-
-### card_content()
-
-The main content area.
-
-```rust
-card_content()
-    .child(/* any content */)
-```
-
-### card_footer()
-
-Actions and secondary information at the bottom.
-
-```rust
-card_footer()
-    .child(button("Cancel").variant(ButtonVariant::Outline))
-    .child(button("Save"))
+    .title("Account Settings")
+    .description("Manage your account preferences");
 ```
 
 ## Examples
@@ -80,151 +33,32 @@ card_footer()
 
 ```rust
 card()
-    .child(card_header()
-        .child(card_title("Notifications"))
-        .child(card_description("Configure notification settings")))
-    .child(card_content()
-        .child(
-            div()
-                .flex_col()
-                .gap(12.0)
-                .child(checkbox().checked(true).child(label("Email notifications")))
-                .child(checkbox().child(label("Push notifications")))
-        ))
+    .child(
+        card_header()
+            .title("Notifications")
+            .description("Configure notification settings"),
+    )
+    .child(
+        card_content().child(
+            text("Card content can contain any layout tree."),
+        ),
+    );
 ```
 
-### Card with Image
+### Card With Actions
 
 ```rust
 card()
-    .overflow_clip()
+    .w(360.0)
     .child(
-        img("cover.jpg")
-            .w_full()
-            .h(200.0)
-            .cover()
+        card_header()
+            .title("Login")
+            .description("Enter your credentials"),
     )
-    .child(card_header()
-        .child(card_title("Beautiful Sunset"))
-        .child(card_description("Photo by @photographer")))
-    .child(card_footer()
-        .child(button("View").variant(ButtonVariant::Outline))
-        .child(button("Download")))
-```
-
-### Card with Form
-
-```rust
-card()
-    .w(350.0)
-    .child(card_header()
-        .child(card_title("Login"))
-        .child(card_description("Enter your credentials")))
-    .child(card_content()
-        .child(
-            div()
-                .flex_col()
-                .gap(16.0)
-                .child(
-                    div()
-                        .flex_col()
-                        .gap(4.0)
-                        .child(label("Email"))
-                        .child(input().placeholder("name@example.com"))
-                )
-                .child(
-                    div()
-                        .flex_col()
-                        .gap(4.0)
-                        .child(label("Password"))
-                        .child(input().input_type("password"))
-                )
-        ))
-    .child(card_footer()
-        .child(button("Sign in").full_width(true)))
-```
-
-### Card Grid
-
-```rust
-div()
-    .grid()
-    .grid_cols(3)
-    .gap(16.0)
+    .child(card_content().child(text("Form fields go here")))
     .child(
-        card()
-            .child(card_header().child(card_title("Plan A")))
-            .child(card_content().child(text("$9/month")))
-            .child(card_footer().child(button("Select")))
-    )
-    .child(
-        card()
-            .child(card_header().child(card_title("Plan B")))
-            .child(card_content().child(text("$19/month")))
-            .child(card_footer().child(button("Select")))
-    )
-    .child(
-        card()
-            .child(card_header().child(card_title("Plan C")))
-            .child(card_content().child(text("$29/month")))
-            .child(card_footer().child(button("Select")))
-    )
+        card_footer()
+            .child(button("Cancel").variant(ButtonVariant::Outline))
+            .child(button("Continue")),
+    );
 ```
-
-### Interactive Card
-
-```rust
-card()
-    .on_click(|| navigate_to("/details"))
-    .cursor("pointer")
-    .child(card_header()
-        .child(card_title("Click Me"))
-        .child(card_description("This entire card is clickable")))
-    .child(card_content()
-        .child(text("Card content...")))
-```
-
-## Styling
-
-Cards automatically use theme tokens:
-
-- Background: `theme.colors.card`
-- Border: `theme.colors.border`
-- Radius: `theme.radius.lg`
-- Shadow: `theme.shadows.sm`
-
-Override with custom styles:
-
-```rust
-card()
-    .bg(Color::rgb(0.1, 0.1, 0.1))
-    .border(2.0, Color::BLUE)
-    .rounded(16.0)
-    .shadow(Shadow::lg())
-```
-
-## API Reference
-
-### card()
-
-| Prop | Type | Description |
-|------|------|-------------|
-| Standard div props | - | All div styling props |
-
-### card_header()
-
-| Prop | Type | Description |
-|------|------|-------------|
-| Standard div props | - | All div styling props |
-
-### card_title()
-
-| Prop | Type | Description |
-|------|------|-------------|
-| Text content | `&str` | Title text |
-
-### card_description()
-
-| Prop | Type | Description |
-|------|------|-------------|
-| Text content | `&str` | Description text |

--- a/docs/book/src/cn/dialog.md
+++ b/docs/book/src/cn/dialog.md
@@ -1,249 +1,76 @@
 # Dialog
 
-Dialogs display content in a modal overlay that requires user interaction.
+Dialogs in `blinc_cn` are imperative overlay builders.
 
 ## Basic Usage
 
 ```rust
 use blinc_cn::prelude::*;
 
-let is_open = use_state(false);
-
-dialog()
-    .open(is_open)
-    .on_open_change(|open| set_is_open(open))
-    .child(dialog_trigger()
-        .child(button("Open Dialog")))
-    .child(dialog_content()
-        .child(dialog_header()
-            .child(dialog_title("Dialog Title"))
-            .child(dialog_description("Dialog description")))
-        .child(text("Dialog content goes here."))
-        .child(dialog_footer()
-            .child(button("Close").on_click(|| set_is_open(false)))))
+button("Open Dialog").on_click(|_| {
+    dialog()
+        .title("Dialog Title")
+        .description("Dialog description")
+        .confirm_text("Continue")
+        .cancel_text("Cancel")
+        .on_confirm(|| println!("confirmed"))
+        .show();
+});
 ```
 
-## Dialog Parts
-
-### dialog()
-
-The root component that manages open state.
+## Dialog Builder
 
 ```rust
 dialog()
-    .open(is_open)
-    .on_open_change(|open| set_open(open))
-```
-
-### dialog_trigger()
-
-The element that opens the dialog when clicked.
-
-```rust
-dialog_trigger()
-    .child(button("Open"))
-```
-
-### dialog_content()
-
-The modal content container with backdrop.
-
-```rust
-dialog_content()
-    .child(/* dialog parts */)
-```
-
-### dialog_header()
-
-Contains title and description.
-
-```rust
-dialog_header()
-    .child(dialog_title("Title"))
-    .child(dialog_description("Description"))
-```
-
-### dialog_footer()
-
-Contains action buttons.
-
-```rust
-dialog_footer()
-    .child(button("Cancel").variant(ButtonVariant::Outline))
-    .child(button("Confirm"))
-```
-
-### dialog_close()
-
-A button that closes the dialog.
-
-```rust
-dialog_close()
-    .child(button("Close"))
+    .title("Edit Profile")
+    .description("Update your profile information")
+    .content(|| {
+        div()
+            .flex_col()
+            .gap(12.0)
+            .child(text("Custom content goes here"))
+    })
+    .footer(|| {
+        div()
+            .flex_row()
+            .gap(8.0)
+            .child(button("Cancel").variant(ButtonVariant::Outline))
+            .child(button("Save"))
+    })
+    .show();
 ```
 
 ## Alert Dialog
 
-For destructive or important confirmations:
+Use `alert_dialog()` for single-action confirmation flows:
 
 ```rust
-let is_open = use_state(false);
-
 alert_dialog()
-    .open(is_open)
-    .on_open_change(|open| set_is_open(open))
-    .child(alert_dialog_trigger()
-        .child(button("Delete").variant(ButtonVariant::Destructive)))
-    .child(alert_dialog_content()
-        .child(alert_dialog_header()
-            .child(alert_dialog_title("Are you sure?"))
-            .child(alert_dialog_description(
-                "This action cannot be undone."
-            )))
-        .child(alert_dialog_footer()
-            .child(alert_dialog_cancel().child(button("Cancel")))
-            .child(alert_dialog_action()
-                .child(button("Delete").variant(ButtonVariant::Destructive)))))
+    .title("Delete Account")
+    .description("This action cannot be undone.")
+    .confirm_text("Delete")
+    .on_confirm(|| println!("delete confirmed"))
+    .show();
 ```
 
 ## Sheet
 
-A panel that slides in from the edge:
-
 ```rust
-let is_open = use_state(false);
-
-sheet()
-    .open(is_open)
-    .side(SheetSide::Right)  // Left, Right, Top, Bottom
-    .on_open_change(|open| set_is_open(open))
-    .child(sheet_trigger()
-        .child(button("Open Sheet")))
-    .child(sheet_content()
-        .child(sheet_header()
-            .child(sheet_title("Settings")))
-        .child(/* content */)
-        .child(sheet_footer()
-            .child(button("Save changes"))))
+button("Open Sheet").on_click(|_| {
+    sheet_right()
+        .title("Settings")
+        .description("Update application settings")
+        .show();
+});
 ```
 
 ## Drawer
 
-A mobile-friendly bottom sheet:
-
 ```rust
-let is_open = use_state(false);
-
-drawer()
-    .open(is_open)
-    .on_open_change(|open| set_is_open(open))
-    .child(drawer_trigger()
-        .child(button("Open Drawer")))
-    .child(drawer_content()
-        .child(drawer_header()
-            .child(drawer_title("Menu")))
-        .child(/* content */))
-```
-
-## Examples
-
-### Form Dialog
-
-```rust
-let is_open = use_state(false);
-let name = use_state(String::new());
-let email = use_state(String::new());
-
-dialog()
-    .open(is_open)
-    .on_open_change(|open| set_is_open(open))
-    .child(dialog_trigger()
-        .child(button("Edit Profile")))
-    .child(dialog_content()
-        .child(dialog_header()
-            .child(dialog_title("Edit Profile"))
-            .child(dialog_description("Update your profile information")))
-        .child(
-            div()
-                .flex_col()
-                .gap(16.0)
-                .child(
-                    div().flex_col().gap(4.0)
-                        .child(label("Name"))
-                        .child(input()
-                            .value(&name)
-                            .on_change(|v| set_name(v)))
-                )
-                .child(
-                    div().flex_col().gap(4.0)
-                        .child(label("Email"))
-                        .child(input()
-                            .value(&email)
-                            .on_change(|v| set_email(v)))
-                )
-        )
-        .child(dialog_footer()
-            .child(dialog_close().child(
-                button("Cancel").variant(ButtonVariant::Outline)
-            ))
-            .child(button("Save").on_click(|| {
-                save_profile();
-                set_is_open(false);
-            }))))
-```
-
-### Confirmation Dialog
-
-```rust
-let is_open = use_state(false);
-
-alert_dialog()
-    .open(is_open)
-    .on_open_change(|open| set_is_open(open))
-    .child(alert_dialog_trigger()
-        .child(button("Delete Account").variant(ButtonVariant::Destructive)))
-    .child(alert_dialog_content()
-        .child(alert_dialog_header()
-            .child(alert_dialog_title("Delete Account"))
-            .child(alert_dialog_description(
-                "Are you sure you want to delete your account? \
-                 All your data will be permanently removed."
-            )))
-        .child(alert_dialog_footer()
-            .child(alert_dialog_cancel().child(
-                button("Cancel").variant(ButtonVariant::Outline)
-            ))
-            .child(alert_dialog_action().child(
-                button("Delete")
-                    .variant(ButtonVariant::Destructive)
-                    .on_click(|| delete_account())
-            ))))
-```
-
-## API Reference
-
-### dialog()
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `open` | `bool` | `false` | Whether dialog is open |
-| `on_open_change` | `Fn(bool)` | - | Called when open state changes |
-
-### sheet()
-
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `open` | `bool` | `false` | Whether sheet is open |
-| `side` | `SheetSide` | `Right` | Which side to slide from |
-| `on_open_change` | `Fn(bool)` | - | Called when open state changes |
-
-### SheetSide
-
-```rust
-enum SheetSide {
-    Left,
-    Right,
-    Top,
-    Bottom,
-}
+button("Open Drawer").on_click(|_| {
+    drawer()
+        .title("Actions")
+        .description("Mobile-style bottom drawer")
+        .show();
+});
 ```

--- a/docs/book/src/cn/form.md
+++ b/docs/book/src/cn/form.md
@@ -1,10 +1,8 @@
 # Form Components
 
-Components for building forms: inputs, checkboxes, selects, and more.
+Components for building forms: inputs, textareas, switches, selects, sliders, and wrappers.
 
 ## Input
-
-Text input field:
 
 ```rust
 use blinc_cn::prelude::*;
@@ -13,55 +11,12 @@ use blinc_layout::widgets::text_input::text_input_data;
 let name = text_input_data();
 
 input(&name)
+    .label("Name")
     .placeholder("Enter your name...")
     .on_change(|value| println!("name: {}", value));
 ```
 
-### Input Types
-
-```rust
-use blinc_layout::widgets::text_input::text_input_data;
-
-let name = text_input_data();
-let email = text_input_data();
-let password = text_input_data();
-let age = text_input_data();
-let search = text_input_data();
-
-// Text (default)
-input(&name).placeholder("Name")
-
-// Email
-input(&email).input_type("email").placeholder("Email")
-
-// Password
-input(&password).input_type("password").placeholder("Password")
-
-// Number
-input(&age).input_type("number").placeholder("Age")
-
-// Search
-input(&search).input_type("search").placeholder("Search...")
-```
-
-### Input States
-
-```rust
-use blinc_layout::widgets::text_input::text_input_data;
-
-let disabled_input = text_input_data();
-let error_input = text_input_data();
-
-// Disabled
-input(&disabled_input).disabled(true)
-
-// With error
-input(&error_input).error("Invalid value")
-```
-
 ## Textarea
-
-Multi-line text input:
 
 ```rust
 use blinc_layout::widgets::text_area::text_area_state;
@@ -69,240 +24,104 @@ use blinc_layout::widgets::text_area::text_area_state;
 let description = text_area_state();
 
 textarea(&description)
+    .label("Description")
     .placeholder("Enter description...")
-    .rows(4)
-    .on_change(|value| println!("description: {}", value));
+    .rows(4);
 ```
 
 ## Field
 
-`field()` wraps a single control with label + helper/error text.
-
 ```rust
-use blinc_layout::widgets::text_input::text_input_data;
-
 let email = text_input_data();
 
 field("Email")
     .required()
     .description("We'll only use this for account notices.")
-    .child(
-        input(&email)
-            .placeholder("name@example.com")
-    )
+    .child(input(&email).placeholder("name@example.com"));
 ```
 
 ## Form
 
-`form()` is a vertical layout container for multiple fields.
-
 ```rust
-use blinc_layout::widgets::text_input::text_input_data;
-
 let name = text_input_data();
 let email = text_input_data();
 
 form()
     .spacing(16.0)
     .max_w(420.0)
-    .child(
-        field("Name")
-            .required()
-            .child(input(&name).placeholder("John Doe"))
-    )
+    .child(field("Name").required().child(input(&name).placeholder("John Doe")))
     .child(
         field("Email")
             .required()
-            .child(input(&email).input_type("email").placeholder("john@example.com"))
-    )
+            .child(input(&email).input_type("email").placeholder("john@example.com")),
+    );
 ```
 
 ## Checkbox
 
 ```rust
 checkbox()
-    .checked(is_checked)
-    .on_change(|checked| println!("checked: {}", checked))
-    .child(label("Accept terms and conditions"))
-```
-
-### Indeterminate State
-
-```rust
-checkbox()
-    .checked(some_checked)
-    .indeterminate(some_checked && !all_checked)
-    .on_change(|checked| toggle_all(checked))
-    .child(label("Select all"))
+    .checked(true)
+    .child(label("Accept terms and conditions"));
 ```
 
 ## Switch
 
-Toggle switch:
-
 ```rust
-switch_()
-    .checked(is_enabled)
-    .on_change(|enabled| println!("enabled: {}", enabled))
-```
+let dark_mode = blinc_core::State::new(false);
 
-### With Label
-
-```rust
-div()
-    .flex_row()
-    .items_center()
-    .gap(8.0)
-    .child(switch_().checked(dark_mode).on_change(|v| println!("dark mode: {}", v)))
-    .child(label("Dark mode"))
+switch(&dark_mode)
+    .label("Dark mode")
+    .on_change(|enabled| println!("dark mode: {}", enabled));
 ```
 
 ## Radio Group
 
 ```rust
-radio_group()
-    .value(selected)
-    .on_change(|value| println!("selected: {}", value))
-    .child(
-        div().flex_col().gap(8.0)
-            .child(radio_item("small").child(label("Small")))
-            .child(radio_item("medium").child(label("Medium")))
-            .child(radio_item("large").child(label("Large")))
-    )
+let selected = blinc_core::State::new("medium".to_string());
+
+radio_group(&selected)
+    .option("small", "Small")
+    .option("medium", "Medium")
+    .option("large", "Large")
+    .on_change(|value| println!("selected: {}", value));
 ```
 
 ## Select
 
-Dropdown selection:
-
 ```rust
-select()
-    .value(selected)
-    .on_change(|value| println!("selected: {}", value))
-    .child(select_trigger()
-        .child(select_value().placeholder("Select option...")))
-    .child(select_content()
-        .child(select_item("opt1").child(text("Option 1")))
-        .child(select_item("opt2").child(text("Option 2")))
-        .child(select_item("opt3").child(text("Option 3"))))
-```
+let framework = blinc_core::State::new(String::new());
 
-### Grouped Options
-
-```rust
-select()
-    .child(select_trigger().child(select_value()))
-    .child(select_content()
-        .child(select_group()
-            .child(select_label("Fruits"))
-            .child(select_item("apple").child(text("Apple")))
-            .child(select_item("banana").child(text("Banana"))))
-        .child(select_separator())
-        .child(select_group()
-            .child(select_label("Vegetables"))
-            .child(select_item("carrot").child(text("Carrot")))
-            .child(select_item("broccoli").child(text("Broccoli")))))
+select(&framework)
+    .label("Framework")
+    .placeholder("Choose one")
+    .option("react", "React")
+    .option("svelte", "Svelte")
+    .option("solid", "Solid")
+    .on_change(|value| println!("selected: {}", value));
 ```
 
 ## Combobox
 
-Searchable select with autocomplete:
-
 ```rust
-combobox()
-    .value(selected)
-    .on_change(|value| println!("selected: {}", value))
-    .child(combobox_trigger()
-        .child(combobox_input().placeholder("Search...")))
-    .child(combobox_content()
-        .child(combobox_empty().child(text("No results found")))
-        .child(combobox_item("react").child(text("React")))
-        .child(combobox_item("vue").child(text("Vue")))
-        .child(combobox_item("svelte").child(text("Svelte"))))
+let framework = blinc_core::State::new(String::new());
+
+combobox(&framework)
+    .label("Framework")
+    .placeholder("Search frameworks...")
+    .option("react", "React")
+    .option("svelte", "Svelte")
+    .option("solid", "Solid");
 ```
 
 ## Slider
 
-Range slider:
-
 ```rust
-slider()
-    .value(volume)
+let volume = blinc_core::State::new(50.0);
+
+slider(&volume)
     .min(0.0)
     .max(100.0)
     .step(1.0)
-    .on_change(|value| println!("volume: {}", value))
-```
-
-### Range Slider
-
-```rust
-slider()
-    .value_range(min_price, max_price)
-    .min(0.0)
-    .max(1000.0)
-    .on_change_range(|min, max| {
-        println!("price range: {} - {}", min, max);
-    })
-```
-
-## Label
-
-```rust
-// Associated with input via for
-label("Email").for_id("email-input")
-
-// Direct child of input
-checkbox()
-    .child(label("Remember me"))
-```
-
-## Form Layout Example
-
-```rust
-use blinc_layout::widgets::text_input::text_input_data;
-
-let name = text_input_data();
-let email = text_input_data();
-
-form()
-    .spacing(24.0)
-    .max_w(400.0)
-    .child(
-        field("Name")
-            .required()
-            .child(input(&name)
-                .placeholder("John Doe")
-                .on_change(|v| println!("name: {}", v)))
-    )
-    .child(
-        field("Email")
-            .required()
-            .child(input(&email)
-                .input_type("email")
-                .placeholder("john@example.com")
-                .on_change(|v| println!("email: {}", v)))
-    )
-    .child(
-        button("Submit")
-            .on_click(|| submit_form())
-    )
-```
-
-## Validation
-
-```rust
-use blinc_layout::widgets::text_input::text_input_data;
-
-let email = text_input_data();
-let show_error = true; // replace with your own validation condition
-
-field("Email")
-    .when(show_error, |f| f.error("Invalid email address"))
-    .child(
-        input(&email)
-            .input_type("email")
-            .on_change(|v| println!("email: {}", v))
-            .error_state(show_error)
-    )
+    .on_change(|value| println!("volume: {}", value));
 ```

--- a/docs/book/src/cn/navigation.md
+++ b/docs/book/src/cn/navigation.md
@@ -1,231 +1,67 @@
 # Navigation Components
 
-Components for navigation: tabs, menus, breadcrumbs, and sidebars.
+Components for tabs, breadcrumbs, menus, pagination, and sidebars.
 
 ## Tabs
-
-Organize content into tabbed sections:
 
 ```rust
 use blinc_cn::prelude::*;
 
-tabs()
-    .value(active_tab)
-    .on_change(|tab| set_active_tab(tab))
-    .child(tabs_list()
-        .child(tabs_trigger("account").child(text("Account")))
-        .child(tabs_trigger("password").child(text("Password")))
-        .child(tabs_trigger("settings").child(text("Settings"))))
-    .child(tabs_content("account")
-        .child(text("Account settings...")))
-    .child(tabs_content("password")
-        .child(text("Password settings...")))
-    .child(tabs_content("settings")
-        .child(text("Other settings...")))
+let active_tab = blinc_core::State::new(String::new());
+
+tabs(&active_tab)
+    .tab("account", "Account", || div().child(text("Account settings")))
+    .tab("password", "Password", || div().child(text("Password settings")))
+    .tab("settings", "Settings", || div().child(text("Other settings")));
 ```
 
 ## Dropdown Menu
 
 ```rust
 dropdown_menu()
-    .child(dropdown_menu_trigger()
-        .child(button("Options").icon_right(icons::CHEVRON_DOWN)))
-    .child(dropdown_menu_content()
-        .child(dropdown_menu_label("Actions"))
-        .child(dropdown_menu_item("edit")
-            .child(icon(icons::EDIT))
-            .child(text("Edit"))
-            .on_click(|| edit_item()))
-        .child(dropdown_menu_item("duplicate")
-            .child(icon(icons::COPY))
-            .child(text("Duplicate")))
-        .child(dropdown_menu_separator())
-        .child(dropdown_menu_item("delete")
-            .child(icon(icons::TRASH))
-            .child(text("Delete"))
-            .variant(MenuItemVariant::Destructive)))
-```
-
-### With Keyboard Shortcuts
-
-```rust
-dropdown_menu_item("save")
-    .child(icon(icons::SAVE))
-    .child(text("Save"))
-    .child(dropdown_menu_shortcut("⌘S"))
-```
-
-### Submenu
-
-```rust
-dropdown_menu_content()
-    .child(dropdown_menu_item("new").child(text("New")))
-    .child(dropdown_menu_sub()
-        .child(dropdown_menu_sub_trigger()
-            .child(text("Share")))
-        .child(dropdown_menu_sub_content()
-            .child(dropdown_menu_item("email").child(text("Email")))
-            .child(dropdown_menu_item("link").child(text("Copy Link")))))
-```
-
-## Context Menu
-
-Right-click menu:
-
-```rust
-context_menu()
-    .child(context_menu_trigger()
-        .child(div().w(200.0).h(150.0).bg(Color::GRAY)
-            .child(text("Right-click me"))))
-    .child(context_menu_content()
-        .child(context_menu_item("cut").child(text("Cut")))
-        .child(context_menu_item("copy").child(text("Copy")))
-        .child(context_menu_item("paste").child(text("Paste")))
-        .child(context_menu_separator())
-        .child(context_menu_item("delete").child(text("Delete"))))
-```
-
-## Menubar
-
-Application menu bar:
-
-```rust
-menubar()
-    .child(menubar_menu()
-        .child(menubar_trigger().child(text("File")))
-        .child(menubar_content()
-            .child(menubar_item("new").child(text("New File")))
-            .child(menubar_item("open").child(text("Open...")))
-            .child(menubar_separator())
-            .child(menubar_item("save").child(text("Save")))
-            .child(menubar_item("save-as").child(text("Save As...")))))
-    .child(menubar_menu()
-        .child(menubar_trigger().child(text("Edit")))
-        .child(menubar_content()
-            .child(menubar_item("undo").child(text("Undo")))
-            .child(menubar_item("redo").child(text("Redo")))))
+    .item("edit", "Edit", || println!("edit"))
+    .item("duplicate", "Duplicate", || println!("duplicate"))
+    .separator()
+    .item("delete", "Delete", || println!("delete"));
 ```
 
 ## Breadcrumb
 
-Navigation path:
-
 ```rust
 breadcrumb()
-    .child(breadcrumb_list()
-        .child(breadcrumb_item()
-            .child(breadcrumb_link("Home").href("/")))
-        .child(breadcrumb_separator())
-        .child(breadcrumb_item()
-            .child(breadcrumb_link("Products").href("/products")))
-        .child(breadcrumb_separator())
-        .child(breadcrumb_item()
-            .child(breadcrumb_page("Details"))))  // Current page (not a link)
-```
-
-### With Ellipsis
-
-```rust
-breadcrumb()
-    .child(breadcrumb_list()
-        .child(breadcrumb_item().child(breadcrumb_link("Home")))
-        .child(breadcrumb_separator())
-        .child(breadcrumb_ellipsis())  // Collapsed items
-        .child(breadcrumb_separator())
-        .child(breadcrumb_item().child(breadcrumb_link("Category")))
-        .child(breadcrumb_separator())
-        .child(breadcrumb_item().child(breadcrumb_page("Current"))))
+    .item("Home", || println!("home"))
+    .item("Products", || println!("products"))
+    .current("Details");
 ```
 
 ## Pagination
 
 ```rust
-pagination()
-    .total(100)
-    .page_size(10)
-    .current_page(current_page)
-    .on_page_change(|page| set_current_page(page))
-    .child(pagination_content()
-        .child(pagination_previous())
-        .child(pagination_items())
-        .child(pagination_next()))
+let page = blinc_core::State::new(1usize);
+
+pagination(&page)
+    .total_pages(10)
+    .on_change(|next| println!("page: {}", next));
 ```
 
 ## Sidebar
 
-Application sidebar navigation:
-
 ```rust
-sidebar()
-    .child(sidebar_header()
-        .child(
-            div().flex_row().items_center().gap(8.0)
-                .child(icon(icons::BOX).size(24.0))
-                .child(text("My App").weight(FontWeight::Bold))
-        ))
-    .child(sidebar_content()
-        .child(sidebar_group()
-            .child(sidebar_group_label("Main"))
-            .child(sidebar_menu()
-                .child(sidebar_menu_item("dashboard")
-                    .icon(icons::HOME)
-                    .active(current_route == "dashboard")
-                    .on_click(|| navigate("/dashboard"))
-                    .child(text("Dashboard")))
-                .child(sidebar_menu_item("projects")
-                    .icon(icons::FOLDER)
-                    .on_click(|| navigate("/projects"))
-                    .child(text("Projects")))
-                .child(sidebar_menu_item("tasks")
-                    .icon(icons::CHECK_SQUARE)
-                    .on_click(|| navigate("/tasks"))
-                    .child(text("Tasks")))))
-        .child(sidebar_group()
-            .child(sidebar_group_label("Settings"))
-            .child(sidebar_menu()
-                .child(sidebar_menu_item("settings")
-                    .icon(icons::SETTINGS)
-                    .on_click(|| navigate("/settings"))
-                    .child(text("Settings")))
-                .child(sidebar_menu_item("help")
-                    .icon(icons::HELP_CIRCLE)
-                    .on_click(|| navigate("/help"))
-                    .child(text("Help"))))))
-    .child(sidebar_footer()
-        .child(
-            div().flex_row().items_center().gap(8.0)
-                .child(avatar().src("user.jpg").size(AvatarSize::Sm))
-                .child(text("John Doe"))
-        ))
-```
+let collapsed = blinc_core::State::new(false);
 
-### Collapsible Sidebar
-
-```rust
-let is_collapsed = use_state(false);
-
-sidebar()
-    .collapsed(is_collapsed)
-    .child(sidebar_header()
-        .child(sidebar_trigger()
-            .on_click(|| set_is_collapsed(!is_collapsed))))
-    .child(/* rest of sidebar */)
+sidebar(&collapsed)
+    .section("Main")
+    .item_active("Dashboard", icons::HOME, || println!("dashboard"))
+    .item("Projects", icons::FOLDER, || println!("projects"))
+    .section("Settings")
+    .item("Preferences", icons::SETTINGS, || println!("prefs"));
 ```
 
 ## Navigation Menu
 
-Horizontal navigation with dropdowns:
-
 ```rust
 navigation_menu()
-    .child(navigation_menu_list()
-        .child(navigation_menu_item()
-            .child(navigation_menu_trigger().child(text("Products")))
-            .child(navigation_menu_content()
-                .child(navigation_menu_link("analytics").child(text("Analytics")))
-                .child(navigation_menu_link("reports").child(text("Reports")))))
-        .child(navigation_menu_item()
-            .child(navigation_menu_link("pricing").child(text("Pricing"))))
-        .child(navigation_menu_item()
-            .child(navigation_menu_link("about").child(text("About")))))
+    .item("Docs", || println!("docs"))
+    .item("Pricing", || println!("pricing"))
+    .item("About", || println!("about"));
 ```

--- a/docs/book/src/cn/overview.md
+++ b/docs/book/src/cn/overview.md
@@ -1,14 +1,23 @@
 # Component Library Overview
 
-`blinc_cn` is a comprehensive component library for Blinc UI, inspired by [shadcn/ui](https://ui.shadcn.com/). It provides 40+ production-ready, themeable components built on top of `blinc_layout`.
+`blinc_cn` is the themed component library for Blinc UI.
 
-## Installation
+## Setup
 
-Add `blinc_cn` to your `Cargo.toml`:
+Initialize theme state before building UI:
 
-```toml
-[dependencies]
-blinc_cn = { path = "path/to/blinc_cn" }
+```rust
+use blinc_cn::ensure_default_theme;
+
+fn init_ui() {
+    ensure_default_theme();
+}
+```
+
+If your app uses stylesheet injection through `WindowedContext`, load the default component styles once:
+
+```rust
+ctx.add_css(blinc_cn::default_styles());
 ```
 
 ## Quick Start
@@ -17,20 +26,15 @@ blinc_cn = { path = "path/to/blinc_cn" }
 use blinc_cn::prelude::*;
 
 fn build_ui() -> impl ElementBuilder {
-    div()
-        .flex_col()
-        .gap(16.0)
-        .p(24.0)
+    card()
+        .w(360.0)
         .child(
-            card()
-                .child(card_header()
-                    .child(card_title("Welcome"))
-                    .child(card_description("Get started with blinc_cn")))
-                .child(card_content()
-                    .child(text("Beautiful, accessible components.")))
-                .child(card_footer()
-                    .child(button("Get Started")))
+            card_header()
+                .title("Welcome")
+                .description("Get started with blinc_cn"),
         )
+        .child(card_content().child(text("Beautiful, themed components.")))
+        .child(card_footer().child(button("Get Started")))
 }
 ```
 
@@ -38,68 +42,27 @@ fn build_ui() -> impl ElementBuilder {
 
 ### Composable
 
-Components are built from smaller primitives that can be combined:
-
-```rust
-// Compose dialog from parts
-dialog()
-    .child(dialog_trigger().child(button("Open")))
-    .child(dialog_content()
-        .child(dialog_header().child(dialog_title("Title")))
-        .child(/* content */)
-        .child(dialog_footer().child(button("Close"))))
-```
+Components stay close to `blinc_layout` builders and can still be customized with regular layout methods.
 
 ### Themeable
 
-All components use theme tokens and automatically support dark mode:
+Components read colors, spacing, radii, and typography from `blinc_theme::ThemeState`.
+Common control, container, overlay, and typography-role defaults are derived from semantic theme tokens,
+so a preset can move the whole component set together instead of each component carrying its own numbers.
 
-```rust
-// Components adapt to theme automatically
-button("Click me") // Uses theme.colors.primary
+### Practical
 
-// Override theme
-ThemeState::set_color_scheme(ColorScheme::Dark);
-```
+The goal is not to hide layout primitives. The goal is to give you better defaults and less repetitive styling.
 
-### Accessible
-
-Components include keyboard navigation and proper semantics:
-
-- Focus management
-- Keyboard shortcuts
-- Screen reader support (planned)
-
-## Component Categories
+## Categories
 
 | Category | Components |
 |----------|------------|
-| **Buttons** | Button |
-| **Cards** | Card, CardHeader, CardContent, CardFooter |
-| **Dialogs** | Dialog, AlertDialog, Sheet, Drawer |
-| **Forms** | Input, Textarea, Checkbox, Switch, Radio, Select, Slider |
-| **Navigation** | Tabs, DropdownMenu, ContextMenu, Breadcrumb, Sidebar |
-| **Feedback** | Alert, Badge, Progress, Spinner, Skeleton, Toast |
-| **Layout** | Avatar, Separator, AspectRatio, ScrollArea, Accordion |
-| **Data** | Tooltip, HoverCard, Popover, Chart |
-
-## Prelude
-
-Import common components with the prelude:
-
-```rust
-use blinc_cn::prelude::*;
-
-// Includes:
-// - All component builders (button, card, dialog, etc.)
-// - Variant enums (ButtonVariant, AlertVariant, etc.)
-// - Size enums (ButtonSize, AvatarSize, etc.)
-// - Common types and traits
-```
-
-## Next Steps
-
-- [Button](./button.md) - Learn about button variants and usage
-- [Card](./card.md) - Build card-based layouts
-- [Dialog](./dialog.md) - Create modal dialogs
-- [Form Components](./form.md) - Build forms with inputs
+| Buttons | Button |
+| Cards | Card, CardHeader, CardContent, CardFooter |
+| Dialogs | Dialog, AlertDialog, Sheet, Drawer |
+| Forms | Input, Textarea, Checkbox, Switch, Radio, Select, Slider, Field, Form |
+| Navigation | Tabs, DropdownMenu, ContextMenu, Breadcrumb, Sidebar, NavigationMenu |
+| Feedback | Alert, Badge, Progress, Spinner, Skeleton, Toast |
+| Layout | Avatar, Separator, AspectRatio, ScrollArea, Accordion |
+| Data | Tooltip, HoverCard, Popover, Chart, TreeView |

--- a/docs/book/src/cn/overview.md
+++ b/docs/book/src/cn/overview.md
@@ -1,6 +1,8 @@
 # Component Library Overview
 
-`blinc_cn` is the themed component library for Blinc UI.
+`blinc_cn` is the themed component library for Blinc UI. Its default stylesheet uses the newer CSS
+engine surface directly, including token-driven `corner-shape`, overlay `backdrop-filter`,
+truncation helpers, and CSS text decoration for link-like affordances.
 
 ## Setup
 

--- a/docs/book/src/mobile/overview.md
+++ b/docs/book/src/mobile/overview.md
@@ -1,6 +1,9 @@
 # Mobile Development
 
-Blinc supports building native mobile applications for both Android and iOS platforms. The same Rust UI code runs on mobile with platform-specific rendering backends (Vulkan for Android, Metal for iOS).
+Blinc can share Rust UI code across desktop, Android, and iOS targets. Mobile
+support currently provides generated platform projects, native bridge wiring,
+touch forwarding, and renderer scaffolding, but it should still be treated as a
+preview surface rather than a finished production target.
 
 ## Cross-Platform Architecture
 
@@ -14,24 +17,25 @@ Blinc supports building native mobile applications for both Android and iOS plat
          │                    │                    │
     ┌────▼────┐         ┌─────▼─────┐        ┌────▼────┐
     │ Desktop │         │  Android  │        │   iOS   │
-    │ (wgpu)  │         │ (Vulkan)  │        │ (Metal) │
+    │ (wgpu)  │         │ (NDK)     │        │ (UIKit) │
     └─────────┘         └───────────┘        └─────────┘
 ```
 
 ## Key Features
 
-- **Shared UI Code**: Write your UI once in Rust, deploy everywhere
-- **Native Performance**: GPU-accelerated rendering via Vulkan/Metal
-- **Touch Support**: Full multi-touch gesture handling
+- **Shared UI Code**: Reuse Rust UI trees and state across platforms
+- **Generated Platform Projects**: Android Gradle and iOS Xcode templates
+- **Native Bridge Wiring**: Template projects register common mobile helpers
+- **Touch Support**: Touch input is forwarded into the shared event system
 - **Reactive State**: Same reactive state system as desktop
-- **Animations**: Spring physics and keyframe animations work seamlessly
+- **Animations**: Shared animation/state APIs are available on mobile too
 
 ## Supported Platforms
 
-| Platform | Backend | Min Version  | Status |
+| Platform | Runtime | Min Version  | Status |
 |----------|---------|--------------|--------|
-| Android  | Vulkan  | API 24 (7.0) | Stable |
-| iOS      | Metal   | iOS 15+      | Stable |
+| Android  | NDK + JNI bridge | API 24 (7.0) | Preview |
+| iOS      | UIKit + native bridge | iOS 15+ | Preview |
 
 ## Project Structure
 
@@ -136,3 +140,10 @@ blinc run ios
 - [Android Development](./android.md) - Set up Android toolchain and build
 - [iOS Development](./ios.md) - Set up iOS toolchain and build
 - [CLI Reference](./cli.md) - Full CLI command reference
+
+## Current Scope
+
+- The mobile templates handle project wiring and native bridge registration.
+- Runtime coverage is still uneven across rendering, lifecycle, and platform
+  services, so validate target behavior on-device before treating it as
+  production-ready.

--- a/docs/plans/2026-03-09-android-runtime-surface-design.md
+++ b/docs/plans/2026-03-09-android-runtime-surface-design.md
@@ -1,0 +1,66 @@
+# Android Runtime Surface Design
+
+**Scope:** `extensions/blinc_platform_android` runtime surface only.
+
+## Problem
+
+The current Android runtime exposes JNI entry points and lifecycle hooks, but the
+core runtime state is still mostly placeholder logic:
+
+- JNI bridge tracks only raw size/touch booleans
+- resize/render/touch handlers do not preserve enough state to drive a host app
+- activity lifecycle logs events but does not keep a coherent renderability model
+
+This makes the Android surface hard to integrate even before a full GPU renderer
+exists.
+
+## Goal
+
+Make the Android runtime surface truthful and useful as bridge scaffolding by
+preserving the state that a renderer or host app actually needs.
+
+## Recommended Approach
+
+### 1. Introduce a host-testable JNI runtime state model
+
+Split state transitions out of raw JNI functions into a pure Rust state object
+that tracks:
+
+- current size and scale factor
+- focus/render eligibility
+- pending redraw requests
+- queued touch events in logical coordinates
+- last rendered frame metadata
+
+JNI entry points should only translate inputs and delegate to this state object.
+
+### 2. Make render/resize/touch mutate meaningful state
+
+- init marks the surface dirty
+- resize marks pending redraw and updates dimensions
+- touch input queues translated logical events and requests redraw
+- render consumes pending redraw markers and records the rendered surface size
+
+This still does not claim a full GPU pipeline exists, but it removes meaningless
+no-op behavior.
+
+### 3. Keep activity lifecycle aligned with bridge semantics
+
+`BlincAndroidApp` should share the same story:
+
+- render only when focused and a window exists
+- lifecycle changes should preserve redraw intent without conflating resume with
+  actual focus gain
+- tests should cover these transitions without Android runtime
+
+## Non-Goals
+
+- Building a complete Vulkan/wgpu renderer
+- Implementing full event-router delivery into Blinc layout/input systems
+- Adding Android instrumentation tests
+
+## Testing
+
+- Unit tests for the pure JNI runtime state model
+- Focused tests for activity renderability transitions
+- `cargo test -p blinc_platform_android`

--- a/docs/plans/2026-03-09-android-runtime-surface-impl-plan.md
+++ b/docs/plans/2026-03-09-android-runtime-surface-impl-plan.md
@@ -1,0 +1,84 @@
+# Android Runtime Surface Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the most visible Android JNI/activity placeholder behavior with a coherent runtime state model that preserves render, resize, focus, and touch state.
+
+**Architecture:** Keep public JNI signatures stable. Introduce a pure Rust state object for JNI bridge transitions so host tests can verify behavior. Then align `BlincAndroidApp` lifecycle/renderability flags with that same bridge story. Do not claim a full GPU renderer exists.
+
+**Tech Stack:** Rust 1.75, edition 2021, JNI bridge layer, Android activity integration.
+
+---
+
+### Task 1: Extract Android JNI Runtime State
+
+**Files:**
+- Modify: `extensions/blinc_platform_android/src/jni_bridge.rs`
+- Test: `extensions/blinc_platform_android/src/jni_bridge.rs`
+
+**Step 1: Introduce pure state model**
+
+Add a target-independent internal state type that tracks:
+
+- dimensions
+- scale factor
+- focus flag
+- redraw requested / surface dirty flags
+- touch-active flag
+- last logical touch position
+- queued logical touch events
+- last rendered size
+
+**Step 2: Delegate JNI transitions**
+
+Have `nativeInit`, `nativeRenderFrame`, `nativeOnTouch`, and `nativeResize`
+update this model instead of only logging.
+
+**Step 3: Add unit tests**
+
+Verify:
+
+- init starts dirty
+- resize requests redraw
+- touch events are translated to logical coordinates and queued
+- render clears pending redraw markers
+
+### Task 2: Align Android Activity Renderability State
+
+**Files:**
+- Modify: `extensions/blinc_platform_android/src/activity.rs`
+- Test: `extensions/blinc_platform_android/src/activity.rs`
+
+**Step 1: Extend lifecycle state**
+
+Track whether redraw is needed and mark it on init/resume/resize/focus events.
+In practice, `Resume` should not force `focused = true`; redraw may be
+re-requested on resume only when the app is already focused or when a later
+focus-gain event arrives.
+
+**Step 2: Make render path consume redraw need**
+
+`render_frame()` should clear pending redraw markers even if the GPU path is not
+implemented yet.
+
+**Step 3: Add focused tests**
+
+Verify `should_render()` and redraw semantics across focus/window transitions.
+
+### Task 3: Verification
+
+**Step 1: Run formatting**
+
+Run: `cargo fmt --all`
+
+**Step 2: Run formatting check**
+
+Run: `cargo fmt --all -- --check`
+
+**Step 3: Run tests**
+
+Run:
+
+```bash
+cargo test -p blinc_platform_android
+```

--- a/docs/plans/2026-03-09-blinc-cn-latest-css-defaults-design.md
+++ b/docs/plans/2026-03-09-blinc-cn-latest-css-defaults-design.md
@@ -1,0 +1,58 @@
+# blinc_cn Latest CSS Defaults Design
+
+## Goal
+
+Apply recently added CSS features to `blinc_cn` defaults aggressively enough that the default component set visibly benefits from the newer engine capabilities, while preserving sensible out-of-the-box UI behavior.
+
+## Scope
+
+- Prioritize the default `blinc_cn` component set over `blinc_layout` primitives.
+- Keep the token-first structure introduced in `blinc_theme`.
+- Use modern CSS features in defaults, not only in demos:
+  - `corner-shape`
+  - `backdrop-filter`
+  - `text-overflow`
+  - `text-decoration`
+  - `pointer-events`
+  - `cursor`
+  - `mix-blend-mode` where it is decorative and low-risk
+
+## Design
+
+### 1. Keep semantic tokens as the backbone
+
+Recent CSS usage should still route through semantic component defaults where practical. New CSS-heavy defaults should consume `control`, `container`, and `overlay` semantics instead of reintroducing component-local hardcoded geometry.
+
+### 2. Apply expressive CSS by component tier
+
+- Controls (`Button`, `Input`, `Textarea`, `Tabs`, `Select`, `Combobox`)
+  - Add `corner-shape` defaults and transitions.
+  - Apply truncation classes to labels and selected values.
+  - Use richer interactive state styling for link/button-like content.
+- Floating surfaces (`Dropdown`, `ContextMenu`, `Menubar`, `Popover`, `HoverCard`, `Dialog`, `Toast`)
+  - Add `backdrop-filter` defaults.
+  - Add `corner-shape` for a more modern silhouette.
+- Navigation/content labels (`NavigationMenu`, `Sidebar`, `Breadcrumb`, `Menubar`)
+  - Add truncation and text-decoration defaults where appropriate.
+- Decorative/supporting surfaces (`Skeleton`, `Badge`, `Kbd`)
+  - Use low-risk modern CSS such as subtle `mix-blend-mode`, `corner-shape`, and interaction utilities.
+
+### 3. Introduce reusable utility classes in `cn_styles`
+
+The stylesheet should gain a small set of reusable CSS utilities so components can opt into recent features without duplicating declarations:
+
+- `.cn-truncate`
+- `.cn-decorative`
+- `.cn-link-text`
+- shared overlay material rules
+
+### 4. Update component markup where CSS needs a target
+
+Some newer CSS properties only matter if text or decorative children expose a class target. Add classes to button labels, select values, combobox values, nav labels, sidebar labels, breadcrumb labels, and menu shortcuts/icons where needed.
+
+## Success Criteria
+
+- The PR no longer relies only on `var()` and pseudo-class support; it uses recently added CSS features in the shipped defaults.
+- Default `blinc_cn` controls and overlays visibly use `corner-shape` and `backdrop-filter`.
+- Common long labels truncate gracefully in buttons, selects, nav, sidebar, and breadcrumb components.
+- Link-like defaults use CSS-driven text decoration rather than only color changes.

--- a/docs/plans/2026-03-09-blinc-cn-latest-css-defaults-impl-plan.md
+++ b/docs/plans/2026-03-09-blinc-cn-latest-css-defaults-impl-plan.md
@@ -1,0 +1,70 @@
+# blinc_cn Latest CSS Defaults Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Apply the newer CSS engine features directly to `blinc_cn` default components so the shipped defaults exercise the modern styling surface instead of leaving it only in demos.
+
+**Architecture:** Extend semantic component tokens only where they help express new defaults, then update `CN_STYLES` with reusable modern CSS patterns and add class targets in component builders where those styles need to land on text or decorative children.
+
+**Tech Stack:** Rust, `blinc_theme`, `blinc_cn`, Blinc CSS engine
+
+---
+
+### Task 1: Extend semantic tokens for shape-forward defaults
+
+**Files:**
+- Modify: `crates/blinc_theme/src/tokens/component.rs`
+- Modify: `crates/blinc_theme/src/state.rs`
+
+1. Add semantic `corner_shape_*` fields for control, container, and overlay tokens.
+2. Derive them from primitive theme scales.
+3. Export them as CSS variables from `ThemeState`.
+
+### Task 2: Upgrade `CN_STYLES` to use recent CSS features
+
+**Files:**
+- Modify: `crates/blinc_cn/src/cn_styles.rs`
+
+1. Add reusable utility classes for truncation and decorative children.
+2. Apply `corner-shape` to controls, containers, overlays, and navigation surfaces.
+3. Apply `backdrop-filter` to overlay/dialog-like defaults.
+4. Apply `text-decoration` to link-like states and `text-overflow` to label helpers.
+5. Use a low-risk `mix-blend-mode` on a decorative/supporting component default.
+
+### Task 3: Add class targets in component builders
+
+**Files:**
+- Modify: `crates/blinc_cn/src/components/button.rs`
+- Modify: `crates/blinc_cn/src/components/select.rs`
+- Modify: `crates/blinc_cn/src/components/combobox.rs`
+- Modify: `crates/blinc_cn/src/components/navigation_menu.rs`
+- Modify: `crates/blinc_cn/src/components/sidebar.rs`
+- Modify: `crates/blinc_cn/src/components/breadcrumb.rs`
+- Modify: `crates/blinc_cn/src/components/dropdown_menu.rs`
+- Modify: `crates/blinc_cn/src/components/context_menu.rs`
+- Modify: `crates/blinc_cn/src/components/menubar.rs`
+
+1. Add explicit classes for labels, values, shortcuts, and decorative icons.
+2. Keep behavior unchanged except where CSS utilities require a target.
+
+### Task 4: Update docs and verify
+
+**Files:**
+- Modify: `crates/blinc_cn/README.md`
+- Modify: `docs/book/src/cn/overview.md`
+
+1. Mention that default styles now lean on newer CSS engine features.
+2. Run:
+   - `cargo fmt --all`
+   - `cargo fmt --all -- --check`
+   - `cargo test -p blinc_theme`
+   - `cargo test -p blinc_cn`
+
+### Task 5: Review loop
+
+**Files:**
+- No code target
+
+1. Request subagent review on the diff.
+2. Fix findings.
+3. Re-run verification before closing the batch.

--- a/docs/plans/2026-03-09-blinc-cn-theme-token-first-design.md
+++ b/docs/plans/2026-03-09-blinc-cn-theme-token-first-design.md
@@ -1,0 +1,97 @@
+# Blinc CN Theme-Token-First Defaults Design
+
+## Goal
+
+Make `blinc_cn` visually coherent by moving default sizing, spacing, typography-role, and overlay/container decisions into `blinc_theme` first, then making `blinc_cn` consume those semantic tokens instead of local constants.
+
+## Problem
+
+`blinc_cn` currently mixes theme tokens with component-local constants. Colors mostly come from tokens, but radii, paddings, gaps, heights, and font sizes are often repeated directly in component code and `cn_styles.rs`. This weakens first-run coherence and makes shadcn-like presets feel only partially centralized.
+
+`blinc_layout` should remain the primitive/widget substrate. Polished defaults belong in `blinc_cn`.
+
+## Design
+
+### 1. Keep primitive tokens, add semantic component roles
+
+Preserve the current primitive scales in `blinc_theme`:
+
+- color tokens
+- spacing scale
+- radius scale
+- typography scale
+- shadow scale
+
+Add semantic component-token groups on top of those primitives:
+
+- control metrics
+  - heights for `sm/md/lg`
+  - horizontal/vertical paddings for `sm/md/lg`
+  - default control radius
+- container metrics
+  - card/dialog/drawer/content padding
+  - section/header/footer gaps
+  - default container radius
+- overlay metrics
+  - menu/select/popover/content padding
+  - overlay radius
+  - overlay shadow
+- typography roles
+  - action text
+  - body text
+  - helper text
+  - label text
+  - title text
+- compact badges/kbd/chips
+  - badge font size
+  - badge paddings
+  - chip radius
+
+The semantic layer must be derived from primitive scales in defaults and presets instead of inventing independent numbers everywhere.
+
+### 2. Make `Theme` and `ThemeState` expose semantic component tokens
+
+Introduce a dedicated semantic token struct in `blinc_theme`, likely alongside `ColorTokens`, `SpacingTokens`, `RadiusTokens`, and `TypographyTokens`.
+
+`Theme` should expose the semantic token set directly, and `ThemeState` should cache and return it just like the other token families. This keeps consumers from rebuilding ad-hoc mappings in every component.
+
+### 3. Rewire `blinc_cn` to consume semantic tokens first
+
+Replace repeated hard-coded defaults in:
+
+- `cn_styles.rs`
+- button/input/textarea size logic
+- card/alert/badge surface defaults
+- dropdown/menu/context-menu/menubar/select overlays
+- tabs/sidebar/avatar/progress where visual constants still leak
+
+Preferred lookup order:
+
+1. explicit component builder override
+2. semantic component token
+3. primitive token only when the semantic token is intentionally derived from it
+
+Avoid direct numeric literals unless they are geometric invariants such as fully-rounded pills or track math.
+
+### 4. Keep CSS overridable, but token-backed by default
+
+`cn_styles.rs` should continue to define CSS variables and class defaults, but its fallback values should mostly point at semantic CSS variables exported from `ThemeState::to_css_variable_map()`, rather than raw literals like `12px`, `16px`, or `14px`.
+
+### 5. Documentation boundary
+
+Document `blinc_layout` as a primitive/widget layer with sane behavioral defaults.
+Document `blinc_cn` as the polished design-system layer responsible for default visual quality.
+
+## Non-Goals
+
+- Reworking all platform-native themes
+- Redesigning the color palettes
+- Turning `blinc_layout` into a shadcn-style component library
+
+## Success Criteria
+
+- `blinc_cn` components in the same preset share a stable radius/spacing/type system by default.
+- `cn_styles.rs` loses most visual hard-coded literals for common component surfaces and controls.
+- overlay components share one default overlay token family.
+- control-like components share one default control token family.
+- docs clearly separate primitive defaults from polished component defaults.

--- a/docs/plans/2026-03-09-blinc-cn-theme-token-first-impl-plan.md
+++ b/docs/plans/2026-03-09-blinc-cn-theme-token-first-impl-plan.md
@@ -1,0 +1,122 @@
+# Blinc CN Theme-Token-First Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move `blinc_cn` visual defaults to semantic theme tokens so presets drive coherent component defaults without per-component magic numbers.
+
+**Architecture:** Add a semantic component-token layer to `blinc_theme`, expose it through `Theme` and `ThemeState`, then refactor `blinc_cn` CSS and component builders to consume that layer. Keep `blinc_layout` as the primitive/widget substrate and only adjust docs there.
+
+**Tech Stack:** Rust 2021, `blinc_theme`, `blinc_cn`, CSS variable export via `ThemeState`
+
+---
+
+### Task 1: Add semantic component token model to `blinc_theme`
+
+**Files:**
+- Create: `crates/blinc_theme/src/tokens/component.rs`
+- Modify: `crates/blinc_theme/src/tokens/mod.rs`
+- Modify: `crates/blinc_theme/src/theme.rs`
+- Modify: `crates/blinc_theme/src/state.rs`
+- Test: `crates/blinc_theme/tests/presets.rs`
+
+**Steps:**
+1. Add a `ComponentTokens` struct that groups semantic defaults for controls, containers, overlays, badge/chip, and typography roles.
+2. Derive default values from existing primitive tokens instead of introducing arbitrary numbers.
+3. Export the new tokens from `tokens/mod.rs`.
+4. Extend `Theme` with `components(&self) -> &ComponentTokens`.
+5. Cache component tokens inside `ThemeState` and add a getter.
+6. Extend CSS variable export so semantic component values can be referenced from `cn_styles.rs`.
+7. Add or update tests proving presets expose stable semantic defaults.
+
+### Task 2: Wire component tokens into theme implementations and presets
+
+**Files:**
+- Modify: `crates/blinc_theme/src/themes/blinc.rs`
+- Modify: `crates/blinc_theme/src/themes/platform/macos.rs`
+- Modify: `crates/blinc_theme/src/themes/platform/windows.rs`
+- Modify: `crates/blinc_theme/src/themes/platform/linux.rs`
+- Modify: `crates/blinc_theme/src/presets/mod.rs`
+- Test: `crates/blinc_theme/tests/presets.rs`
+
+**Steps:**
+1. Update each theme struct to store or derive `ComponentTokens`.
+2. Ensure shadcn-style presets derive semantic control/container/overlay values from their preset radii and spacing.
+3. Keep platform themes coherent without overfitting them to `blinc_cn`.
+4. Add tests for radius/padding/typography role expectations in the shadcn-like presets.
+
+### Task 3: Refactor `blinc_cn` shared CSS defaults to semantic tokens
+
+**Files:**
+- Modify: `crates/blinc_cn/src/cn_styles.rs`
+- Modify: `crates/blinc_cn/src/lib.rs`
+- Test: `crates/blinc_cn/tests` if needed, otherwise component-local tests
+
+**Steps:**
+1. Replace common hard-coded literals in CSS with semantic theme CSS variables.
+2. Introduce component-variable fallbacks that point to semantic component variables first.
+3. Keep user override points stable.
+4. Update any bootstrap docs/comments that still reference old registration flow.
+
+### Task 4: Refactor control components to semantic control tokens
+
+**Files:**
+- Modify: `crates/blinc_cn/src/components/button.rs`
+- Modify: `crates/blinc_cn/src/components/input.rs`
+- Modify: `crates/blinc_cn/src/components/textarea.rs`
+- Modify: `crates/blinc_cn/src/components/select.rs`
+- Modify: `crates/blinc_cn/src/components/combobox.rs`
+- Modify: `crates/blinc_cn/src/components/label.rs`
+- Test: component-local tests in those files
+
+**Steps:**
+1. Replace size-specific font/radius/padding defaults with semantic control tokens.
+2. Keep explicit builder overrides working.
+3. Update tests to assert token-driven fallback behavior.
+
+### Task 5: Refactor surfaces and overlays to semantic container/overlay tokens
+
+**Files:**
+- Modify: `crates/blinc_cn/src/components/card.rs`
+- Modify: `crates/blinc_cn/src/components/alert.rs`
+- Modify: `crates/blinc_cn/src/components/dialog.rs`
+- Modify: `crates/blinc_cn/src/components/drawer.rs`
+- Modify: `crates/blinc_cn/src/components/dropdown_menu.rs`
+- Modify: `crates/blinc_cn/src/components/context_menu.rs`
+- Modify: `crates/blinc_cn/src/components/menubar.rs`
+- Modify: `crates/blinc_cn/src/components/popover.rs`
+- Modify: `crates/blinc_cn/src/components/tooltip.rs`
+- Test: existing local tests plus any new overlay default assertions
+
+**Steps:**
+1. Move overlay paddings/radii/font sizes to semantic overlay tokens.
+2. Move card/dialog/drawer paddings and gaps to semantic container tokens.
+3. Keep geometry-only exceptions local if truly required.
+
+### Task 6: Refactor remaining visual outliers and docs
+
+**Files:**
+- Modify: `crates/blinc_cn/src/components/avatar.rs`
+- Modify: `crates/blinc_cn/src/components/progress.rs`
+- Modify: `crates/blinc_cn/src/components/sidebar.rs`
+- Modify: `crates/blinc_cn/src/components/tabs.rs`
+- Modify: `crates/blinc_cn/README.md`
+- Modify: `docs/book/src/cn/*.md`
+- Modify: `crates/blinc_layout/README.md`
+
+**Steps:**
+1. Reduce residual local constants in the visual outlier components.
+2. Document that `blinc_cn` owns polished defaults while `blinc_layout` owns primitives/widgets.
+3. Update examples to emphasize preset-driven defaults.
+
+### Task 7: Verify and review
+
+**Files:**
+- Modify only if fixes are needed from review
+
+**Steps:**
+1. Run `cargo fmt --all`.
+2. Run `cargo fmt --all -- --check`.
+3. Run `cargo test -p blinc_theme`.
+4. Run `cargo test -p blinc_cn`.
+5. Request subagent review focused on token architecture regressions and default consistency.
+6. Apply findings before closing the task.

--- a/docs/plans/2026-03-09-ios-runtime-surface-design.md
+++ b/docs/plans/2026-03-09-ios-runtime-surface-design.md
@@ -1,0 +1,67 @@
+# iOS Runtime Surface Design
+
+**Scope:** `extensions/blinc_platform_ios` runtime surface only.
+
+## Problem
+
+The current iOS platform crate still exposes placeholder behavior in three places
+that leak directly into the public API:
+
+- `is_dark_mode()` always returns `false`
+- `get_safe_area_insets()` always returns zeroes
+- `IOSEventLoop::run()` returns `Unsupported`, even though the crate already
+  documents UIKit-managed lifecycle integration
+
+This creates a gap between what the crate surface suggests and what downstream
+code can rely on.
+
+## Goal
+
+Make the iOS platform surface more truthful and immediately useful without
+pretending Blinc owns the iOS runtime.
+
+## Recommended Approach
+
+### 1. Use UIKit for environment reads
+
+Implement small iOS-only helpers that query:
+
+- active interface style for dark mode
+- active window/root-view safe area insets
+
+These should stay inside `app.rs` so the public surface remains unchanged.
+
+### 2. Separate query logic from fallback policy
+
+Split UIKit access into internal helper functions that return `Option<_>`.
+Public API functions should preserve the existing cross-platform fallback story:
+
+- dark mode falls back to `false`
+- safe area falls back to `(0, 0, 0, 0)`
+
+This keeps behavior explicit and testable.
+
+### 3. Reframe the event loop as UIKit-managed
+
+`IOSEventLoop::run()` should no longer present itself as a missing feature.
+Instead, it should:
+
+- emit the minimal lifecycle/frame events that can be produced from the Rust side
+- return `Ok(())`
+- document that UIKit owns the real run loop and frame scheduling
+
+This makes the API truthful: the event loop exists as an integration surface,
+but it is not a desktop-style blocking owner loop.
+
+## Non-Goals
+
+- Building a full Rust-owned iOS run loop
+- Implementing full CADisplayLink-driven event delivery inside the Rust crate
+- Adding iOS integration tests that require simulator/device execution
+
+## Testing
+
+- Add unit tests for fallback/helper behavior that do not require iOS runtime
+- Keep iOS-specific UIKit calls behind `#[cfg(target_os = "ios")]`
+- Run `cargo test -p blinc_platform_ios`
+

--- a/docs/plans/2026-03-09-ios-runtime-surface-impl-plan.md
+++ b/docs/plans/2026-03-09-ios-runtime-surface-impl-plan.md
@@ -1,0 +1,78 @@
+# iOS Runtime Surface Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the most visible placeholder behavior in `blinc_platform_ios` with UIKit-backed environment reads and a truthful UIKit-managed event-loop surface.
+
+**Architecture:** Keep public APIs stable. Add small internal query helpers in `app.rs` for dark mode and safe area, then update `IOSEventLoop::run()` to behave like a UIKit-managed bridge surface rather than a missing feature. Prefer helper extraction so non-iOS tests can verify fallback logic without simulator execution.
+
+**Tech Stack:** Rust 1.75, edition 2021, `objc2`, `objc2-ui-kit`, `blinc_platform_ios`.
+
+---
+
+### Task 1: Add iOS Environment Query Helpers
+
+**Files:**
+- Modify: `extensions/blinc_platform_ios/src/app.rs`
+- Test: `extensions/blinc_platform_ios/src/app.rs`
+
+**Step 1: Extract helpers**
+
+Add internal helpers that return:
+
+- optional dark-mode state
+- optional safe-area insets
+
+UIKit code should stay behind `#[cfg(target_os = "ios")]`.
+
+**Step 2: Keep public fallback behavior**
+
+Have `is_dark_mode()` and `get_safe_area_insets()` call the helpers and fall back
+when UIKit context is unavailable.
+
+**Step 3: Add focused tests**
+
+Add tests for the fallback wrappers/helper combinators that run on non-iOS too.
+
+### Task 2: Replace Unsupported iOS Event Loop Behavior
+
+**Files:**
+- Modify: `extensions/blinc_platform_ios/src/event_loop.rs`
+- Test: `extensions/blinc_platform_ios/src/event_loop.rs`
+
+**Step 1: Adjust run semantics**
+
+Make `IOSEventLoop::run()` dispatch a minimal set of bridge-safe events and
+return `Ok(())` instead of `Unsupported`.
+
+**Step 2: Add focused tests**
+
+On non-iOS targets, keep placeholder behavior as-is. Add tests for any shared
+event-sequence helper used by the iOS path.
+
+### Task 3: Update iOS Surface Docs
+
+**Files:**
+- Modify: `extensions/blinc_platform_ios/README.md`
+
+**Step 1: Clarify runtime guarantees**
+
+Document that:
+
+- environment queries now reflect UIKit when available
+- the event loop surface is UIKit-managed rather than Rust-owned
+- renderer/lifecycle completeness still depends on the host app
+
+### Task 4: Verification
+
+**Step 1: Run formatting**
+
+Run: `cargo fmt --all`
+
+**Step 2: Run formatting check**
+
+Run: `cargo fmt --all -- --check`
+
+**Step 3: Run tests**
+
+Run: `cargo test -p blinc_platform_ios`

--- a/docs/plans/2026-03-09-native-maturity-and-blinc-cn-defaults-design.md
+++ b/docs/plans/2026-03-09-native-maturity-and-blinc-cn-defaults-design.md
@@ -1,0 +1,130 @@
+# Native Maturity And blinc_cn Defaults Design
+
+**Scope:** desktop, Android, iOS, and `blinc_cn`. HarmonyOS is explicitly out of scope for this pass.
+
+## Problem
+
+The repository currently has two high-friction issues:
+
+1. `blinc_cn` does not provide a reliable low-friction path to attractive default UI. Theme/bootstrap requirements are implicit, docs are out of sync with the actual API, and several default component visuals are inconsistent or too raw.
+2. Native platform documentation, templates, and exposed APIs overstate maturity for desktop, Android, and iOS. In practice, users can easily copy documented examples that do not compile, do not wire required native bridges, or imply runtime capabilities that are not implemented.
+
+## Goals
+
+- Make `blinc_cn` usable with a small, explicit bootstrap path that does not rely on hidden setup.
+- Align `blinc_cn` README/book examples with the real API surface.
+- Improve the default visual behavior of a small set of high-impact components so the stock result is more coherent.
+- Reduce documentation overstatement for desktop, Android, and iOS.
+- Ensure generated mobile templates are consistent with the currently supported native bridge/runtime story.
+
+## Non-Goals
+
+- Building the missing Android/iOS renderer/runtime pieces from scratch.
+- Adding a full OS accessibility bridge for desktop or mobile.
+- Expanding the platform abstraction with new large native capability surfaces in this pass.
+- Touching HarmonyOS.
+
+## Recommended Approach
+
+### 1. Add an official `blinc_cn` bootstrap surface
+
+Introduce a small public bootstrap API in `blinc_cn` that:
+
+- initializes `ThemeState` with a sensible preset when not already initialized
+- exposes the default CSS string through a stable, documented helper
+- makes docs/examples show the supported setup path instead of hidden assumptions
+
+This does not remove manual control. It gives users a default path while preserving explicit theme/preset override APIs.
+
+### 2. Treat docs/API alignment as a product bug
+
+Update `crates/blinc_cn/README.md` and the component book pages so every example reflects the actual exported API:
+
+- imperative `dialog().show()` usage
+- `switch(&state)` rather than removed helpers
+- current `select(&state).option(...)` style
+- current card/header/footer functions and size enum names
+- explicit bootstrap/setup instructions
+
+The success criterion is that a new user can follow the docs without reverse-engineering the crate source.
+
+### 3. Improve a small set of default visuals instead of redesigning everything
+
+Target only components with high leverage and clear default-quality issues:
+
+- `Progress`: make the track recede visually instead of competing with the fill
+- `Avatar`: make fallback/empty states look intentional
+- `Sidebar`: replace cramped hardcoded spacing with token-driven defaults
+- `Tabs` and `Select`: reduce mismatches between CSS defaults and inline Rust styling
+
+This keeps the pass surgical and lowers regression risk.
+
+### 4. Reframe native docs around implemented reality
+
+For desktop, Android, and iOS:
+
+- document current supported behavior accurately
+- stop implying full native maturity where crates still contain placeholders/stubs
+- make template READMEs and generated scaffolds match what is actually wired
+
+For Android/iOS templates specifically, ensure native bridge files and initialization steps are consistent across template and example projects.
+
+## Design Details
+
+### blinc_cn bootstrap
+
+Add public helpers with behavior like:
+
+- `ensure_default_theme()`: initialize `ThemeState::init_default()` only if absent
+- `ensure_theme(bundle, scheme)`: initialize custom theme only if absent
+- `default_styles() -> &'static str`: return `CN_STYLES`
+
+This avoids forcing initialization inside every component while still giving the ecosystem a canonical setup point.
+
+### Visual token policy
+
+Prefer token-driven values over local hardcoded spacing/colors when the value represents shared system semantics. Keep local constants only when they are intrinsic to a control’s geometry and not a theme concern.
+
+### Native maturity framing
+
+Desktop remains the strongest runtime, but documentation should clearly separate:
+
+- currently implemented runtime/window/input behavior
+- planned shell/productization capabilities
+
+Android and iOS docs should distinguish:
+
+- app-level/mobile example support
+- platform crate completeness
+- template-level wiring guarantees
+
+## Testing Strategy
+
+- Unit tests for new bootstrap helpers.
+- Targeted tests for adjusted component defaults where cheap to assert structurally.
+- `cargo test -p blinc_cn`
+- `cargo test -p blinc_theme`
+- focused checks for template file presence and native bridge wiring via file-level verification
+- repository formatting gate before completion:
+  - `cargo fmt --all`
+  - `cargo fmt --all -- --check`
+
+## Risks
+
+- Docs may still reference stale APIs in pages not touched by this batch.
+- Visual default changes can subtly affect demos/tests.
+- Template updates can diverge from examples again if not normalized around a single bridge story.
+
+## Rollout
+
+Batch 1:
+
+- `blinc_cn` bootstrap helpers
+- README/book corrections
+- high-impact visual default fixes
+
+Batch 2:
+
+- template/native bridge normalization
+- desktop/Android/iOS documentation corrections
+- small supporting tests

--- a/docs/plans/2026-03-09-native-maturity-and-blinc-cn-defaults-impl-plan.md
+++ b/docs/plans/2026-03-09-native-maturity-and-blinc-cn-defaults-impl-plan.md
@@ -1,0 +1,243 @@
+# Native Maturity And blinc_cn Defaults Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `blinc_cn` easier to bootstrap correctly, align its docs with the actual API, improve a few poor default visuals, and bring desktop/Android/iOS/template docs in line with implemented reality.
+
+**Architecture:** Keep the implementation surgical. Add explicit bootstrap helpers in `blinc_cn`, update the highest-traffic docs/examples to the real API, tune a small number of component defaults to rely more consistently on theme tokens, and normalize native-template/docs claims without trying to invent missing runtime features.
+
+**Tech Stack:** Rust 1.75, edition 2021, `blinc_cn`, `blinc_theme`, mobile/native templates, mdBook docs.
+
+---
+
+### Task 1: Add Official blinc_cn Bootstrap Helpers
+
+**Files:**
+- Modify: `crates/blinc_cn/src/lib.rs`
+- Test: `crates/blinc_cn/src/lib.rs`
+
+**Step 1: Add public helpers**
+
+Add helpers to expose:
+
+- `ensure_default_theme()`
+- `ensure_theme(bundle, scheme)`
+- `default_styles() -> &'static str`
+
+These should use `ThemeState::try_get()` and initialize only when absent.
+
+**Step 2: Add focused tests**
+
+Add tests that verify:
+
+- `default_styles()` returns a non-empty stylesheet
+- `ensure_default_theme()` leaves theme state available
+
+Use existing singleton carefully and avoid tests that depend on resetting the singleton.
+
+**Step 3: Run focused tests**
+
+Run: `cargo test -p blinc_cn bootstrap -- --nocapture`
+
+**Step 4: Commit**
+
+```bash
+git add crates/blinc_cn/src/lib.rs
+git commit -m "feat(blinc_cn): add bootstrap helpers"
+```
+
+### Task 2: Fix blinc_cn README To Match Real Setup And API
+
+**Files:**
+- Modify: `crates/blinc_cn/README.md`
+
+**Step 1: Rewrite setup section**
+
+Document:
+
+- bootstrap helper usage
+- explicit theme initialization option
+- default styles helper usage
+
+**Step 2: Replace stale examples**
+
+Update examples to use current APIs:
+
+- `switch(&state)`
+- `select(&state).option(...)`
+- imperative `dialog().show()`
+- current button size enum names
+- currently exported card helpers
+
+**Step 3: Verify references**
+
+Run: `rg -n "switch_|dialog_trigger|select_trigger|ButtonSize::Sm|ButtonSize::Default|card_title|card_description" crates/blinc_cn/README.md`
+Expected: no matches
+
+**Step 4: Commit**
+
+```bash
+git add crates/blinc_cn/README.md
+git commit -m "docs(blinc_cn): align readme with actual api"
+```
+
+### Task 3: Correct mdBook blinc_cn Pages
+
+**Files:**
+- Modify: `docs/book/src/cn/overview.md`
+- Modify: `docs/book/src/cn/dialog.md`
+- Modify: `docs/book/src/cn/form.md`
+- Modify: `docs/book/src/cn/navigation.md`
+- Modify: `docs/book/src/cn/card.md`
+- Modify: `docs/book/src/cn/button.md`
+
+**Step 1: Update high-traffic pages**
+
+Correct the same stale patterns found in README.
+
+**Step 2: Add bootstrap note**
+
+At least `overview.md` should explain the required `blinc_cn` setup path.
+
+**Step 3: Verify stale API references are removed from touched pages**
+
+Run: `rg -n "switch_|dialog_trigger|dialog_content|select_trigger|select_content|radio_item|card_title|card_description|ButtonSize::Sm|ButtonSize::Default" docs/book/src/cn/{overview,dialog,form,navigation,card,button}.md`
+
+**Step 4: Commit**
+
+```bash
+git add docs/book/src/cn/overview.md docs/book/src/cn/dialog.md docs/book/src/cn/form.md docs/book/src/cn/navigation.md docs/book/src/cn/card.md docs/book/src/cn/button.md
+git commit -m "docs(book): update blinc_cn component guides"
+```
+
+### Task 4: Improve High-Impact blinc_cn Defaults
+
+**Files:**
+- Modify: `crates/blinc_cn/src/components/progress.rs`
+- Modify: `crates/blinc_cn/src/components/avatar.rs`
+- Modify: `crates/blinc_cn/src/components/sidebar.rs`
+- Modify: `crates/blinc_cn/src/components/select.rs`
+- Modify: `crates/blinc_cn/src/components/tabs.rs`
+- Modify: `crates/blinc_cn/src/cn_styles.rs`
+
+**Step 1: Progress**
+
+Make the default track use a more recessed surface/token treatment than the current strong secondary fill.
+
+**Step 2: Avatar**
+
+Improve fallback/empty avatar styling so it remains intentional on cards and surfaces.
+
+**Step 3: Sidebar**
+
+Replace the most cramped hardcoded spacing with token-driven spacing values.
+
+**Step 4: Select/Tabs**
+
+Reduce conflicts between inline Rust appearance defaults and CSS defaults. Prefer a single authoritative default path where practical.
+
+**Step 5: Run focused tests**
+
+Run: `cargo test -p blinc_cn`
+
+**Step 6: Commit**
+
+```bash
+git add crates/blinc_cn/src/components/progress.rs crates/blinc_cn/src/components/avatar.rs crates/blinc_cn/src/components/sidebar.rs crates/blinc_cn/src/components/select.rs crates/blinc_cn/src/components/tabs.rs crates/blinc_cn/src/cn_styles.rs
+git commit -m "feat(blinc_cn): refine default component styling"
+```
+
+### Task 5: Normalize Android/iOS Template Native Bridge Wiring
+
+**Files:**
+- Modify: `toolchain/templates/rust/platforms/android/README.md`
+- Modify or Create: `toolchain/templates/rust/platforms/android/app/src/main/kotlin/com/blinc/BlincNativeBridge.kt`
+- Modify: `toolchain/templates/rust/platforms/ios/BlincApp/AppDelegate.swift`
+- Modify: `toolchain/templates/rust/platforms/ios/README.md`
+
+**Step 1: Android template**
+
+Ensure the template either includes the bridge file or the README stops claiming it does.
+
+**Step 2: iOS template**
+
+Make the AppDelegate and README consistent with the example/native bridge setup that is actually required.
+
+**Step 3: Verify template/example consistency**
+
+Run:
+
+```bash
+rg -n "BlincNativeBridge" toolchain/templates/rust/platforms/android toolchain/templates/rust/platforms/ios mobile/example/platforms/android mobile/example/platforms/ios
+```
+
+**Step 4: Commit**
+
+```bash
+git add toolchain/templates/rust/platforms/android/README.md toolchain/templates/rust/platforms/android/app/src/main/kotlin/com/blinc/BlincNativeBridge.kt toolchain/templates/rust/platforms/ios/BlincApp/AppDelegate.swift toolchain/templates/rust/platforms/ios/README.md
+git commit -m "fix(templates): align mobile bridge wiring"
+```
+
+### Task 6: Correct Desktop/Android/iOS Maturity Claims
+
+**Files:**
+- Modify: `docs/book/src/mobile/overview.md`
+- Modify: `extensions/blinc_platform_android/README.md`
+- Modify: `extensions/blinc_platform_ios/README.md`
+- Modify: `crates/blinc_platform/README.md`
+- Modify: `README.md`
+
+**Step 1: Reframe support claims**
+
+Adjust wording so docs reflect implemented support rather than planned support.
+
+**Step 2: Clarify current guarantees**
+
+Be explicit about:
+
+- desktop strengths and current limitations
+- Android/iOS platform crate limitations vs app/example support
+- missing OS-level accessibility bridge and shell/productization features
+
+**Step 3: Verify obvious overstatements removed**
+
+Run:
+
+```bash
+rg -n "Stable|automatic safe area|proper app state handling|Vulkan Rendering|Metal Rendering|full native|production-ready" docs/book/src/mobile/overview.md extensions/blinc_platform_android/README.md extensions/blinc_platform_ios/README.md crates/blinc_platform/README.md README.md
+```
+
+Review matches manually.
+
+**Step 4: Commit**
+
+```bash
+git add docs/book/src/mobile/overview.md extensions/blinc_platform_android/README.md extensions/blinc_platform_ios/README.md crates/blinc_platform/README.md README.md
+git commit -m "docs(platform): align native support claims with implementation"
+```
+
+### Task 7: Final Verification
+
+**Files:**
+- Verify all touched files
+
+**Step 1: Run formatting**
+
+Run: `cargo fmt --all`
+
+**Step 2: Run formatting check**
+
+Run: `cargo fmt --all -- --check`
+
+**Step 3: Run tests**
+
+Run:
+
+```bash
+cargo test -p blinc_cn
+cargo test -p blinc_theme
+```
+
+**Step 4: Summarize any residual gaps**
+
+Note any remaining doc debt or native runtime gaps that were intentionally left out of scope.

--- a/extensions/blinc_platform_android/README.md
+++ b/extensions/blinc_platform_android/README.md
@@ -5,11 +5,13 @@
 > This crate is a component of Blinc, a GPU-accelerated UI framework for Rust.
 > For full documentation and guides, visit the [Blinc documentation](https://project-blinc.github.io/Blinc).
 
-Android platform implementation for Blinc UI.
+Android platform scaffolding for Blinc UI.
 
 ## Overview
 
-`blinc_platform_android` provides native Android integration using the NDK, including activity lifecycle, touch input, and GPU rendering via Vulkan.
+`blinc_platform_android` provides the current Android runtime surface for Blinc:
+NativeActivity entry points, JNI/native bridge helpers, touch forwarding, asset
+loading, and the renderer integration points used by generated templates.
 
 ## Supported Platforms
 
@@ -18,12 +20,11 @@ Android platform implementation for Blinc UI.
 
 ## Features
 
-- **Native Activity**: Full NDK integration
-- **JNI Bridge**: Java interoperability
-- **Touch Input**: Multi-touch support
-- **Vulkan Rendering**: Hardware-accelerated graphics
+- **Native Activity**: Android entry-point helpers
+- **JNI Bridge**: Rust-to-Kotlin interoperability
+- **Touch Input**: Touch forwarding into Blinc events
 - **Asset Loading**: Load from APK resources
-- **Lifecycle**: Proper activity state handling
+- **Template Support**: Kotlin bridge wiring for generated projects
 
 ## Quick Start
 
@@ -45,6 +46,13 @@ pub extern "C" fn ANativeActivity_onCreate(
     });
 }
 ```
+
+## Status
+
+The Android runtime is still under active development. Use it as template-backed
+scaffolding for shared UI experiments and app integration, and verify renderer
+and lifecycle behavior in your target app before treating it as production
+ready.
 
 ## Project Setup
 
@@ -131,34 +139,6 @@ let data = loader.load("images/logo.png")?;
 if loader.exists("config.json") {
     let config = loader.load("config.json")?;
 }
-```
-
-## Lifecycle
-
-```rust
-android_main(activity, |ctx| {
-    ctx.on_start(|| {
-        // Activity started
-    });
-
-    ctx.on_resume(|| {
-        // Activity resumed
-    });
-
-    ctx.on_pause(|| {
-        // Activity paused - save state
-    });
-
-    ctx.on_stop(|| {
-        // Activity stopped
-    });
-
-    ctx.on_destroy(|| {
-        // Cleanup
-    });
-
-    build_ui()
-});
 ```
 
 ## Building

--- a/extensions/blinc_platform_android/src/activity.rs
+++ b/extensions/blinc_platform_android/src/activity.rs
@@ -12,25 +12,114 @@ use ndk::native_window::NativeWindow;
 #[cfg(target_os = "android")]
 use tracing::{debug, info, warn};
 
-/// Android application state
-#[cfg(target_os = "android")]
-pub struct BlincAndroidApp {
-    window: Option<NativeWindow>,
-    running: bool,
+#[derive(Debug, Default)]
+struct AndroidRenderState {
+    has_window: bool,
     focused: bool,
+    running: bool,
+    redraw_requested: bool,
+    last_surface_size: Option<(u32, u32)>,
 }
 
-#[cfg(target_os = "android")]
+impl AndroidRenderState {
+    fn new() -> Self {
+        Self {
+            running: true,
+            ..Self::default()
+        }
+    }
+
+    fn on_window_attached(&mut self, width: u32, height: u32) {
+        self.has_window = true;
+        self.last_surface_size = Some((width, height));
+        self.redraw_requested = true;
+    }
+
+    fn on_window_resized(&mut self, width: u32, height: u32) {
+        self.last_surface_size = Some((width, height));
+        self.redraw_requested = true;
+    }
+
+    fn on_window_detached(&mut self) {
+        self.has_window = false;
+        self.redraw_requested = false;
+    }
+
+    fn on_focus_changed(&mut self, focused: bool) {
+        self.focused = focused;
+        if focused && self.has_window {
+            self.redraw_requested = true;
+        }
+    }
+
+    fn on_resume(&mut self) {
+        if self.focused && self.has_window {
+            self.redraw_requested = true;
+        }
+    }
+
+    fn on_pause(&mut self) {
+        self.focused = false;
+    }
+
+    fn on_destroy(&mut self) {
+        self.running = false;
+        self.redraw_requested = false;
+    }
+
+    fn mark_low_memory(&mut self) {
+        // Low-memory is advisory. Keep any already-queued redraw request intact.
+    }
+
+    fn should_render(&self) -> bool {
+        self.running && self.has_window && self.focused && self.redraw_requested
+    }
+
+    fn mark_rendered(&mut self) {
+        self.redraw_requested = false;
+    }
+}
+
+/// Android application state
+pub struct BlincAndroidApp {
+    #[cfg(target_os = "android")]
+    window: Option<NativeWindow>,
+    render_state: AndroidRenderState,
+}
+
 impl BlincAndroidApp {
     /// Create a new Blinc Android application
     pub fn new() -> Self {
         Self {
+            #[cfg(target_os = "android")]
             window: None,
-            running: true,
-            focused: false,
+            render_state: AndroidRenderState::new(),
         }
     }
 
+    /// Render a frame
+    pub fn render_frame(&mut self) {
+        // TODO: Render using blinc_gpu
+        // 1. Process reactive updates
+        // 2. Update animations
+        // 3. Layout widgets
+        // 4. Paint to GPU
+        self.render_state.mark_rendered();
+    }
+
+    /// Check if app is running
+    pub fn is_running(&self) -> bool {
+        self.render_state.running
+    }
+
+    /// Check if we should render
+    pub fn should_render(&self) -> bool {
+        self.render_state.should_render()
+    }
+}
+
+#[cfg(target_os = "android")]
+impl BlincAndroidApp {
     /// Handle Android events
     pub fn handle_event(&mut self, app: &AndroidApp, event: PollEvent) {
         match event {
@@ -51,6 +140,8 @@ impl BlincAndroidApp {
                     let width = window.width();
                     let height = window.height();
                     info!("Window size: {}x{}", width, height);
+                    self.render_state
+                        .on_window_attached(width as u32, height as u32);
                     self.window = Some(window);
                     self.init_graphics();
                 }
@@ -59,6 +150,7 @@ impl BlincAndroidApp {
             MainEvent::TerminateWindow { .. } => {
                 info!("Native window terminated");
                 self.window = None;
+                self.render_state.on_window_detached();
             }
 
             MainEvent::WindowResized { .. } => {
@@ -66,28 +158,29 @@ impl BlincAndroidApp {
                     let width = window.width();
                     let height = window.height();
                     info!("Window resized: {}x{}", width, height);
-                    // TODO: Handle resize in GPU renderer
+                    self.render_state
+                        .on_window_resized(width as u32, height as u32);
                 }
             }
 
             MainEvent::GainedFocus => {
                 info!("App gained focus");
-                self.focused = true;
+                self.render_state.on_focus_changed(true);
             }
 
             MainEvent::LostFocus => {
                 info!("App lost focus");
-                self.focused = false;
+                self.render_state.on_focus_changed(false);
             }
 
             MainEvent::Pause => {
                 info!("App paused");
-                self.focused = false;
+                self.render_state.on_pause();
             }
 
             MainEvent::Resume { .. } => {
                 info!("App resumed");
-                self.focused = true;
+                self.render_state.on_resume();
             }
 
             MainEvent::Start => {
@@ -100,7 +193,7 @@ impl BlincAndroidApp {
 
             MainEvent::Destroy => {
                 info!("App destroyed");
-                self.running = false;
+                self.render_state.on_destroy();
             }
 
             MainEvent::SaveState { .. } => {
@@ -114,7 +207,7 @@ impl BlincAndroidApp {
 
             MainEvent::LowMemory => {
                 warn!("Low memory warning");
-                // TODO: Release caches
+                self.render_state.mark_low_memory();
             }
 
             MainEvent::ContentRectChanged { .. } => {
@@ -132,25 +225,6 @@ impl BlincAndroidApp {
             // This will use blinc_gpu with Vulkan backend
             info!("Graphics initialization placeholder");
         }
-    }
-
-    /// Render a frame
-    pub fn render_frame(&mut self) {
-        // TODO: Render using blinc_gpu
-        // 1. Process reactive updates
-        // 2. Update animations
-        // 3. Layout widgets
-        // 4. Paint to GPU
-    }
-
-    /// Check if app is running
-    pub fn is_running(&self) -> bool {
-        self.running
-    }
-
-    /// Check if we should render
-    pub fn should_render(&self) -> bool {
-        self.window.is_some() && self.focused
     }
 }
 
@@ -204,11 +278,105 @@ pub fn android_main() {
 
 #[cfg(test)]
 mod tests {
-    use super::android_main;
+    use super::{android_main, AndroidRenderState, BlincAndroidApp};
 
     // Tests run on host, not on Android
     #[test]
     fn test_placeholder() {
         android_main();
+    }
+
+    #[test]
+    fn render_requires_window_focus_and_redraw_request() {
+        let mut state = AndroidRenderState::new();
+        assert!(!state.should_render());
+
+        state.on_window_attached(1080, 2400);
+        assert!(!state.should_render());
+
+        state.on_focus_changed(true);
+        assert!(state.should_render());
+
+        state.mark_rendered();
+        assert!(!state.should_render());
+    }
+
+    #[test]
+    fn resize_and_resume_request_redraw_again() {
+        let mut state = AndroidRenderState::new();
+        state.on_window_attached(100, 200);
+        state.on_focus_changed(true);
+        state.mark_rendered();
+
+        state.on_window_resized(200, 300);
+        assert!(state.should_render());
+        assert_eq!(state.last_surface_size, Some((200, 300)));
+
+        state.mark_rendered();
+        state.on_pause();
+        assert!(!state.should_render());
+
+        state.on_resume();
+        assert!(!state.should_render());
+
+        state.on_focus_changed(true);
+        assert!(state.should_render());
+    }
+
+    #[test]
+    fn detach_and_destroy_stop_rendering() {
+        let mut state = AndroidRenderState::new();
+        state.on_window_attached(100, 200);
+        state.on_focus_changed(true);
+        assert!(state.should_render());
+
+        state.on_window_detached();
+        assert!(!state.should_render());
+
+        state.on_destroy();
+        assert!(!state.running);
+        assert!(!state.should_render());
+    }
+
+    #[test]
+    fn render_frame_clears_pending_redraw_on_app() {
+        let mut app = BlincAndroidApp::new();
+        app.render_state.on_window_attached(100, 200);
+        app.render_state.on_focus_changed(true);
+        assert!(app.should_render());
+
+        app.render_frame();
+        assert!(!app.should_render());
+    }
+
+    #[test]
+    fn focus_regain_and_window_reattach_re_request_redraw() {
+        let mut state = AndroidRenderState::new();
+        state.on_window_attached(100, 200);
+        state.on_focus_changed(true);
+        state.mark_rendered();
+
+        state.on_focus_changed(false);
+        assert!(!state.should_render());
+
+        state.on_focus_changed(true);
+        assert!(state.should_render());
+
+        state.mark_rendered();
+        state.on_window_detached();
+        state.on_window_attached(300, 400);
+        assert_eq!(state.last_surface_size, Some((300, 400)));
+        assert!(state.redraw_requested);
+    }
+
+    #[test]
+    fn low_memory_does_not_drop_pending_redraw() {
+        let mut state = AndroidRenderState::new();
+        state.on_window_attached(100, 200);
+        state.on_focus_changed(true);
+        assert!(state.should_render());
+
+        state.mark_low_memory();
+        assert!(state.should_render());
     }
 }

--- a/extensions/blinc_platform_android/src/jni_bridge.rs
+++ b/extensions/blinc_platform_android/src/jni_bridge.rs
@@ -248,6 +248,13 @@ impl BlincHandle {
     }
 }
 
+// SAFETY: Android surfaces are represented here as opaque native window pointers.
+// The pointer is never dereferenced directly in Rust and all handle access is
+// synchronized through the registry's `Mutex`, so moving `BlincHandle` between
+// threads does not create additional aliasing beyond the JNI bridge contract.
+#[cfg(target_os = "android")]
+unsafe impl Send for BlincHandle {}
+
 #[cfg(target_os = "android")]
 fn next_handle_id() -> i64 {
     static NEXT_HANDLE_ID: AtomicI64 = AtomicI64::new(1);
@@ -268,6 +275,28 @@ fn lock_or_recover<'a, T>(mutex: &'a Mutex<T>, label: &str) -> std::sync::MutexG
         Err(poisoned) => {
             warn!("Recovering from poisoned mutex: {}", label);
             poisoned.into_inner()
+        }
+    }
+}
+
+fn take_owned_from_arc_mutex<T>(
+    arc: std::sync::Arc<std::sync::Mutex<T>>,
+    label: &str,
+) -> Option<T> {
+    match std::sync::Arc::try_unwrap(arc) {
+        Ok(mutex) => match mutex.into_inner() {
+            Ok(value) => Some(value),
+            Err(poisoned) => {
+                tracing::warn!("Recovering from poisoned mutex during {}", label);
+                Some(poisoned.into_inner())
+            }
+        },
+        Err(_) => {
+            tracing::error!(
+                "Refusing to destroy {} while other references are still alive",
+                label
+            );
+            None
         }
     }
 }
@@ -295,22 +324,7 @@ fn destroy_handle(handle: jlong) -> Option<BlincHandle> {
         registry.remove(&id)?
     };
 
-    match Arc::try_unwrap(arc) {
-        Ok(mutex) => match mutex.into_inner() {
-            Ok(handle) => Some(handle),
-            Err(poisoned) => {
-                warn!("Recovering from poisoned BlincHandle during destroy");
-                Some(poisoned.into_inner())
-            }
-        },
-        Err(arc) => {
-            let mut guard = lock_or_recover(&arc, "android blinc handle");
-            Some(std::mem::replace(
-                &mut *guard,
-                BlincHandle::new(0, 0, 1.0, std::ptr::null_mut()),
-            ))
-        }
-    }
+    take_owned_from_arc_mutex(arc, "android blinc handle")
 }
 
 /// Initialize Blinc renderer with an Android Surface
@@ -623,7 +637,10 @@ pub fn jni_bridge_placeholder() {
 
 #[cfg(test)]
 mod tests {
-    use super::{BlincRuntimeState, TouchPhase, MAX_QUEUED_TOUCH_EVENTS};
+    use super::{
+        take_owned_from_arc_mutex, BlincRuntimeState, TouchPhase, MAX_QUEUED_TOUCH_EVENTS,
+    };
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn runtime_starts_dirty_and_focused() {
@@ -689,5 +706,23 @@ mod tests {
         let events = runtime.take_touch_events();
         assert_eq!(events.len(), MAX_QUEUED_TOUCH_EVENTS);
         assert_eq!(events.first().unwrap().phase, TouchPhase::Move);
+    }
+
+    #[test]
+    fn take_owned_from_arc_mutex_returns_value_when_unique() {
+        let value = take_owned_from_arc_mutex(Arc::new(Mutex::new(String::from("owned"))), "test");
+
+        assert_eq!(value.as_deref(), Some("owned"));
+    }
+
+    #[test]
+    fn take_owned_from_arc_mutex_refuses_when_referenced_elsewhere() {
+        let value = Arc::new(Mutex::new(String::from("shared")));
+        let shared = Arc::clone(&value);
+
+        let taken = take_owned_from_arc_mutex(value, "test");
+
+        assert!(taken.is_none());
+        assert_eq!(*shared.lock().unwrap(), "shared");
     }
 }

--- a/extensions/blinc_platform_android/src/jni_bridge.rs
+++ b/extensions/blinc_platform_android/src/jni_bridge.rs
@@ -75,22 +75,157 @@ use jni::JNIEnv;
 use ndk::native_window::NativeWindow;
 
 #[cfg(target_os = "android")]
+use std::collections::HashMap;
+
+#[cfg(target_os = "android")]
+use std::sync::atomic::{AtomicI64, Ordering};
+
+#[cfg(target_os = "android")]
+use std::sync::{Arc, Mutex, OnceLock};
+
+#[cfg(target_os = "android")]
 use tracing::{debug, error, info, warn};
+
+const MAX_QUEUED_TOUCH_EVENTS: usize = 64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TouchPhase {
+    Down,
+    Up,
+    Move,
+    Cancel,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct TouchEventRecord {
+    phase: TouchPhase,
+    x: f32,
+    y: f32,
+}
+
+#[derive(Debug)]
+struct BlincRuntimeState {
+    width: u32,
+    height: u32,
+    scale_factor: f64,
+    focused: bool,
+    redraw_requested: bool,
+    surface_dirty: bool,
+    touch_active: bool,
+    last_touch: (f32, f32),
+    queued_touch_events: Vec<TouchEventRecord>,
+    last_rendered_size: Option<(u32, u32)>,
+}
+
+impl BlincRuntimeState {
+    fn new(width: u32, height: u32, scale_factor: f64) -> Self {
+        Self {
+            width,
+            height,
+            scale_factor,
+            focused: true,
+            redraw_requested: true,
+            surface_dirty: true,
+            touch_active: false,
+            last_touch: (0.0, 0.0),
+            queued_touch_events: Vec::new(),
+            last_rendered_size: None,
+        }
+    }
+
+    fn push_touch_event(&mut self, event: TouchEventRecord) {
+        if self.queued_touch_events.len() == MAX_QUEUED_TOUCH_EVENTS {
+            self.queued_touch_events.remove(0);
+        }
+        self.queued_touch_events.push(event);
+    }
+
+    fn logical_point(&self, x: f32, y: f32) -> (f32, f32) {
+        let scale = self.scale_factor.max(f64::EPSILON) as f32;
+        (x / scale, y / scale)
+    }
+
+    fn record_touch(&mut self, phase: TouchPhase, x: f32, y: f32) -> bool {
+        let (logical_x, logical_y) = self.logical_point(x, y);
+        match phase {
+            TouchPhase::Down => {
+                self.touch_active = true;
+                self.last_touch = (logical_x, logical_y);
+                self.push_touch_event(TouchEventRecord {
+                    phase,
+                    x: logical_x,
+                    y: logical_y,
+                });
+                self.redraw_requested = true;
+                true
+            }
+            TouchPhase::Up => {
+                self.touch_active = false;
+                self.last_touch = (logical_x, logical_y);
+                self.push_touch_event(TouchEventRecord {
+                    phase,
+                    x: logical_x,
+                    y: logical_y,
+                });
+                self.redraw_requested = true;
+                true
+            }
+            TouchPhase::Move => {
+                if !self.touch_active {
+                    return false;
+                }
+                self.last_touch = (logical_x, logical_y);
+                self.push_touch_event(TouchEventRecord {
+                    phase,
+                    x: logical_x,
+                    y: logical_y,
+                });
+                self.redraw_requested = true;
+                true
+            }
+            TouchPhase::Cancel => {
+                self.touch_active = false;
+                self.push_touch_event(TouchEventRecord {
+                    phase,
+                    x: logical_x,
+                    y: logical_y,
+                });
+                self.redraw_requested = true;
+                true
+            }
+        }
+    }
+
+    fn resize(&mut self, width: u32, height: u32) {
+        self.width = width;
+        self.height = height;
+        self.surface_dirty = true;
+        self.redraw_requested = true;
+    }
+
+    fn set_focused(&mut self, focused: bool) {
+        self.focused = focused;
+        if focused {
+            self.redraw_requested = true;
+        }
+    }
+
+    fn note_rendered(&mut self) {
+        self.last_rendered_size = Some((self.width, self.height));
+        self.redraw_requested = false;
+        self.surface_dirty = false;
+    }
+
+    fn take_touch_events(&mut self) -> Vec<TouchEventRecord> {
+        std::mem::take(&mut self.queued_touch_events)
+    }
+}
 
 /// Opaque handle to BlincRenderer state
 /// This is passed to Kotlin as a Long and cast back when needed
 #[cfg(target_os = "android")]
 struct BlincHandle {
-    /// Width of the surface in pixels
-    width: u32,
-    /// Height of the surface in pixels
-    height: u32,
-    /// Scale factor (display density)
-    scale_factor: f64,
-    /// Whether touch is currently active
-    touch_active: bool,
-    /// Last touch position
-    last_touch: (f32, f32),
+    runtime: BlincRuntimeState,
     /// Native window pointer for GPU rendering
     native_window_ptr: *mut std::ffi::c_void,
     // TODO: Add actual renderer state when blinc_gpu is integrated
@@ -107,19 +242,76 @@ impl BlincHandle {
         native_window_ptr: *mut std::ffi::c_void,
     ) -> Self {
         Self {
-            width,
-            height,
-            scale_factor,
-            touch_active: false,
-            last_touch: (0.0, 0.0),
+            runtime: BlincRuntimeState::new(width, height, scale_factor),
             native_window_ptr,
         }
     }
 }
 
-// BlincHandle contains a raw pointer but we only use it from the JNI thread
 #[cfg(target_os = "android")]
-unsafe impl Send for BlincHandle {}
+fn next_handle_id() -> i64 {
+    static NEXT_HANDLE_ID: AtomicI64 = AtomicI64::new(1);
+    NEXT_HANDLE_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+#[cfg(target_os = "android")]
+fn handle_registry() -> &'static Mutex<HashMap<i64, Arc<Mutex<BlincHandle>>>> {
+    static HANDLE_REGISTRY: OnceLock<Mutex<HashMap<i64, Arc<Mutex<BlincHandle>>>>> =
+        OnceLock::new();
+    HANDLE_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(target_os = "android")]
+fn lock_or_recover<'a, T>(mutex: &'a Mutex<T>, label: &str) -> std::sync::MutexGuard<'a, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            warn!("Recovering from poisoned mutex: {}", label);
+            poisoned.into_inner()
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+fn register_handle(handle: BlincHandle) -> i64 {
+    let id = next_handle_id();
+    let mut registry = lock_or_recover(handle_registry(), "android handle registry");
+    registry.insert(id, Arc::new(Mutex::new(handle)));
+    id
+}
+
+#[cfg(target_os = "android")]
+fn get_handle(handle: jlong) -> Option<Arc<Mutex<BlincHandle>>> {
+    let id = i64::try_from(handle).ok()?;
+    let registry = lock_or_recover(handle_registry(), "android handle registry");
+    registry.get(&id).cloned()
+}
+
+#[cfg(target_os = "android")]
+fn destroy_handle(handle: jlong) -> Option<BlincHandle> {
+    let id = i64::try_from(handle).ok()?;
+    let arc = {
+        let mut registry = lock_or_recover(handle_registry(), "android handle registry");
+        registry.remove(&id)?
+    };
+
+    match Arc::try_unwrap(arc) {
+        Ok(mutex) => match mutex.into_inner() {
+            Ok(handle) => Some(handle),
+            Err(poisoned) => {
+                warn!("Recovering from poisoned BlincHandle during destroy");
+                Some(poisoned.into_inner())
+            }
+        },
+        Err(arc) => {
+            let mut guard = lock_or_recover(&arc, "android blinc handle");
+            Some(std::mem::replace(
+                &mut *guard,
+                BlincHandle::new(0, 0, 1.0, std::ptr::null_mut()),
+            ))
+        }
+    }
+}
 
 /// Initialize Blinc renderer with an Android Surface
 ///
@@ -175,25 +367,16 @@ pub extern "system" fn Java_com_blinc_BlincBridge_nativeInit(
     };
 
     // Create handle with surface info
-    let handle = Box::new(BlincHandle::new(
+    let handle_id = register_handle(BlincHandle::new(
         width as u32,
         height as u32,
         scale_factor,
         native_window_ptr,
     ));
 
-    // TODO: Initialize GPU renderer with native_window_ptr
-    // This would involve:
-    // 1. Create wgpu Instance with Vulkan backend
-    // 2. Create surface from native window pointer
-    // 3. Initialize GpuRenderer
-    // 4. Store in handle
+    info!("Created BlincHandle id {}", handle_id);
 
-    // Convert to raw pointer and return as jlong
-    let ptr = Box::into_raw(handle);
-    info!("Created BlincHandle at {:p}", ptr);
-
-    ptr as jlong
+    handle_id as jlong
 }
 
 /// Render a frame
@@ -215,15 +398,28 @@ pub extern "system" fn Java_com_blinc_BlincBridge_nativeRenderFrame(
         return;
     }
 
-    let _blinc = unsafe { &mut *(handle as *mut BlincHandle) };
+    let arc = match get_handle(handle) {
+        Some(arc) => arc,
+        None => {
+            warn!("nativeRenderFrame called with unknown or destroyed handle");
+            return;
+        }
+    };
+    let mut blinc = lock_or_recover(&arc, "android blinc handle");
 
-    // TODO: Implement actual rendering
-    // 1. Get surface texture
-    // 2. Clear with background color
-    // 3. Render UI tree
-    // 4. Present
+    let was_dirty = blinc.runtime.surface_dirty;
+    let was_redraw_requested = blinc.runtime.redraw_requested;
+    blinc.runtime.note_rendered();
 
-    debug!("nativeRenderFrame called");
+    debug!(
+        "nativeRenderFrame called for handle {} at {}x{} (dirty={}, redraw_requested={}, focused={})",
+        handle,
+        blinc.runtime.width,
+        blinc.runtime.height,
+        was_dirty,
+        was_redraw_requested,
+        blinc.runtime.focused
+    );
 }
 
 /// Handle touch input event
@@ -254,11 +450,14 @@ pub extern "system" fn Java_com_blinc_BlincBridge_nativeOnTouch(
         return JNI_FALSE;
     }
 
-    let blinc = unsafe { &mut *(handle as *mut BlincHandle) };
-
-    // Convert to logical coordinates
-    let logical_x = x / blinc.scale_factor as f32;
-    let logical_y = y / blinc.scale_factor as f32;
+    let arc = match get_handle(handle) {
+        Some(arc) => arc,
+        None => {
+            warn!("nativeOnTouch called with unknown or destroyed handle");
+            return JNI_FALSE;
+        }
+    };
+    let mut blinc = lock_or_recover(&arc, "android blinc handle");
 
     // Android MotionEvent actions
     const ACTION_DOWN: i32 = 0;
@@ -266,37 +465,37 @@ pub extern "system" fn Java_com_blinc_BlincBridge_nativeOnTouch(
     const ACTION_MOVE: i32 = 2;
     const ACTION_CANCEL: i32 = 3;
 
-    match action {
+    let handled = match action {
         ACTION_DOWN => {
-            debug!("Touch down at ({}, {})", logical_x, logical_y);
-            blinc.touch_active = true;
-            blinc.last_touch = (logical_x, logical_y);
-            // TODO: Route to event router
+            let handled = blinc.runtime.record_touch(TouchPhase::Down, x, y);
+            debug!("Touch down handled={}", handled);
+            handled
         }
         ACTION_UP => {
-            debug!("Touch up at ({}, {})", logical_x, logical_y);
-            blinc.touch_active = false;
-            blinc.last_touch = (logical_x, logical_y);
-            // TODO: Route to event router
+            let handled = blinc.runtime.record_touch(TouchPhase::Up, x, y);
+            debug!("Touch up handled={}", handled);
+            handled
         }
         ACTION_MOVE => {
-            if blinc.touch_active {
-                debug!("Touch move to ({}, {})", logical_x, logical_y);
-                blinc.last_touch = (logical_x, logical_y);
-                // TODO: Route to event router
-            }
+            let handled = blinc.runtime.record_touch(TouchPhase::Move, x, y);
+            debug!("Touch move handled={}", handled);
+            handled
         }
         ACTION_CANCEL => {
             debug!("Touch cancelled");
-            blinc.touch_active = false;
-            // TODO: Route to event router
+            blinc.runtime.record_touch(TouchPhase::Cancel, x, y)
         }
         _ => {
             debug!("Unknown touch action: {}", action);
+            return JNI_FALSE;
         }
-    }
+    };
 
-    JNI_TRUE
+    if handled {
+        JNI_TRUE
+    } else {
+        JNI_FALSE
+    }
 }
 
 /// Handle surface resize
@@ -321,14 +520,22 @@ pub extern "system" fn Java_com_blinc_BlincBridge_nativeResize(
         warn!("nativeResize called with null handle");
         return;
     }
+    let arc = match get_handle(handle) {
+        Some(arc) => arc,
+        None => {
+            warn!("nativeResize called with unknown or destroyed handle");
+            return;
+        }
+    };
+    let mut blinc = lock_or_recover(&arc, "android blinc handle");
 
-    let blinc = unsafe { &mut *(handle as *mut BlincHandle) };
+    if width <= 0 || height <= 0 {
+        warn!("Ignoring invalid resize to {}x{}", width, height);
+        return;
+    }
 
     info!("Surface resized to {}x{}", width, height);
-    blinc.width = width as u32;
-    blinc.height = height as u32;
-
-    // TODO: Reconfigure wgpu surface with new dimensions
+    blinc.runtime.resize(width as u32, height as u32);
 }
 
 /// Destroy the renderer and free resources
@@ -350,10 +557,12 @@ pub extern "system" fn Java_com_blinc_BlincBridge_nativeDestroy(
         return;
     }
 
-    info!("Destroying BlincHandle at {:p}", handle as *const ());
+    info!("Destroying BlincHandle id {}", handle);
 
-    // Reclaim the Box and drop it
-    let blinc = unsafe { Box::from_raw(handle as *mut BlincHandle) };
+    let Some(blinc) = destroy_handle(handle) else {
+        warn!("nativeDestroy called with unknown or already-destroyed handle");
+        return;
+    };
 
     // Release the native window reference
     if !blinc.native_window_ptr.is_null() {
@@ -361,7 +570,6 @@ pub extern "system" fn Java_com_blinc_BlincBridge_nativeDestroy(
     }
 
     // TODO: Clean up GPU resources
-    // The Box will be dropped here, cleaning up the handle
 
     info!("BlincHandle destroyed");
 }
@@ -411,4 +619,75 @@ fn get_native_window_from_surface(
 #[cfg(not(target_os = "android"))]
 pub fn jni_bridge_placeholder() {
     // Placeholder for non-Android builds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BlincRuntimeState, TouchPhase, MAX_QUEUED_TOUCH_EVENTS};
+
+    #[test]
+    fn runtime_starts_dirty_and_focused() {
+        let runtime = BlincRuntimeState::new(1080, 2400, 3.0);
+        assert!(runtime.focused);
+        assert!(runtime.redraw_requested);
+        assert!(runtime.surface_dirty);
+        assert_eq!(runtime.last_rendered_size, None);
+    }
+
+    #[test]
+    fn resize_marks_surface_dirty_and_requests_redraw() {
+        let mut runtime = BlincRuntimeState::new(100, 200, 2.0);
+        runtime.note_rendered();
+        runtime.resize(300, 400);
+
+        assert_eq!((runtime.width, runtime.height), (300, 400));
+        assert!(runtime.redraw_requested);
+        assert!(runtime.surface_dirty);
+    }
+
+    #[test]
+    fn touch_events_are_recorded_in_logical_coordinates() {
+        let mut runtime = BlincRuntimeState::new(1080, 1920, 2.0);
+
+        assert!(runtime.record_touch(TouchPhase::Down, 200.0, 300.0));
+        assert!(runtime.record_touch(TouchPhase::Move, 240.0, 320.0));
+        assert!(runtime.record_touch(TouchPhase::Up, 240.0, 320.0));
+
+        let events = runtime.take_touch_events();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].x, 100.0);
+        assert_eq!(events[0].y, 150.0);
+        assert_eq!(events[1].phase, TouchPhase::Move);
+        assert_eq!(events[2].phase, TouchPhase::Up);
+    }
+
+    #[test]
+    fn move_without_active_touch_is_ignored() {
+        let mut runtime = BlincRuntimeState::new(100, 100, 1.0);
+        assert!(!runtime.record_touch(TouchPhase::Move, 10.0, 20.0));
+        assert!(runtime.take_touch_events().is_empty());
+    }
+
+    #[test]
+    fn render_clears_dirty_flags_and_records_size() {
+        let mut runtime = BlincRuntimeState::new(640, 480, 1.0);
+        runtime.note_rendered();
+
+        assert!(!runtime.redraw_requested);
+        assert!(!runtime.surface_dirty);
+        assert_eq!(runtime.last_rendered_size, Some((640, 480)));
+    }
+
+    #[test]
+    fn touch_queue_is_bounded() {
+        let mut runtime = BlincRuntimeState::new(100, 100, 1.0);
+        assert!(runtime.record_touch(TouchPhase::Down, 0.0, 0.0));
+        for i in 0..(MAX_QUEUED_TOUCH_EVENTS + 8) {
+            assert!(runtime.record_touch(TouchPhase::Move, i as f32, i as f32));
+        }
+
+        let events = runtime.take_touch_events();
+        assert_eq!(events.len(), MAX_QUEUED_TOUCH_EVENTS);
+        assert_eq!(events.first().unwrap().phase, TouchPhase::Move);
+    }
 }

--- a/extensions/blinc_platform_ios/README.md
+++ b/extensions/blinc_platform_ios/README.md
@@ -5,11 +5,13 @@
 > This crate is a component of Blinc, a GPU-accelerated UI framework for Rust.
 > For full documentation and guides, visit the [Blinc documentation](https://project-blinc.github.io/Blinc).
 
-iOS platform implementation for Blinc UI.
+iOS platform scaffolding for Blinc UI.
 
 ## Overview
 
-`blinc_platform_ios` provides UIKit integration, Metal rendering, and touch input handling for iOS and iPadOS applications.
+`blinc_platform_ios` provides the current iOS runtime surface for Blinc:
+UIKit integration points, touch forwarding, native bridge helpers, and the
+render-loop scaffolding used by generated templates.
 
 ## Supported Platforms
 
@@ -18,28 +20,15 @@ iOS platform implementation for Blinc UI.
 
 ## Features
 
-- **UIKit Integration**: Native iOS view hierarchy
-- **Metal Rendering**: Hardware-accelerated graphics
-- **Touch Input**: Full multi-touch support
-- **iOS Lifecycle**: Proper app state handling
-- **Safe Area**: Automatic safe area inset handling
+- **UIKit Integration**: Template-friendly app shell
+- **Touch Input**: Touch forwarding into Blinc events
+- **Native Bridge**: Rust-to-Swift interoperability
+- **Template Support**: Bridge registration from generated projects
 
 ## Quick Start
 
-```rust
-use blinc_platform_ios::ios_main;
-
-#[no_mangle]
-pub extern "C" fn main() {
-    ios_main(|ctx| {
-        // Build your UI
-        div()
-            .w_full()
-            .h_full()
-            .child(text("Hello iOS!"))
-    });
-}
-```
+Use the generated iOS template and connect your Rust static library through the
+provided bridging header and `BlincNativeBridge`.
 
 ## Project Setup
 
@@ -94,43 +83,20 @@ fn handle_touch(event: TouchEvent) {
 }
 ```
 
-## Safe Area
+## Status
 
-```rust
-// Get safe area insets
-let insets = ctx.safe_area_insets();
+The iOS runtime is still under active development. Treat the crate as bridge and
+template scaffolding for shared UI work, and validate lifecycle, safe-area, and
+rendering behavior in your target app before treating it as production ready.
 
-// Build UI respecting safe area
-div()
-    .pt(insets.top)
-    .pb(insets.bottom)
-    .pl(insets.left)
-    .pr(insets.right)
-    .child(/* content */)
-```
+The current runtime surface now reflects UIKit when available for:
 
-## Lifecycle
+- dark-mode detection
+- safe-area inset queries
+- initial lifecycle/frame bridge events from the Rust-side event loop surface
 
-```rust
-ios_main(|ctx| {
-    // App became active
-    ctx.on_did_become_active(|| {
-        // Resume animations, etc.
-    });
-
-    // App will resign active
-    ctx.on_will_resign_active(|| {
-        // Pause animations, save state
-    });
-
-    // App entered background
-    ctx.on_did_enter_background(|| {
-        // Save data
-    });
-
-    build_ui()
-});
-```
+`IOSEventLoop` should still be treated as a UIKit-managed integration point, not
+as a desktop-style blocking owner loop.
 
 ## Building
 

--- a/extensions/blinc_platform_ios/src/app.rs
+++ b/extensions/blinc_platform_ios/src/app.rs
@@ -9,10 +9,74 @@ use blinc_platform::{Platform, PlatformError};
 #[cfg(target_os = "ios")]
 use objc2_foundation::MainThreadMarker;
 #[cfg(target_os = "ios")]
-use objc2_ui_kit::UIScreen;
+use objc2_ui_kit::{UIApplication, UIScreen, UIUserInterfaceStyle, UIWindow};
 
 #[cfg(target_os = "ios")]
 use tracing::info;
+
+fn resolve_dark_mode(value: Option<bool>) -> bool {
+    value.unwrap_or(false)
+}
+
+fn resolve_safe_area_insets(value: Option<(f32, f32, f32, f32)>) -> (f32, f32, f32, f32) {
+    value.unwrap_or((0.0, 0.0, 0.0, 0.0))
+}
+
+#[cfg(target_os = "ios")]
+#[allow(deprecated)]
+fn active_window() -> Option<objc2::rc::Retained<UIWindow>> {
+    let mtm = MainThreadMarker::new()?;
+    let application = UIApplication::sharedApplication(mtm);
+
+    application
+        .keyWindow()
+        .or_else(|| application.windows().firstObject())
+}
+
+#[cfg(target_os = "ios")]
+pub(crate) fn current_window() -> Option<IOSWindow> {
+    let window = active_window()?;
+    let scale_factor = window.screen().scale() as f64;
+    let bounds = window.bounds();
+    let width = (bounds.size.width * scale_factor).round() as u32;
+    let height = (bounds.size.height * scale_factor).round() as u32;
+    Some(IOSWindow::new(window, scale_factor, width, height))
+}
+
+#[cfg(target_os = "ios")]
+fn query_dark_mode() -> Option<bool> {
+    let window = active_window()?;
+    let scene = window.windowScene()?;
+    let traits = scene.traitCollection();
+    let style = unsafe { traits.userInterfaceStyle() };
+    Some(style == UIUserInterfaceStyle::Dark)
+}
+
+#[cfg(target_os = "ios")]
+fn query_safe_area_insets() -> Option<(f32, f32, f32, f32)> {
+    let window = active_window()?;
+
+    if let Some(controller) = window.rootViewController() {
+        controller.loadViewIfNeeded();
+        if let Some(view) = controller.view() {
+            let insets = view.safeAreaInsets();
+            return Some((
+                insets.top as f32,
+                insets.left as f32,
+                insets.bottom as f32,
+                insets.right as f32,
+            ));
+        }
+    }
+
+    let insets = window.safeAreaInsets();
+    Some((
+        insets.top as f32,
+        insets.left as f32,
+        insets.bottom as f32,
+        insets.right as f32,
+    ))
+}
 
 /// iOS platform implementation
 pub struct IOSPlatform {
@@ -26,6 +90,7 @@ pub struct IOSPlatform {
 #[cfg(target_os = "ios")]
 impl IOSPlatform {
     /// Get the main screen's scale factor
+    #[allow(deprecated)]
     fn get_screen_scale() -> f64 {
         // On iOS, UIScreen::mainScreen() requires MainThreadMarker
         // We assume this is called from the main thread
@@ -120,15 +185,13 @@ pub fn get_display_scale() -> f64 {
 /// Check if the system is in dark mode
 #[cfg(target_os = "ios")]
 pub fn is_dark_mode() -> bool {
-    // TODO: Implement proper dark mode detection using UITraitCollection
-    // For now, default to light mode
-    false
+    resolve_dark_mode(query_dark_mode())
 }
 
 /// Placeholder for non-iOS builds
 #[cfg(not(target_os = "ios"))]
 pub fn is_dark_mode() -> bool {
-    false
+    resolve_dark_mode(None)
 }
 
 /// Get the safe area insets for the main screen
@@ -136,16 +199,13 @@ pub fn is_dark_mode() -> bool {
 /// Returns (top, left, bottom, right) insets in logical points.
 #[cfg(target_os = "ios")]
 pub fn get_safe_area_insets() -> (f32, f32, f32, f32) {
-    // Get key window's safe area insets
-    // This accounts for notch, home indicator, etc.
-    // Note: In a real implementation, you'd get this from the UIWindow
-    (0.0, 0.0, 0.0, 0.0)
+    resolve_safe_area_insets(query_safe_area_insets())
 }
 
 /// Placeholder for non-iOS builds
 #[cfg(not(target_os = "ios"))]
 pub fn get_safe_area_insets() -> (f32, f32, f32, f32) {
-    (0.0, 0.0, 0.0, 0.0)
+    resolve_safe_area_insets(None)
 }
 
 /// iOS system font paths
@@ -175,4 +235,33 @@ pub fn system_font_paths() -> &'static [&'static str] {
         "/System/Library/Fonts/CoreAddition/Verdana.ttf",
         "/System/Library/Fonts/CoreAddition/TimesNewRomanPS.ttf",
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_dark_mode, resolve_safe_area_insets};
+
+    #[test]
+    fn dark_mode_defaults_to_light_when_unavailable() {
+        assert!(!resolve_dark_mode(None));
+    }
+
+    #[test]
+    fn dark_mode_preserves_detected_value() {
+        assert!(resolve_dark_mode(Some(true)));
+        assert!(!resolve_dark_mode(Some(false)));
+    }
+
+    #[test]
+    fn safe_area_defaults_to_zeroes_when_unavailable() {
+        assert_eq!(resolve_safe_area_insets(None), (0.0, 0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn safe_area_preserves_detected_insets() {
+        assert_eq!(
+            resolve_safe_area_insets(Some((10.0, 4.0, 34.0, 4.0))),
+            (10.0, 4.0, 34.0, 4.0)
+        );
+    }
 }

--- a/extensions/blinc_platform_ios/src/assets.rs
+++ b/extensions/blinc_platform_ios/src/assets.rs
@@ -30,7 +30,7 @@ impl IOSAssetLoader {
     /// Create a new iOS asset loader
     pub fn new() -> Self {
         // Get the main bundle's resource path
-        let resource_path = unsafe {
+        let resource_path = {
             let bundle = NSBundle::mainBundle();
             bundle
                 .resourcePath()

--- a/extensions/blinc_platform_ios/src/event_loop.rs
+++ b/extensions/blinc_platform_ios/src/event_loop.rs
@@ -6,13 +6,24 @@ use crate::window::IOSWindow;
 use blinc_platform::{ControlFlow, Event, EventLoop, PlatformError};
 
 #[cfg(target_os = "ios")]
+use crate::app::current_window;
+
+#[cfg(target_os = "ios")]
 use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(target_os = "ios")]
 use std::sync::Arc;
 
 #[cfg(target_os = "ios")]
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
+
+#[cfg(any(target_os = "ios", test))]
+fn managed_event_sequence() -> [Event; 2] {
+    [
+        Event::Lifecycle(blinc_platform::LifecycleEvent::Resumed),
+        Event::Frame,
+    ]
+}
 
 /// Wake proxy for iOS event loop
 ///
@@ -97,26 +108,20 @@ impl EventLoop for IOSEventLoop {
     where
         F: FnMut(Event, &Self::Window) -> ControlFlow + 'static,
     {
-        // Note: On iOS, the event loop is managed by UIApplicationMain and RunLoop
-        // This implementation is a placeholder that would need to integrate with
-        // the iOS application lifecycle.
-        //
-        // In practice, iOS apps use:
-        // - UIApplicationDelegate for lifecycle events
-        // - CADisplayLink for frame callbacks
-        // - UIGestureRecognizers for touch events
-        //
-        // The actual integration happens in the IOSApp::run() in blinc_app
+        info!("iOS event loop is UIKit-managed; dispatching initial bridge events");
 
-        info!("iOS event loop started - delegating to UIApplicationMain");
-
-        // On iOS, we don't run a blocking event loop here
-        // Instead, the run loop is managed by UIKit and we receive callbacks
-
-        Err(PlatformError::Unsupported(
-            "iOS event loop is managed by UIKit. Use IOSApp::run() from blinc_app instead."
-                .to_string(),
-        ))
+        // UIKit owns the run loop on iOS. From Rust we can only expose a small
+        // integration surface and hand off control back to the host app.
+        if let Some(window) = current_window() {
+            for event in managed_event_sequence() {
+                if matches!(handler(event, &window), ControlFlow::Exit) {
+                    break;
+                }
+            }
+        } else {
+            warn!("No active UIWindow available for initial iOS bridge events");
+        }
+        Ok(())
     }
 }
 
@@ -151,5 +156,21 @@ impl EventLoop for IOSEventLoop {
         Err(PlatformError::Unsupported(
             "iOS platform only available on iOS".to_string(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::managed_event_sequence;
+    use blinc_platform::{Event, LifecycleEvent};
+
+    #[test]
+    fn managed_event_sequence_starts_with_resume_then_frame() {
+        let events = managed_event_sequence();
+        assert!(matches!(
+            events[0],
+            Event::Lifecycle(LifecycleEvent::Resumed)
+        ));
+        assert!(matches!(events[1], Event::Frame));
     }
 }

--- a/extensions/blinc_platform_ios/src/lib.rs
+++ b/extensions/blinc_platform_ios/src/lib.rs
@@ -55,14 +55,12 @@ pub use window::IOSWindow;
 #[cfg(target_os = "ios")]
 pub use app::ios_main;
 
-use blinc_platform::PlatformError;
-
 // Convenience constructor for non-iOS builds
 #[cfg(not(target_os = "ios"))]
 impl IOSPlatform {
     /// Create a placeholder platform (for cross-compilation checks)
-    pub fn with_placeholder() -> Result<Self, PlatformError> {
-        Err(PlatformError::Unsupported(
+    pub fn with_placeholder() -> Result<Self, blinc_platform::PlatformError> {
+        Err(blinc_platform::PlatformError::Unsupported(
             "iOS platform only available on iOS".to_string(),
         ))
     }

--- a/mobile/example/platforms/ios/BlincApp/BlincViewController.swift
+++ b/mobile/example/platforms/ios/BlincApp/BlincViewController.swift
@@ -42,24 +42,49 @@ class BlincViewController: UIViewController {
     private var sensorDebugBodyLabel: UILabel?
     private var sensorDebugTimer: Timer?
     private var sensorPollBatch: UInt64 = 0
+    private var shouldShowSensorDebugOverlay: Bool {
+        ProcessInfo.processInfo.environment["BLINC_SENSOR_DEBUG_OVERLAY"] == "1"
+    }
+
+    private var chromeBackgroundColor: UIColor {
+        if traitCollection.userInterfaceStyle == .dark {
+            return UIColor(red: 0.08, green: 0.08, blue: 0.12, alpha: 1.0)
+        }
+        return UIColor(red: 0.95, green: 0.97, blue: 1.0, alpha: 1.0)
+    }
 
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        applyChromeBackground()
 
         // Create Metal view
         metalView = BlincMetalView(frame: view.bounds)
-        metalView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        metalView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(metalView)
+        NSLayoutConstraint.activate([
+            metalView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            metalView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            metalView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            metalView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+        ])
+        view.layoutIfNeeded()
 
         // Initialize Blinc context
         initializeBlinc()
 
         // Set up display link
         setupDisplayLink()
-        setupSensorDebugOverlay()
-        refreshSensorDebugOverlay()
+        if shouldShowSensorDebugOverlay {
+            setupSensorDebugOverlay()
+            refreshSensorDebugOverlay()
+        }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        applyChromeBackground()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -70,7 +95,9 @@ class BlincViewController: UIViewController {
         if let ctx = renderContext {
             blinc_set_focused(ctx, true)
         }
-        startSensorDebugTimer()
+        if shouldShowSensorDebugOverlay {
+            startSensorDebugTimer()
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -81,7 +108,9 @@ class BlincViewController: UIViewController {
         if let ctx = renderContext {
             blinc_set_focused(ctx, false)
         }
-        stopSensorDebugTimer()
+        if shouldShowSensorDebugOverlay {
+            stopSensorDebugTimer()
+        }
     }
 
     override func viewDidLayoutSubviews() {
@@ -89,8 +118,8 @@ class BlincViewController: UIViewController {
 
         // Update Blinc with new size
         let scale = UIScreen.main.scale
-        let width = UInt32(view.bounds.width * scale)
-        let height = UInt32(view.bounds.height * scale)
+        let width = UInt32(metalView.bounds.width * scale)
+        let height = UInt32(metalView.bounds.height * scale)
 
         if let ctx = renderContext {
             blinc_update_size(ctx, width, height, Double(scale))
@@ -105,7 +134,9 @@ class BlincViewController: UIViewController {
         // Stop display link
         displayLink?.invalidate()
         displayLink = nil
-        stopSensorDebugTimer()
+        if shouldShowSensorDebugOverlay {
+            stopSensorDebugTimer()
+        }
 
         // Clean up Blinc resources
         if let gpu = gpuRenderer {
@@ -120,8 +151,8 @@ class BlincViewController: UIViewController {
 
     private func initializeBlinc() {
         let scale = UIScreen.main.scale
-        let width = UInt32(view.bounds.width * scale)
-        let height = UInt32(view.bounds.height * scale)
+        let width = UInt32(metalView.bounds.width * scale)
+        let height = UInt32(metalView.bounds.height * scale)
 
         os_log(.info, log: log, "Starting initialization %dx%d @ %.1fx", width, height, scale)
 
@@ -155,6 +186,11 @@ class BlincViewController: UIViewController {
         loadBundledFonts(gpu: gpu)
 
         os_log(.info, log: log, "Blinc fully initialized: %dx%d @ %.1fx", width, height, scale)
+    }
+
+    private func applyChromeBackground() {
+        view.backgroundColor = chromeBackgroundColor
+        metalView?.backgroundColor = chromeBackgroundColor
     }
 
     /// Load bundled fonts from the app bundle
@@ -438,9 +474,10 @@ class BlincViewController: UIViewController {
 
         for touch in touches {
             let point = touch.location(in: view)
+            let metalPoint = touch.location(in: metalView)
             let touchId = getTouchId(for: touch)
             os_log(.info, log: log, "touchesBegan: calling blinc_handle_touch at (%.1f, %.1f)", point.x, point.y)
-            blinc_handle_touch(ctx, touchId, Float(point.x), Float(point.y), 0) // 0 = began
+            blinc_handle_touch(ctx, touchId, Float(metalPoint.x), Float(metalPoint.y), 0) // 0 = began
         }
     }
 
@@ -448,7 +485,7 @@ class BlincViewController: UIViewController {
         guard let ctx = renderContext else { return }
 
         for touch in touches {
-            let point = touch.location(in: view)
+            let point = touch.location(in: metalView)
             let touchId = getTouchId(for: touch)
             blinc_handle_touch(ctx, touchId, Float(point.x), Float(point.y), 1) // 1 = moved
         }
@@ -463,7 +500,7 @@ class BlincViewController: UIViewController {
         }
 
         for touch in touches {
-            let point = touch.location(in: view)
+            let point = touch.location(in: metalView)
             let touchId = getTouchId(for: touch)
             os_log(.info, log: log, "touchesEnded: calling blinc_handle_touch at (%.1f, %.1f)", point.x, point.y)
             blinc_handle_touch(ctx, touchId, Float(point.x), Float(point.y), 2) // 2 = ended
@@ -475,7 +512,7 @@ class BlincViewController: UIViewController {
         guard let ctx = renderContext else { return }
 
         for touch in touches {
-            let point = touch.location(in: view)
+            let point = touch.location(in: metalView)
             let touchId = getTouchId(for: touch)
             blinc_handle_touch(ctx, touchId, Float(point.x), Float(point.y), 3) // 3 = cancelled
             removeTouchId(for: touch)

--- a/mobile/example/src/main.rs
+++ b/mobile/example/src/main.rs
@@ -12,18 +12,121 @@ use blinc_core::{Brush, DrawContext, Gradient};
 use std::f32::consts::PI;
 use std::sync::Arc;
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct ExampleTheme {
+    pub(crate) page_bg: Color,
+    pub(crate) section_bg: Color,
+    pub(crate) card_bg: Color,
+    pub(crate) panel_bg: Color,
+    pub(crate) text_primary: Color,
+    pub(crate) text_secondary: Color,
+    pub(crate) text_muted: Color,
+    pub(crate) button_idle: Color,
+    pub(crate) button_hovered: Color,
+    pub(crate) button_pressed: Color,
+    pub(crate) button_disabled: Color,
+    pub(crate) accent: Color,
+    pub(crate) sensor_idle: Color,
+    pub(crate) sensor_hovered: Color,
+    pub(crate) sensor_pressed: Color,
+    pub(crate) sensor_active_idle: Color,
+    pub(crate) sensor_active_hovered: Color,
+    pub(crate) sensor_active_pressed: Color,
+}
+
+impl ExampleTheme {
+    pub(crate) fn for_appearance(is_dark: bool) -> Self {
+        if is_dark {
+            Self {
+                page_bg: Color::rgba(0.08, 0.08, 0.12, 1.0),
+                section_bg: Color::rgba(0.12, 0.12, 0.17, 1.0),
+                card_bg: Color::rgba(0.18, 0.18, 0.23, 1.0),
+                panel_bg: Color::rgba(0.22, 0.22, 0.28, 1.0),
+                text_primary: Color::WHITE,
+                text_secondary: Color::rgba(0.84, 0.88, 0.96, 1.0),
+                text_muted: Color::rgba(0.58, 0.60, 0.68, 1.0),
+                button_idle: Color::rgba(0.30, 0.30, 0.40, 1.0),
+                button_hovered: Color::rgba(0.38, 0.38, 0.50, 1.0),
+                button_pressed: Color::rgba(0.22, 0.22, 0.30, 1.0),
+                button_disabled: Color::rgba(0.20, 0.20, 0.20, 0.5),
+                accent: Color::rgba(0.40, 0.80, 1.0, 1.0),
+                sensor_idle: Color::rgba(0.30, 0.30, 0.40, 1.0),
+                sensor_hovered: Color::rgba(0.40, 0.40, 0.50, 1.0),
+                sensor_pressed: Color::rgba(0.20, 0.20, 0.30, 1.0),
+                sensor_active_idle: Color::rgba(0.18, 0.38, 0.26, 1.0),
+                sensor_active_hovered: Color::rgba(0.22, 0.46, 0.31, 1.0),
+                sensor_active_pressed: Color::rgba(0.12, 0.28, 0.19, 1.0),
+            }
+        } else {
+            Self {
+                page_bg: Color::rgba(0.95, 0.97, 1.0, 1.0),
+                section_bg: Color::rgba(1.0, 1.0, 1.0, 1.0),
+                card_bg: Color::rgba(0.92, 0.95, 1.0, 1.0),
+                panel_bg: Color::rgba(0.96, 0.97, 1.0, 1.0),
+                text_primary: Color::rgba(0.12, 0.16, 0.25, 1.0),
+                text_secondary: Color::rgba(0.24, 0.30, 0.40, 1.0),
+                text_muted: Color::rgba(0.42, 0.48, 0.58, 1.0),
+                button_idle: Color::rgba(0.78, 0.84, 0.94, 1.0),
+                button_hovered: Color::rgba(0.70, 0.78, 0.90, 1.0),
+                button_pressed: Color::rgba(0.62, 0.70, 0.84, 1.0),
+                button_disabled: Color::rgba(0.80, 0.82, 0.86, 0.7),
+                accent: Color::rgba(0.18, 0.50, 0.88, 1.0),
+                sensor_idle: Color::rgba(0.78, 0.84, 0.94, 1.0),
+                sensor_hovered: Color::rgba(0.70, 0.78, 0.90, 1.0),
+                sensor_pressed: Color::rgba(0.62, 0.70, 0.84, 1.0),
+                sensor_active_idle: Color::rgba(0.52, 0.78, 0.62, 1.0),
+                sensor_active_hovered: Color::rgba(0.46, 0.72, 0.57, 1.0),
+                sensor_active_pressed: Color::rgba(0.38, 0.64, 0.50, 1.0),
+            }
+        }
+    }
+}
+
+pub(crate) fn content_padding_for_safe_area(_insets: (f32, f32, f32, f32)) -> (f32, f32) {
+    (16.0, 20.0)
+}
+
+fn current_theme() -> ExampleTheme {
+    ExampleTheme::for_appearance(current_is_dark_mode())
+}
+
+#[cfg(target_os = "ios")]
+fn current_is_dark_mode() -> bool {
+    blinc_platform_ios::is_dark_mode()
+}
+
+#[cfg(not(target_os = "ios"))]
+fn current_is_dark_mode() -> bool {
+    true
+}
+
+#[cfg(target_os = "ios")]
+fn current_safe_area_insets() -> (f32, f32, f32, f32) {
+    blinc_platform_ios::get_safe_area_insets()
+}
+
+#[cfg(not(target_os = "ios"))]
+fn current_safe_area_insets() -> (f32, f32, f32, f32) {
+    (0.0, 0.0, 0.0, 0.0)
+}
+
 /// Counter button with stateful hover/press states
-fn counter_button(label: &str, count: State<i32>, delta: i32) -> impl ElementBuilder {
+fn counter_button(
+    label: &str,
+    count: State<i32>,
+    delta: i32,
+    theme: ExampleTheme,
+) -> impl ElementBuilder {
     let label = label.to_string();
 
     let count = count.clone();
     stateful::<ButtonState>()
         .on_state(move |ctx| {
             let bg = match ctx.state() {
-                ButtonState::Idle => Color::rgba(0.3, 0.3, 0.4, 1.0),
-                ButtonState::Hovered => Color::rgba(0.4, 0.4, 0.5, 1.0),
-                ButtonState::Pressed => Color::rgba(0.2, 0.2, 0.3, 1.0),
-                ButtonState::Disabled => Color::rgba(0.2, 0.2, 0.2, 0.5),
+                ButtonState::Idle => theme.button_idle,
+                ButtonState::Hovered => theme.button_hovered,
+                ButtonState::Pressed => theme.button_pressed,
+                ButtonState::Disabled => theme.button_disabled,
             };
 
             div()
@@ -34,7 +137,7 @@ fn counter_button(label: &str, count: State<i32>, delta: i32) -> impl ElementBui
                 .items_center()
                 .justify_center()
                 .cursor(CursorStyle::Pointer)
-                .child(text(&label).size(24.0).color(Color::WHITE))
+                .child(text(&label).size(24.0).color(theme.text_primary))
         })
         .on_click(move |_| {
             count.set(count.get() + delta);
@@ -42,36 +145,36 @@ fn counter_button(label: &str, count: State<i32>, delta: i32) -> impl ElementBui
 }
 
 /// Counter display that reacts to count changes
-fn counter_display(count: State<i32>) -> impl ElementBuilder {
+fn counter_display(count: State<i32>, theme: ExampleTheme) -> impl ElementBuilder {
     stateful::<NoState>()
         .deps([count.signal_id()])
         .on_state(move |_ctx| {
             div().child(
                 text(format!("Count: {}", count.get()))
                     .size(48.0)
-                    .color(Color::rgba(0.4, 0.8, 1.0, 1.0))
+                    .color(theme.accent)
                     .align(TextAlign::Center),
             )
         })
 }
 
 /// Counter demo section
-fn counter_section(ctx: &WindowedContext) -> Div {
+fn counter_section(ctx: &WindowedContext, theme: ExampleTheme) -> Div {
     let count = ctx.use_state_keyed("count", || 0i32);
 
-    section_card("Counter Demo")
-        .child(counter_display(count.clone()))
+    section_card("Counter Demo", theme)
+        .child(counter_display(count.clone(), theme))
         .child(
             div()
                 .flex_row()
                 .gap(16.0)
-                .child(counter_button("-", count.clone(), -1))
-                .child(counter_button("+", count.clone(), 1)),
+                .child(counter_button("-", count.clone(), -1, theme))
+                .child(counter_button("+", count.clone(), 1, theme)),
         )
 }
 
 /// Demo 1: Spinning loader using rotation keyframes
-fn spinning_loader_demo(ctx: &WindowedContext) -> Div {
+fn spinning_loader_demo(ctx: &WindowedContext, theme: ExampleTheme) -> Div {
     let timeline = ctx.use_animated_timeline();
 
     let entry_id = timeline.lock().unwrap().configure(|t| {
@@ -83,7 +186,7 @@ fn spinning_loader_demo(ctx: &WindowedContext) -> Div {
 
     let render_timeline = Arc::clone(&timeline);
 
-    demo_card("Spinning Loader").child(
+    demo_card("Spinning Loader", theme).child(
         canvas(move |ctx: &mut dyn DrawContext, bounds| {
             let timeline = render_timeline.lock().unwrap();
             let angle_deg = timeline.get(entry_id).unwrap_or(0.0);
@@ -133,7 +236,7 @@ fn spinning_loader_demo(ctx: &WindowedContext) -> Div {
 }
 
 /// Demo 2: Pulsing dots with staggered keyframes
-fn pulsing_dots_demo(ctx: &WindowedContext) -> Div {
+fn pulsing_dots_demo(ctx: &WindowedContext, theme: ExampleTheme) -> Div {
     let timelines: Vec<SharedAnimatedTimeline> = (0..3)
         .map(|i| ctx.use_animated_timeline_for(format!("pulsing_dot_{}", i)))
         .collect();
@@ -158,7 +261,7 @@ fn pulsing_dots_demo(ctx: &WindowedContext) -> Div {
 
     let timelines_clone: Vec<_> = timelines.iter().map(Arc::clone).collect();
 
-    demo_card("Pulsing Dots").child(
+    demo_card("Pulsing Dots", theme).child(
         canvas(move |ctx: &mut dyn DrawContext, bounds| {
             let cx = bounds.width / 2.0;
             let cy = bounds.height / 2.0;
@@ -188,7 +291,7 @@ fn pulsing_dots_demo(ctx: &WindowedContext) -> Div {
 }
 
 /// Demo 3: Progress bar with eased fill animation
-fn progress_bar_demo(ctx: &WindowedContext) -> Div {
+fn progress_bar_demo(ctx: &WindowedContext, theme: ExampleTheme) -> Div {
     let timeline = ctx.use_animated_timeline();
 
     let entry_id = timeline.lock().unwrap().configure(|t| {
@@ -204,7 +307,7 @@ fn progress_bar_demo(ctx: &WindowedContext) -> Div {
         ready_timeline.lock().unwrap().start();
     });
 
-    demo_card("Progress Bar")
+    demo_card("Progress Bar", theme)
         .id("progress-bar-demo")
         .child(
             canvas(move |ctx: &mut dyn DrawContext, bounds| {
@@ -220,7 +323,7 @@ fn progress_bar_demo(ctx: &WindowedContext) -> Div {
                 ctx.fill_rect(
                     Rect::new(bar_x, bar_y, bar_width, bar_height),
                     blinc_core::CornerRadius::uniform(6.0),
-                    Brush::Solid(Color::rgba(0.2, 0.2, 0.25, 1.0)),
+                    Brush::Solid(theme.panel_bg),
                 );
 
                 // Filled portion
@@ -244,7 +347,7 @@ fn progress_bar_demo(ctx: &WindowedContext) -> Div {
         .child(
             text("Tap to restart")
                 .size(12.0)
-                .color(Color::rgba(0.5, 0.5, 0.5, 1.0)),
+                .color(theme.text_muted),
         )
         .on_click(move |_| {
             click_timeline.lock().unwrap().restart();
@@ -252,7 +355,7 @@ fn progress_bar_demo(ctx: &WindowedContext) -> Div {
 }
 
 /// Demo 4: Bouncing ball with squash and stretch
-fn bouncing_ball_demo(ctx: &WindowedContext) -> Div {
+fn bouncing_ball_demo(ctx: &WindowedContext, theme: ExampleTheme) -> Div {
     let timeline = ctx.use_animated_timeline();
 
     let entry_id = timeline.lock().unwrap().configure(|t| {
@@ -264,7 +367,7 @@ fn bouncing_ball_demo(ctx: &WindowedContext) -> Div {
 
     let render_timeline = Arc::clone(&timeline);
 
-    demo_card("Bouncing Ball").child(
+    demo_card("Bouncing Ball", theme).child(
         canvas(move |ctx: &mut dyn DrawContext, bounds| {
             let timeline = render_timeline.lock().unwrap();
             let t = timeline.get(entry_id).unwrap_or(0.0);
@@ -331,12 +434,12 @@ fn bouncing_ball_demo(ctx: &WindowedContext) -> Div {
 }
 
 /// Animation demos section
-fn animation_section(ctx: &WindowedContext) -> Div {
-    section_card("Keyframe Animations")
+fn animation_section(ctx: &WindowedContext, theme: ExampleTheme) -> Div {
+    section_card("Keyframe Animations", theme)
         .child(
             text("Canvas elements with multi-property keyframe animations")
                 .size(16.0)
-                .color(Color::rgba(0.6, 0.6, 0.7, 1.0))
+                .color(theme.text_muted)
                 .align(TextAlign::Center),
         )
         .child(
@@ -345,8 +448,8 @@ fn animation_section(ctx: &WindowedContext) -> Div {
                 .gap(10.0)
                 .flex_wrap()
                 .justify_center()
-                .child(spinning_loader_demo(ctx))
-                .child(pulsing_dots_demo(ctx)),
+                .child(spinning_loader_demo(ctx, theme))
+                .child(pulsing_dots_demo(ctx, theme)),
         )
         .child(
             div()
@@ -354,20 +457,20 @@ fn animation_section(ctx: &WindowedContext) -> Div {
                 .gap(10.0)
                 .flex_wrap()
                 .justify_center()
-                .child(progress_bar_demo(ctx))
-                .child(bouncing_ball_demo(ctx)),
+                .child(progress_bar_demo(ctx, theme))
+                .child(bouncing_ball_demo(ctx, theme)),
         )
 }
 
 /// Helper to create a section card
-fn section_card(title: &str) -> Div {
+fn section_card(title: &str, theme: ExampleTheme) -> Div {
     div()
         .w_full()
         .flex_col()
         .gap(6.0)
         .py(5.0)
         .px(8.0)
-        .bg(Color::rgba(0.12, 0.12, 0.17, 1.0))
+        .bg(theme.section_bg)
         .rounded(16.0)
         .items_center()
         .child(
@@ -376,67 +479,73 @@ fn section_card(title: &str) -> Div {
                     .size(24.0)
                     .align(TextAlign::Center)
                     .weight(FontWeight::Bold)
-                    .color(Color::WHITE)
+                    .color(theme.text_primary)
                     .no_wrap(),
             ),
         )
 }
 
 /// Helper to create a demo card
-fn demo_card(title: &str) -> Div {
+fn demo_card(title: &str, theme: ExampleTheme) -> Div {
     div()
         .w(170.0)
         .flex_col()
         .gap(5.0)
         .py(8.0)
         .px(4.0)
-        .bg(Color::rgba(0.18, 0.18, 0.23, 1.0))
+        .bg(theme.card_bg)
         .rounded(12.0)
         .items_center()
         .child(
             text(title)
                 .size(14.0)
                 .weight(FontWeight::SemiBold)
-                .color(Color::WHITE),
+                .color(theme.text_primary),
         )
 }
 
 /// Main application UI with scroll container
 fn app_ui(ctx: &mut WindowedContext) -> impl ElementBuilder {
+    let theme = current_theme();
+    let insets = current_safe_area_insets();
+    let (top_padding, bottom_padding) = content_padding_for_safe_area(insets);
+
     div()
+        .id("example.root")
         .w(ctx.width)
         .h(ctx.height)
-        .bg(Color::rgba(0.08, 0.08, 0.12, 1.0))
+        .bg(theme.page_bg)
         .child(
-            scroll().w(ctx.width).h(ctx.height).child(
+            scroll().id("example.scroll").w(ctx.width).h(ctx.height).child(
                 div()
+                    .id("example.content")
                     .w_full()
                     .flex_col()
                     .items_center()
                     .gap(4.0)
                     .px(8.0)
-                    .py(15.0)
+                    .pt(top_padding)
+                    .pb(bottom_padding)
                     // Header
                     .child(
                         text("Blinc Mobile Example")
+                            .id("example.header.title")
                             .align(TextAlign::Center)
                             .size(28.0)
                             .weight(FontWeight::Bold)
-                            .color(Color::WHITE),
+                            .color(theme.text_primary),
                     )
                     .child(
                         text("Scroll down for more demos")
                             .size(14.0)
-                            .color(Color::rgba(0.5, 0.5, 0.6, 1.0)),
+                            .color(theme.text_muted),
                     )
                     // Counter section
-                    .child(counter_section(ctx))
+                    .child(counter_section(ctx, theme))
                     // Sensor section
-                    .child(sensor_inspector::sensor_section(ctx, section_card))
+                    .child(sensor_inspector::sensor_section(ctx, section_card, theme))
                     // Animation section
-                    .child(animation_section(ctx))
-                    // Footer spacer
-                    .child(div().h(20.0)),
+                    .child(animation_section(ctx, theme)),
             ),
         )
 }
@@ -502,7 +611,6 @@ fn main() {}
 #[cfg(target_os = "ios")]
 #[no_mangle]
 pub extern "C" fn ios_app_init() {
-    use std::io::Write;
     let _ = tracing_subscriber::fmt()
         .with_max_level(tracing::Level::DEBUG)
         .with_writer(std::io::stderr)
@@ -539,4 +647,80 @@ pub extern "C" fn napi_register_module() {
 
     // TODO: Register N-API functions for XComponent callbacks
     // blinc_platform_harmony::napi_bridge::register_module()
+}
+
+#[cfg(test)]
+mod tests {
+    use blinc_app::RenderTree;
+    use blinc_app::windowed::WindowedContext;
+    use super::{content_padding_for_safe_area, ExampleTheme};
+
+    #[test]
+    fn light_and_dark_theme_palettes_are_distinct() {
+        let dark = ExampleTheme::for_appearance(true);
+        let light = ExampleTheme::for_appearance(false);
+
+        assert_ne!(dark.page_bg, light.page_bg);
+        assert_ne!(dark.card_bg, light.card_bg);
+        assert_ne!(dark.text_primary, light.text_primary);
+    }
+
+    #[test]
+    fn content_padding_uses_tighter_top_spacing_than_before() {
+        let (top, bottom) = content_padding_for_safe_area((24.0, 0.0, 34.0, 0.0));
+
+        assert_eq!(top, 16.0, "expected default top spacing to stay stable");
+        assert_eq!(bottom, 20.0, "expected default bottom spacing to stay stable");
+    }
+
+    #[test]
+    fn content_padding_keeps_legacy_top_spacing_without_safe_area() {
+        let (top, bottom) = content_padding_for_safe_area((0.0, 0.0, 0.0, 0.0));
+
+        assert_eq!(top, 16.0, "expected zero-inset layouts to keep the old top spacing");
+        assert_eq!(bottom, 20.0, "expected zero-inset layouts to keep the old bottom spacing");
+    }
+
+    #[test]
+    fn header_title_stays_near_top_in_headless_layout() {
+        let mut ctx = WindowedContext::new_headless(393.0, 852.0);
+        let ui = super::app_ui(&mut ctx);
+        let mut tree = RenderTree::from_element_with_registry(&ui, ctx.element_registry().clone());
+        tree.compute_layout(ctx.width, ctx.height);
+
+        let title = tree
+            .query_by_id("example.header.title")
+            .expect("header title should exist");
+        let bounds = tree
+            .get_bounds(title)
+            .expect("header title should have layout bounds");
+
+        assert!(
+            bounds.y < 120.0,
+            "header title should start near the top, got y={}",
+            bounds.y
+        );
+    }
+
+    #[test]
+    fn scroll_content_fills_at_least_the_viewport_height() {
+        let mut ctx = WindowedContext::new_headless(393.0, 852.0);
+        let ui = super::app_ui(&mut ctx);
+        let mut tree = RenderTree::from_element_with_registry(&ui, ctx.element_registry().clone());
+        tree.compute_layout(ctx.width, ctx.height);
+
+        let content = tree
+            .query_by_id("example.content")
+            .expect("content root should exist");
+        let bounds = tree
+            .get_bounds(content)
+            .expect("content root should have layout bounds");
+
+        assert!(
+            bounds.height >= ctx.height,
+            "expected content to fill the viewport height, got height={} viewport={}",
+            bounds.height,
+            ctx.height
+        );
+    }
 }

--- a/mobile/example/src/sensor_inspector.rs
+++ b/mobile/example/src/sensor_inspector.rs
@@ -4,6 +4,7 @@ use blinc_core::native_bridge::native_call;
 use blinc_core::reactive::State;
 use blinc_platform::sensors::native_bridge::NativeBridgeBackend;
 use blinc_platform::sensors::{SensorClient, SensorConfig, SensorFrame, SensorKind};
+use crate::ExampleTheme;
 use std::collections::BTreeMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -267,6 +268,7 @@ fn sensor_toggle_button(
     snapshot: State<SensorPanelData>,
     live_enabled: State<bool>,
     pending_start: State<bool>,
+    theme: ExampleTheme,
 ) -> impl ElementBuilder {
     let client = sensor_client();
     let live_state = live_enabled.clone();
@@ -276,13 +278,13 @@ fn sensor_toggle_button(
         .on_state(move |ctx| {
             let is_live = live_state.get();
             let bg = match (ctx.state(), is_live) {
-                (ButtonState::Idle, false) => Color::rgba(0.3, 0.3, 0.4, 1.0),
-                (ButtonState::Hovered, false) => Color::rgba(0.4, 0.4, 0.5, 1.0),
-                (ButtonState::Pressed, false) => Color::rgba(0.2, 0.2, 0.3, 1.0),
-                (ButtonState::Idle, true) => Color::rgba(0.18, 0.38, 0.26, 1.0),
-                (ButtonState::Hovered, true) => Color::rgba(0.22, 0.46, 0.31, 1.0),
-                (ButtonState::Pressed, true) => Color::rgba(0.12, 0.28, 0.19, 1.0),
-                (ButtonState::Disabled, _) => Color::rgba(0.2, 0.2, 0.2, 0.5),
+                (ButtonState::Idle, false) => theme.sensor_idle,
+                (ButtonState::Hovered, false) => theme.sensor_hovered,
+                (ButtonState::Pressed, false) => theme.sensor_pressed,
+                (ButtonState::Idle, true) => theme.sensor_active_idle,
+                (ButtonState::Hovered, true) => theme.sensor_active_hovered,
+                (ButtonState::Pressed, true) => theme.sensor_active_pressed,
+                (ButtonState::Disabled, _) => theme.button_disabled,
             };
 
             div()
@@ -297,7 +299,7 @@ fn sensor_toggle_button(
                     text(if is_live { "Sensors ON" } else { "Sensors OFF" })
                         .size(16.0)
                         .weight(FontWeight::SemiBold)
-                        .color(Color::WHITE),
+                        .color(theme.text_primary),
                 )
         })
         .on_click(move |_| {
@@ -361,7 +363,11 @@ fn sensor_toggle_button(
         })
 }
 
-pub fn sensor_section(ctx: &WindowedContext, section_card: fn(&str) -> Div) -> Div {
+pub fn sensor_section(
+    ctx: &WindowedContext,
+    section_card: fn(&str, ExampleTheme) -> Div,
+    theme: ExampleTheme,
+) -> Div {
     let snapshot = ctx.use_state_keyed("sensor_snapshot", SensorPanelData::default);
     let live_enabled = ctx.use_state_keyed("sensor_live_enabled", || false);
     let pending_start = ctx.use_state_keyed("sensor_pending_start", || false);
@@ -433,18 +439,19 @@ pub fn sensor_section(ctx: &WindowedContext, section_card: fn(&str) -> Div) -> D
 
     let detail_snapshot = snapshot.clone();
 
-    section_card("Sensor Inspector")
+    section_card("Sensor Inspector", theme)
         .id("sensor-section")
         .child(
             text("Turn ON to stream continuously. OFF freezes the last snapshot.")
                 .size(14.0)
-                .color(Color::rgba(0.6, 0.6, 0.7, 1.0))
+                .color(theme.text_muted)
                 .align(TextAlign::Center),
         )
         .child(sensor_toggle_button(
             snapshot.clone(),
             live_enabled.clone(),
             pending_start.clone(),
+            theme,
         ))
         .child(
             div()
@@ -453,14 +460,14 @@ pub fn sensor_section(ctx: &WindowedContext, section_card: fn(&str) -> Div) -> D
                 .gap(4.0)
                 .py(8.0)
                 .px(10.0)
-                .bg(Color::rgba(0.18, 0.18, 0.23, 1.0))
+                .bg(theme.panel_bg)
                 .rounded(12.0)
                 .items_start()
                 .child(
                     text("Live Sensor Snapshot")
                         .size(14.0)
                         .weight(FontWeight::SemiBold)
-                        .color(Color::WHITE),
+                        .color(theme.text_primary),
                 )
                 .child(
                     stateful::<NoState>()
@@ -475,62 +482,62 @@ pub fn sensor_section(ctx: &WindowedContext, section_card: fn(&str) -> Div) -> D
                                 .child(
                                     text(data.status_line.clone())
                                         .size(12.0)
-                                        .color(Color::rgba(0.85, 0.9, 1.0, 1.0)),
+                                        .color(theme.text_secondary),
                                 )
                                 .child(
                                     text(data.permission_line.clone())
                                         .size(11.0)
-                                        .color(Color::rgba(0.75, 0.82, 0.9, 1.0)),
+                                        .color(theme.text_secondary),
                                 )
                                 .child(
                                     text(data.supported_line.clone())
                                         .size(11.0)
-                                        .color(Color::rgba(0.75, 0.82, 0.9, 1.0)),
+                                        .color(theme.text_secondary),
                                 )
                                 .child(
                                     text(data.kinds_line.clone())
                                         .size(11.0)
-                                        .color(Color::rgba(0.75, 0.82, 0.9, 1.0)),
+                                        .color(theme.text_secondary),
                                 )
                                 .child(
                                     text(data.sample_line.clone())
                                         .size(11.0)
-                                        .color(Color::rgba(0.75, 0.82, 0.9, 1.0)),
+                                        .color(theme.text_secondary),
                                 )
                                 .child(
                                     text(data.accel_line.clone())
                                         .size(10.5)
-                                        .color(Color::rgba(0.70, 0.80, 0.88, 1.0)),
+                                        .color(theme.text_muted),
                                 )
                                 .child(
                                     text(data.gyro_line.clone())
                                         .size(10.5)
-                                        .color(Color::rgba(0.70, 0.80, 0.88, 1.0)),
+                                        .color(theme.text_muted),
                                 )
                                 .child(
                                     text(data.magnet_line.clone())
                                         .size(10.5)
-                                        .color(Color::rgba(0.70, 0.80, 0.88, 1.0)),
+                                        .color(theme.text_muted),
                                 )
                                 .child(
                                     text(data.barometer_line.clone())
                                         .size(10.5)
-                                        .color(Color::rgba(0.70, 0.80, 0.88, 1.0)),
+                                        .color(theme.text_muted),
                                 )
                                 .child(
                                     text(data.step_line.clone())
                                         .size(10.5)
-                                        .color(Color::rgba(0.70, 0.80, 0.88, 1.0)),
+                                        .color(theme.text_muted),
                                 )
                                 .child(
                                     text(data.activity_line.clone())
                                         .size(10.5)
-                                        .color(Color::rgba(0.70, 0.80, 0.88, 1.0)),
+                                        .color(theme.text_muted),
                                 )
                                 .child(
                                     text(data.note_line.clone())
                                         .size(11.0)
-                                        .color(Color::rgba(0.5, 0.8, 0.6, 1.0)),
+                                        .color(theme.accent),
                                 )
                         }),
                 ),

--- a/toolchain/templates/rust/platforms/android/README.md
+++ b/toolchain/templates/rust/platforms/android/README.md
@@ -65,7 +65,9 @@ platforms/android/
 
 ## Native Bridge
 
-The `BlincNativeBridge` allows Rust to call Kotlin functions:
+The generated template includes `BlincNativeBridge.kt` and wires it from
+`MainActivity` so common platform helpers are available immediately. Rust can
+call Kotlin handlers through that bridge:
 
 ```rust
 // In Rust
@@ -73,7 +75,7 @@ let battery: String = native_call("device", "get_battery_level", ()).unwrap();
 ```
 
 ```kotlin
-// In Kotlin (already registered by default)
+// In Kotlin (already registered by MainActivity)
 BlincNativeBridge.registerString("device", "get_battery_level") {
     // Return battery percentage as string
 }

--- a/toolchain/templates/rust/platforms/android/app/src/main/kotlin/com/blinc/BlincNativeBridge.kt
+++ b/toolchain/templates/rust/platforms/android/app/src/main/kotlin/com/blinc/BlincNativeBridge.kt
@@ -1,0 +1,1572 @@
+/**
+ * Blinc Native Bridge for Android
+ *
+ * Kotlin implementation for handling native calls from Rust.
+ * Register handlers for each namespace/function, then Rust can call
+ * them via native_call("namespace", "function", args).
+ *
+ * Usage:
+ * ```kotlin
+ * // In Application.onCreate()
+ * BlincNativeBridge.registerDefaults(context)
+ *
+ * // Or register custom handlers
+ * BlincNativeBridge.register("myapi", "my_function") { args ->
+ *     // args is JSONArray
+ *     "result"
+ * }
+ * ```
+ */
+
+package com.blinc.{{project_name_snake}}
+
+import android.app.Activity
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.net.Uri
+import android.os.BatteryManager
+import android.os.Build
+import android.os.Looper
+import android.os.ParcelUuid
+import android.os.SystemClock
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import android.util.Log
+import androidx.core.content.getSystemService
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.ArrayDeque
+import java.util.Locale
+import java.util.TimeZone
+import java.lang.ref.WeakReference
+
+object BlincNativeBridge {
+
+    // Handler type: (args: JSONArray) -> Any?
+    private val handlers = mutableMapOf<String, MutableMap<String, (JSONArray) -> Any?>>()
+
+    // Application context for system services
+    private var appContext: Context? = null
+    private var foregroundActivityRef: WeakReference<Activity>? = null
+    private val sensorCollector = AndroidSensorCollector()
+    private val bleCollector = AndroidBleCollector(sensorCollector)
+
+    /**
+     * Initialize with application context
+     */
+    fun init(context: Context) {
+        appContext = context.applicationContext
+        sensorCollector.attach(context.applicationContext)
+        bleCollector.attach(context.applicationContext)
+        sensorCollector.setForegroundActivity(foregroundActivityRef?.get())
+        bleCollector.setForegroundActivity(foregroundActivityRef?.get())
+    }
+
+    /**
+     * Set the currently visible Activity for runtime permission requests.
+     */
+    fun setForegroundActivity(activity: Activity?) {
+        foregroundActivityRef = if (activity == null) null else WeakReference(activity)
+        sensorCollector.setForegroundActivity(activity)
+        bleCollector.setForegroundActivity(activity)
+    }
+
+    /**
+     * Register a native function handler
+     *
+     * @param namespace The namespace (e.g., "device", "haptics")
+     * @param name The function name
+     * @param handler Handler that receives JSON args and returns a result
+     */
+    fun register(namespace: String, name: String, handler: (JSONArray) -> Any?) {
+        handlers.getOrPut(namespace) { mutableMapOf() }[name] = handler
+    }
+
+    /**
+     * Convenience: Register a no-arg function returning String
+     */
+    fun registerString(namespace: String, name: String, handler: () -> String) {
+        register(namespace, name) { handler() }
+    }
+
+    /**
+     * Convenience: Register a no-arg void function
+     */
+    fun registerVoid(namespace: String, name: String, handler: () -> Unit) {
+        register(namespace, name) { handler(); null }
+    }
+
+    /**
+     * Called from JNI to execute a registered function
+     *
+     * @param namespace The namespace
+     * @param name The function name
+     * @param argsJson JSON-encoded arguments array
+     * @return JSON-encoded result or error
+     */
+    @JvmStatic
+    fun callNative(namespace: String, name: String, argsJson: String): String {
+        return try {
+            val nsHandlers = handlers[namespace]
+                ?: return errorJson("NotRegistered", "Namespace '$namespace' not found")
+
+            val handler = nsHandlers[name]
+                ?: return errorJson("NotRegistered", "Function '$namespace.$name' not found")
+
+            val args = JSONArray(argsJson)
+            val result = handler(args)
+
+            successJson(result)
+        } catch (e: Exception) {
+            errorJson("PlatformError", e.message ?: "Unknown error")
+        }
+    }
+
+    /**
+     * Register default handlers for common functionality
+     */
+    fun registerDefaults(context: Context) {
+        init(context)
+        val ctx = context.applicationContext
+
+        // =====================================================================
+        // Device namespace
+        // =====================================================================
+
+        registerString("device", "get_battery_level") {
+            val bm = ctx.getSystemService<BatteryManager>()
+            bm?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)?.toString() ?: "0"
+        }
+
+        registerString("device", "get_model") {
+            Build.MODEL
+        }
+
+        registerString("device", "get_os_version") {
+            Build.VERSION.RELEASE
+        }
+
+        register("device", "is_low_power_mode") {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                val pm = ctx.getSystemService(Context.POWER_SERVICE) as? android.os.PowerManager
+                pm?.isPowerSaveMode ?: false
+            } else {
+                false
+            }
+        }
+
+        register("device", "has_notch") {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                // Check for display cutout
+                // This requires a window, return false as default
+                false
+            } else {
+                false
+            }
+        }
+
+        registerString("device", "get_locale") {
+            Locale.getDefault().toString()
+        }
+
+        registerString("device", "get_timezone") {
+            TimeZone.getDefault().id
+        }
+
+        // =====================================================================
+        // Haptics namespace
+        // =====================================================================
+
+        register("haptics", "vibrate") { args ->
+            val durationMs = args.optLong(0, 100)
+            vibrate(ctx, durationMs)
+            null
+        }
+
+        register("haptics", "impact") { args ->
+            val style = args.optInt(0, 1)
+            val amplitude = when (style) {
+                0 -> 50   // light
+                2 -> 255  // heavy
+                else -> 128 // medium
+            }
+            vibrateWithAmplitude(ctx, 10, amplitude)
+            null
+        }
+
+        registerVoid("haptics", "selection") {
+            vibrateWithAmplitude(ctx, 5, 50)
+        }
+
+        registerVoid("haptics", "success") {
+            vibrateWithAmplitude(ctx, 30, 200)
+        }
+
+        registerVoid("haptics", "warning") {
+            vibrateWithAmplitude(ctx, 50, 150)
+        }
+
+        registerVoid("haptics", "error") {
+            vibrateWithAmplitude(ctx, 100, 255)
+        }
+
+        // =====================================================================
+        // Clipboard namespace
+        // =====================================================================
+
+        register("clipboard", "copy") { args ->
+            val text = args.optString(0, "")
+            val clipboard = ctx.getSystemService<ClipboardManager>()
+            clipboard?.setPrimaryClip(ClipData.newPlainText("Blinc", text))
+            null
+        }
+
+        registerString("clipboard", "paste") {
+            val clipboard = ctx.getSystemService<ClipboardManager>()
+            clipboard?.primaryClip?.getItemAt(0)?.text?.toString() ?: ""
+        }
+
+        register("clipboard", "has_content") {
+            val clipboard = ctx.getSystemService<ClipboardManager>()
+            clipboard?.hasPrimaryClip() ?: false
+        }
+
+        registerVoid("clipboard", "clear") {
+            val clipboard = ctx.getSystemService<ClipboardManager>()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                clipboard?.clearPrimaryClip()
+            }
+        }
+
+        // =====================================================================
+        // App namespace
+        // =====================================================================
+
+        registerString("app", "get_version") {
+            try {
+                ctx.packageManager.getPackageInfo(ctx.packageName, 0).versionName ?: "1.0"
+            } catch (e: Exception) {
+                "1.0"
+            }
+        }
+
+        registerString("app", "get_build_number") {
+            try {
+                val info = ctx.packageManager.getPackageInfo(ctx.packageName, 0)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    info.longVersionCode.toString()
+                } else {
+                    @Suppress("DEPRECATION")
+                    info.versionCode.toString()
+                }
+            } catch (e: Exception) {
+                "1"
+            }
+        }
+
+        registerString("app", "get_bundle_id") {
+            ctx.packageName
+        }
+
+        register("app", "open_url") { args ->
+            val url = args.optString(0, "")
+            try {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                ctx.startActivity(intent)
+                true
+            } catch (e: Exception) {
+                false
+            }
+        }
+
+        register("app", "share_text") { args ->
+            val text = args.optString(0, "")
+            val intent = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_TEXT, text)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            ctx.startActivity(Intent.createChooser(intent, "Share").apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            })
+            null
+        }
+
+        // =====================================================================
+        // Permissions namespace
+        // =====================================================================
+
+        register("permissions", "has_location") {
+            sensorCollector.hasLocationPermission()
+        }
+        register("permissions", "has_location_always") {
+            sensorCollector.hasLocationAlwaysPermission()
+        }
+        register("permissions", "has_motion") {
+            sensorCollector.hasMotionPermission()
+        }
+        register("permissions", "has_camera") {
+            sensorCollector.hasCameraPermission()
+        }
+        register("permissions", "has_microphone") {
+            sensorCollector.hasMicrophonePermission()
+        }
+        register("permissions", "has_photos") {
+            sensorCollector.hasPhotosPermission()
+        }
+        register("permissions", "has_notifications") {
+            sensorCollector.hasNotificationsPermission()
+        }
+        register("permissions", "has_bluetooth_scan") {
+            sensorCollector.hasBluetoothScanPermission()
+        }
+        register("permissions", "has_bluetooth_connect") {
+            sensorCollector.hasBluetoothConnectPermission()
+        }
+        register("permissions", "request_location_when_in_use") {
+            sensorCollector.requestLocationPermissionWhenInUse()
+        }
+        register("permissions", "request_location_always") {
+            sensorCollector.requestLocationPermissionAlways()
+        }
+        register("permissions", "request_motion") {
+            sensorCollector.requestMotionPermission()
+        }
+        register("permissions", "request_camera") {
+            sensorCollector.requestCameraPermission()
+        }
+        register("permissions", "request_microphone") {
+            sensorCollector.requestMicrophonePermission()
+        }
+        register("permissions", "request_photos") {
+            sensorCollector.requestPhotosPermission()
+        }
+        register("permissions", "request_notifications") {
+            sensorCollector.requestNotificationsPermission()
+        }
+        register("permissions", "request_bluetooth_scan") {
+            sensorCollector.requestBluetoothScanPermission()
+        }
+        register("permissions", "request_bluetooth_connect") {
+            sensorCollector.requestBluetoothConnectPermission()
+        }
+
+        // =====================================================================
+        // BLE namespace
+        // =====================================================================
+
+        register("ble", "configure") { args ->
+            bleCollector.configure(args.optString(0, "{}"))
+        }
+
+        register("ble", "start") { args ->
+            val sessionId = args.optString(0, "")
+            bleCollector.start(sessionId)
+        }
+
+        register("ble", "stop") { args ->
+            val sessionId = args.optString(0, "")
+            bleCollector.stop(sessionId)
+        }
+
+        registerString("ble", "status") {
+            bleCollector.statusJson()
+        }
+
+        register("ble", "drain_results") { args ->
+            bleCollector.drainResults(args.optInt(0, 64))
+        }
+
+        // =====================================================================
+        // Sensor namespace (default stubs)
+        // =====================================================================
+
+        register("sensor", "configure") { args ->
+            sensorCollector.configure(args.optString(0, "{}"))
+        }
+
+        register("sensor", "start") { args ->
+            val sessionId = args.optString(0, "")
+            sensorCollector.start(sessionId)
+        }
+
+        register("sensor", "stop") { args ->
+            val sessionId = args.optString(0, "")
+            sensorCollector.stop(sessionId)
+        }
+
+        registerString("sensor", "status") {
+            sensorCollector.statusJson()
+        }
+
+        register("sensor", "drain_frames") { args ->
+            sensorCollector.drainFrames(args.optInt(0, 64))
+        }
+
+        register("sensor", "peek_frames") { args ->
+            sensorCollector.peekFrames(args.optInt(0, 32))
+        }
+
+        registerString("sensor", "supported_kinds") {
+            sensorCollector.supportedKindsJson()
+        }
+
+        registerVoid("sensor", "clear_buffer") {
+            sensorCollector.clearBuffer()
+        }
+    }
+
+    // =========================================================================
+    // Helper functions
+    // =========================================================================
+
+    private fun successJson(value: Any?): String {
+        val obj = JSONObject()
+        obj.put("success", true)
+        when (value) {
+            null -> obj.put("value", JSONObject.NULL)
+            is String -> obj.put("value", value)
+            is Boolean -> obj.put("value", value)
+            is Int -> obj.put("value", value)
+            is Long -> obj.put("value", value)
+            is Float -> obj.put("value", value)
+            is Double -> obj.put("value", value)
+            is ByteArray -> obj.put("value", android.util.Base64.encodeToString(value, android.util.Base64.NO_WRAP))
+            else -> obj.put("value", value.toString())
+        }
+        return obj.toString()
+    }
+
+    private fun errorJson(type: String, message: String): String {
+        val obj = JSONObject()
+        obj.put("success", false)
+        obj.put("errorType", type)
+        obj.put("errorMessage", message)
+        return obj.toString()
+    }
+
+    private fun vibrate(context: Context, durationMs: Long) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val vm = context.getSystemService<VibratorManager>()
+            vm?.defaultVibrator?.vibrate(
+                VibrationEffect.createOneShot(durationMs, VibrationEffect.DEFAULT_AMPLITUDE)
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            val v = context.getSystemService<Vibrator>()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                v?.vibrate(VibrationEffect.createOneShot(durationMs, VibrationEffect.DEFAULT_AMPLITUDE))
+            } else {
+                @Suppress("DEPRECATION")
+                v?.vibrate(durationMs)
+            }
+        }
+    }
+
+    private fun vibrateWithAmplitude(context: Context, durationMs: Long, amplitude: Int) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val vm = context.getSystemService<VibratorManager>()
+                vm?.defaultVibrator?.vibrate(VibrationEffect.createOneShot(durationMs, amplitude))
+            } else {
+                @Suppress("DEPRECATION")
+                val v = context.getSystemService<Vibrator>()
+                v?.vibrate(VibrationEffect.createOneShot(durationMs, amplitude))
+            }
+        } else {
+            vibrate(context, durationMs)
+        }
+    }
+}
+
+private data class AndroidSensorConfig(
+    val enabled: Set<String> = setOf("gps", "accelerometer", "gyroscope"),
+    val gpsHz: Int = 1,
+    val imuHz: Int = 50,
+    val frameFlushMs: Int = 200,
+)
+
+private class AndroidSensorCollector {
+    private val lock = Any()
+    private val frameBuffer: ArrayDeque<JSONObject> = ArrayDeque()
+    private val accuracyBySensor: MutableMap<Int, Int> = mutableMapOf()
+    private val recentStepDetectorNs: ArrayDeque<Long> = ArrayDeque()
+    private val frameCountsByKind: MutableMap<String, Long> = mutableMapOf()
+    private val latestSampleByKind: MutableMap<String, String> = mutableMapOf()
+
+    private var context: Context? = null
+    private var foregroundActivityRef: WeakReference<Activity>? = null
+    private var sensorManager: SensorManager? = null
+    private var locationManager: LocationManager? = null
+    private var config: AndroidSensorConfig = AndroidSensorConfig()
+    private var running: Boolean = false
+    private var activeSessionId: String? = null
+    private var seq: Long = 0L
+    private var totalFrameCount: Long = 0L
+    private var lastStatsLogMs: Long = 0L
+    private var locationListener: LocationListener? = null
+
+    private val maxBufferedFrames = 4096
+    private val cadenceWindowNs = 8_000_000_000L
+
+    private val sensorListener = object : SensorEventListener {
+        override fun onSensorChanged(event: SensorEvent) {
+            val sensorType = event.sensor.type
+            val monotonicNs = event.timestamp
+            val accuracy = mapSensorAccuracy(event.accuracy)
+            if (sensorType == Sensor.TYPE_STEP_DETECTOR) {
+                handleStepDetectorEvent(monotonicNs, accuracy, event.values.copyOf())
+                return
+            }
+            val kind = sensorTypeToKind(sensorType) ?: return
+            appendFrame(kind, monotonicNs, accuracy, event.values.copyOf())
+            if (kind == "rotation_vector" && synchronized(lock) { config.enabled.contains("quaternion") }) {
+                appendFrame("quaternion", monotonicNs, accuracy, event.values.copyOf())
+            }
+        }
+
+        override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+            if (sensor != null) {
+                synchronized(lock) {
+                    accuracyBySensor[sensor.type] = accuracy
+                }
+            }
+        }
+    }
+
+    fun attach(appContext: Context) {
+        context = appContext
+        sensorManager = appContext.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+        locationManager = appContext.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+    }
+
+    fun setForegroundActivity(activity: Activity?) {
+        foregroundActivityRef = if (activity == null) null else WeakReference(activity)
+    }
+
+    fun configure(configJson: String): Boolean {
+        return runCatching {
+            val root = JSONObject(configJson)
+            val enabled = mutableSetOf<String>()
+            root.optJSONArray("enabled")?.let { arr ->
+                for (i in 0 until arr.length()) {
+                    val kind = arr.optString(i, "").trim()
+                    if (kind.isNotEmpty()) {
+                        enabled.add(kind)
+                    }
+                }
+            }
+            val next = AndroidSensorConfig(
+                enabled = if (enabled.isEmpty()) AndroidSensorConfig().enabled else enabled,
+                gpsHz = root.optInt("gps_hz", 1).coerceAtLeast(1),
+                imuHz = root.optInt("imu_hz", 50).coerceAtLeast(1),
+                frameFlushMs = root.optInt("frame_flush_ms", 200).coerceAtLeast(20),
+            )
+            synchronized(lock) {
+                config = next
+            }
+            true
+        }.getOrElse { false }
+    }
+
+    fun start(sessionId: String): Boolean {
+        val normalizedId = sessionId.trim()
+        if (normalizedId.isEmpty()) {
+            return false
+        }
+        val ctx = context ?: return false
+        val localConfig: AndroidSensorConfig
+        var restarting = false
+
+        synchronized(lock) {
+            if (running) {
+                restarting = true
+                stopInternalLocked()
+            }
+            running = true
+            activeSessionId = normalizedId
+            resetFrameStatsLocked()
+            localConfig = config
+        }
+
+        if (restarting) {
+            stopSensors()
+        }
+        startSensors(ctx)
+        Log.i(
+            TAG,
+            "start: session=$normalizedId enabled=${localConfig.enabled} gpsHz=${localConfig.gpsHz} imuHz=${localConfig.imuHz}",
+        )
+        return true
+    }
+
+    fun stop(sessionId: String): Boolean {
+        var stoppedSession: String? = null
+        synchronized(lock) {
+            if (!running) {
+                return true
+            }
+            if (sessionId.isNotBlank() && sessionId != activeSessionId) {
+                return false
+            }
+            stoppedSession = activeSessionId
+            stopInternalLocked()
+        }
+        stopSensors()
+        Log.i(TAG, "stop: session=${stoppedSession ?: "-"}")
+        return true
+    }
+
+    fun statusJson(): String {
+        val payload = JSONObject()
+        synchronized(lock) {
+            payload.put("running", running)
+            payload.put("buffered_frames", frameBuffer.size)
+            if (activeSessionId == null) {
+                payload.put("active_session_id", JSONObject.NULL)
+            } else {
+                payload.put("active_session_id", activeSessionId)
+            }
+        }
+        return payload.toString()
+    }
+
+    fun drainFrames(maxFrames: Int): String {
+        val count = maxFrames.coerceIn(1, 2048)
+        val arr = JSONArray()
+        synchronized(lock) {
+            repeat(count) {
+                if (frameBuffer.isEmpty()) {
+                    return@repeat
+                }
+                arr.put(frameBuffer.removeFirst())
+            }
+        }
+        return arr.toString()
+    }
+
+    fun peekFrames(maxFrames: Int): String {
+        val count = maxFrames.coerceIn(1, 256)
+        val arr = JSONArray()
+        synchronized(lock) {
+            val start = (frameBuffer.size - count).coerceAtLeast(0)
+            var index = 0
+            for (frame in frameBuffer) {
+                if (index >= start) {
+                    arr.put(frame)
+                }
+                index += 1
+            }
+        }
+        return arr.toString()
+    }
+
+    fun clearBuffer() {
+        synchronized(lock) {
+            frameBuffer.clear()
+        }
+    }
+
+    fun supportedKindsJson(): String {
+        if (context == null) {
+            return "[]"
+        }
+        val sm = sensorManager ?: return "[]"
+        val lm = locationManager
+        val kinds = mutableListOf<String>()
+
+        if (lm != null && lm.allProviders?.isNotEmpty() == true) {
+            kinds.add("gps")
+        }
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_ACCELEROMETER, "accelerometer")
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_LINEAR_ACCELERATION, "linear_acceleration")
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_GRAVITY, "gravity")
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_GYROSCOPE, "gyroscope")
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_ROTATION_VECTOR, "rotation_vector")
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_ROTATION_VECTOR, "quaternion")
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_MAGNETIC_FIELD, "magnetometer")
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_PRESSURE, "barometer")
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_LIGHT, "ambient_light")
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_PROXIMITY, "proximity")
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_AMBIENT_TEMPERATURE, "ambient_temperature")
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_RELATIVE_HUMIDITY, "relative_humidity")
+        addIfSensorAvailable(kinds, sm, Sensor.TYPE_STEP_COUNTER, "step_counter")
+        val hasStepDetector = sm.getDefaultSensor(Sensor.TYPE_STEP_DETECTOR) != null
+        if (hasStepDetector) {
+            kinds.add("step_detector")
+            kinds.add("cadence")
+            kinds.add("activity")
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+            addIfSensorAvailable(kinds, sm, Sensor.TYPE_HEART_RATE, "heart_rate")
+        }
+
+        return JSONArray(kinds.distinct()).toString()
+    }
+
+    fun hasLocationPermission(): Boolean {
+        val ctx = context ?: return false
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return true
+        }
+        val fine = ctx.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+        val coarse = ctx.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+        return fine || coarse
+    }
+
+    fun hasLocationAlwaysPermission(): Boolean {
+        if (!hasLocationPermission()) {
+            return false
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return true
+        }
+        val ctx = context ?: return false
+        return ctx.checkSelfPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    fun hasMotionPermission(): Boolean {
+        val ctx = context ?: return false
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return true
+        }
+        return ctx.checkSelfPermission(Manifest.permission.ACTIVITY_RECOGNITION) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    fun hasCameraPermission(): Boolean {
+        val ctx = context ?: return false
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return true
+        }
+        return ctx.checkSelfPermission(Manifest.permission.CAMERA) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    fun hasMicrophonePermission(): Boolean {
+        val ctx = context ?: return false
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return true
+        }
+        return ctx.checkSelfPermission(Manifest.permission.RECORD_AUDIO) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    fun hasPhotosPermission(): Boolean {
+        val ctx = context ?: return false
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return true
+        }
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ctx.checkSelfPermission(Manifest.permission.READ_MEDIA_IMAGES) ==
+                PackageManager.PERMISSION_GRANTED
+        } else {
+            @Suppress("DEPRECATION")
+            ctx.checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) ==
+                PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    fun hasNotificationsPermission(): Boolean {
+        val ctx = context ?: return false
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return true
+        }
+        return ctx.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    fun hasBluetoothScanPermission(): Boolean {
+        val ctx = context ?: return false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return ctx.checkSelfPermission(Manifest.permission.BLUETOOTH_SCAN) ==
+                PackageManager.PERMISSION_GRANTED
+        }
+        return hasLocationPermission()
+    }
+
+    fun hasBluetoothConnectPermission(): Boolean {
+        val ctx = context ?: return false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return ctx.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) ==
+                PackageManager.PERMISSION_GRANTED
+        }
+        return true
+    }
+
+    fun requestLocationPermissionWhenInUse(): Boolean {
+        if (hasLocationPermission()) {
+            return true
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return true
+        }
+        val activity = foregroundActivityRef?.get() ?: return false
+        val missing = mutableListOf<String>()
+        if (activity.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            missing.add(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+        if (activity.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            missing.add(Manifest.permission.ACCESS_COARSE_LOCATION)
+        }
+        if (missing.isEmpty()) {
+            return true
+        }
+        activity.runOnUiThread {
+            activity.requestPermissions(missing.toTypedArray(), REQUEST_CODE_LOCATION_WHEN_IN_USE)
+        }
+        return false
+    }
+
+    fun requestLocationPermissionAlways(): Boolean {
+        val whenInUseGranted = requestLocationPermissionWhenInUse()
+        if (!whenInUseGranted) {
+            return false
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return true
+        }
+        val activity = foregroundActivityRef?.get() ?: return false
+        val granted = activity.checkSelfPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+        if (granted) {
+            return true
+        }
+        activity.runOnUiThread {
+            activity.requestPermissions(
+                arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION),
+                REQUEST_CODE_LOCATION_ALWAYS,
+            )
+        }
+        return false
+    }
+
+    fun requestMotionPermission(): Boolean {
+        if (hasMotionPermission()) {
+            return true
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return true
+        }
+        requestPermissions(arrayOf(Manifest.permission.ACTIVITY_RECOGNITION), REQUEST_CODE_MOTION)
+        return false
+    }
+
+    fun requestCameraPermission(): Boolean {
+        if (hasCameraPermission()) {
+            return true
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return true
+        }
+        requestPermissions(arrayOf(Manifest.permission.CAMERA), REQUEST_CODE_CAMERA)
+        return false
+    }
+
+    fun requestMicrophonePermission(): Boolean {
+        if (hasMicrophonePermission()) {
+            return true
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return true
+        }
+        requestPermissions(arrayOf(Manifest.permission.RECORD_AUDIO), REQUEST_CODE_MICROPHONE)
+        return false
+    }
+
+    fun requestPhotosPermission(): Boolean {
+        if (hasPhotosPermission()) {
+            return true
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return true
+        }
+        val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(Manifest.permission.READ_MEDIA_IMAGES)
+        } else {
+            @Suppress("DEPRECATION")
+            arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
+        requestPermissions(permissions, REQUEST_CODE_PHOTOS)
+        return false
+    }
+
+    fun requestNotificationsPermission(): Boolean {
+        if (hasNotificationsPermission()) {
+            return true
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return true
+        }
+        requestPermissions(arrayOf(Manifest.permission.POST_NOTIFICATIONS), REQUEST_CODE_NOTIFICATIONS)
+        return false
+    }
+
+    fun requestBluetoothScanPermission(): Boolean {
+        if (hasBluetoothScanPermission()) {
+            return true
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            requestPermissions(arrayOf(Manifest.permission.BLUETOOTH_SCAN), REQUEST_CODE_BLUETOOTH_SCAN)
+            return false
+        }
+        return requestLocationPermissionWhenInUse()
+    }
+
+    fun requestBluetoothConnectPermission(): Boolean {
+        if (hasBluetoothConnectPermission()) {
+            return true
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return true
+        }
+        requestPermissions(
+            arrayOf(Manifest.permission.BLUETOOTH_CONNECT),
+            REQUEST_CODE_BLUETOOTH_CONNECT,
+        )
+        return false
+    }
+
+    private fun requestPermissions(permissions: Array<String>, requestCode: Int) {
+        val activity = foregroundActivityRef?.get() ?: return
+        activity.runOnUiThread {
+            activity.requestPermissions(permissions, requestCode)
+        }
+    }
+
+    companion object {
+        private const val TAG = "BlincSensor"
+        private const val STATS_LOG_INTERVAL_MS = 1_000L
+        private const val REQUEST_CODE_LOCATION_WHEN_IN_USE = 3101
+        private const val REQUEST_CODE_LOCATION_ALWAYS = 3102
+        private const val REQUEST_CODE_MOTION = 3103
+        private const val REQUEST_CODE_CAMERA = 3104
+        private const val REQUEST_CODE_MICROPHONE = 3105
+        private const val REQUEST_CODE_PHOTOS = 3106
+        private const val REQUEST_CODE_NOTIFICATIONS = 3107
+        private const val REQUEST_CODE_BLUETOOTH_SCAN = 3108
+        private const val REQUEST_CODE_BLUETOOTH_CONNECT = 3109
+    }
+
+    private fun addIfSensorAvailable(
+        out: MutableList<String>,
+        sensorManager: SensorManager,
+        sensorType: Int,
+        kind: String,
+    ) {
+        if (sensorManager.getDefaultSensor(sensorType) != null) {
+            out.add(kind)
+        }
+    }
+
+    private fun startSensors(ctx: Context) {
+        val localConfig = synchronized(lock) { config }
+        val sm = sensorManager ?: return
+        val imuDelayUs = (1_000_000L / localConfig.imuHz.toLong()).toInt().coerceAtLeast(2_000)
+
+        fun registerSensor(sensorType: Int) {
+            val sensor = sm.getDefaultSensor(sensorType) ?: return
+            sm.registerListener(sensorListener, sensor, imuDelayUs)
+        }
+
+        if (localConfig.enabled.contains("accelerometer")) {
+            registerSensor(Sensor.TYPE_ACCELEROMETER)
+        }
+        if (localConfig.enabled.contains("linear_acceleration")) {
+            registerSensor(Sensor.TYPE_LINEAR_ACCELERATION)
+        }
+        if (localConfig.enabled.contains("gravity")) {
+            registerSensor(Sensor.TYPE_GRAVITY)
+        }
+        if (localConfig.enabled.contains("gyroscope")) {
+            registerSensor(Sensor.TYPE_GYROSCOPE)
+        }
+        if (localConfig.enabled.contains("rotation_vector") || localConfig.enabled.contains("quaternion")) {
+            registerSensor(Sensor.TYPE_ROTATION_VECTOR)
+        }
+        if (localConfig.enabled.contains("magnetometer")) {
+            registerSensor(Sensor.TYPE_MAGNETIC_FIELD)
+        }
+        if (localConfig.enabled.contains("barometer")) {
+            registerSensor(Sensor.TYPE_PRESSURE)
+        }
+        if (localConfig.enabled.contains("ambient_light")) {
+            registerSensor(Sensor.TYPE_LIGHT)
+        }
+        if (localConfig.enabled.contains("proximity")) {
+            registerSensor(Sensor.TYPE_PROXIMITY)
+        }
+        if (localConfig.enabled.contains("ambient_temperature")) {
+            registerSensor(Sensor.TYPE_AMBIENT_TEMPERATURE)
+        }
+        if (localConfig.enabled.contains("relative_humidity")) {
+            registerSensor(Sensor.TYPE_RELATIVE_HUMIDITY)
+        }
+        if (localConfig.enabled.contains("step_counter")) {
+            registerSensor(Sensor.TYPE_STEP_COUNTER)
+        }
+        if (localConfig.enabled.contains("step_detector") ||
+            localConfig.enabled.contains("cadence") ||
+            localConfig.enabled.contains("activity")
+        ) {
+            registerSensor(Sensor.TYPE_STEP_DETECTOR)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH &&
+            localConfig.enabled.contains("heart_rate")
+        ) {
+            registerSensor(Sensor.TYPE_HEART_RATE)
+        }
+
+        if (localConfig.enabled.contains("gps")) {
+            startLocationUpdates(ctx, localConfig.gpsHz)
+        }
+        Log.d(TAG, "registered sensors: enabled=${localConfig.enabled}")
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun startLocationUpdates(ctx: Context, gpsHz: Int) {
+        if (!hasLocationPermission()) {
+            return
+        }
+        val lm = locationManager ?: return
+        val intervalMs = (1_000L / gpsHz.coerceAtLeast(1)).coerceAtLeast(250L)
+        val provider = when {
+            lm.isProviderEnabled(LocationManager.GPS_PROVIDER) -> LocationManager.GPS_PROVIDER
+            lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER) -> LocationManager.NETWORK_PROVIDER
+            else -> null
+        } ?: return
+
+        locationListener = LocationListener { location ->
+            appendLocationFrame(location)
+        }
+
+        lm.requestLocationUpdates(
+            provider,
+            intervalMs,
+            0f,
+            locationListener!!,
+            Looper.getMainLooper(),
+        )
+
+        lm.getLastKnownLocation(provider)?.let { appendLocationFrame(it) }
+    }
+
+    private fun stopSensors() {
+        sensorManager?.unregisterListener(sensorListener)
+        locationListener?.let { listener ->
+            locationManager?.removeUpdates(listener)
+        }
+        locationListener = null
+    }
+
+    private fun stopInternalLocked() {
+        running = false
+        activeSessionId = null
+        accuracyBySensor.clear()
+        recentStepDetectorNs.clear()
+        resetFrameStatsLocked()
+    }
+
+    private fun handleStepDetectorEvent(monotonicNs: Long, accuracy: String, rawValues: FloatArray) {
+        val (emitStepDetector, emitCadence, emitActivity, cadenceHz) = synchronized(lock) {
+            val enabled = config.enabled
+            val emitStepDetectorLocal = enabled.contains("step_detector")
+            val emitCadenceLocal = enabled.contains("cadence")
+            val emitActivityLocal = enabled.contains("activity")
+
+            var cadenceHzLocal = 0f
+            if (emitCadenceLocal || emitActivityLocal) {
+                recentStepDetectorNs.addLast(monotonicNs)
+                while (recentStepDetectorNs.isNotEmpty() &&
+                    monotonicNs - recentStepDetectorNs.first() > cadenceWindowNs
+                ) {
+                    recentStepDetectorNs.removeFirst()
+                }
+
+                if (recentStepDetectorNs.size >= 2) {
+                    val windowDurationNs = (monotonicNs - recentStepDetectorNs.first()).coerceAtLeast(1L)
+                    val windowSeconds = windowDurationNs.toDouble() / 1_000_000_000.0
+                    cadenceHzLocal = ((recentStepDetectorNs.size - 1).toDouble() / windowSeconds).toFloat()
+                }
+            }
+
+            Quadruple(emitStepDetectorLocal, emitCadenceLocal, emitActivityLocal, cadenceHzLocal)
+        }
+
+        if (emitStepDetector) {
+            appendFrame("step_detector", monotonicNs, accuracy, rawValues)
+        }
+        if (emitCadence) {
+            appendFrame("cadence", monotonicNs, accuracy, floatArrayOf(cadenceHz))
+        }
+        if (emitActivity) {
+            val activityValues = when {
+                cadenceHz >= 2.0f -> floatArrayOf(0f, 0f, 1f, 0f, 0f, 0f) // running
+                cadenceHz >= 0.5f -> floatArrayOf(0f, 1f, 0f, 0f, 0f, 0f) // walking
+                else -> floatArrayOf(1f, 0f, 0f, 0f, 0f, 0f) // stationary
+            }
+            appendFrame("activity", monotonicNs, accuracy, activityValues)
+        }
+    }
+
+    private fun appendLocationFrame(location: Location) {
+        val monotonicNs = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            location.elapsedRealtimeNanos
+        } else {
+            SystemClock.elapsedRealtimeNanos()
+        }
+        val unixTimeMs = location.time
+        val values = floatArrayOf(
+            location.latitude.toFloat(),
+            location.longitude.toFloat(),
+            location.altitude.toFloat(),
+            location.speed,
+            location.bearing,
+            location.accuracy,
+        )
+        appendFrame(
+            kind = "gps",
+            monotonicNs = monotonicNs,
+            accuracy = mapLocationAccuracy(location.accuracy),
+            values = values,
+            unixTimeMs = unixTimeMs,
+        )
+    }
+
+    private fun appendFrame(
+        kind: String,
+        monotonicNs: Long,
+        accuracy: String,
+        values: FloatArray,
+        unixTimeMs: Long? = null,
+    ) {
+        var statsLog: String? = null
+        synchronized(lock) {
+            if (!running) {
+                return
+            }
+            val frame = JSONObject()
+            frame.put("seq", ++seq)
+            frame.put("sensor", kind)
+            frame.put("time_monotonic_ns", monotonicNs)
+            frame.put("time_unix_ms", unixTimeMs ?: monotonicToUnixMs(monotonicNs))
+            frame.put("accuracy", accuracy)
+            val valueArray = JSONArray()
+            values.forEach { valueArray.put(it.toDouble()) }
+            frame.put("values", valueArray)
+
+            if (frameBuffer.size >= maxBufferedFrames) {
+                frameBuffer.removeFirst()
+            }
+            frameBuffer.addLast(frame)
+
+            totalFrameCount += 1
+            frameCountsByKind[kind] = (frameCountsByKind[kind] ?: 0L) + 1L
+            if (kind != "gps") {
+                latestSampleByKind[kind] = formatValues(values)
+            }
+
+            val nowMs = SystemClock.elapsedRealtime()
+            if (nowMs - lastStatsLogMs >= STATS_LOG_INTERVAL_MS) {
+                lastStatsLogMs = nowMs
+                val counts = frameCountsByKind
+                    .entries
+                    .sortedBy { it.key }
+                    .joinToString(", ") { "${it.key}=${it.value}" }
+                val latest = listOf("accelerometer", "gyroscope", "magnetometer", "barometer")
+                    .mapNotNull { key ->
+                        latestSampleByKind[key]?.let { sample -> "$key=[$sample]" }
+                    }
+                    .joinToString(" ")
+                val session = activeSessionId ?: "-"
+                statsLog = "session=$session buffered=${frameBuffer.size} total=$totalFrameCount kinds={$counts} latest=$latest"
+            }
+        }
+        if (statsLog != null) {
+            Log.d(TAG, "frame-stats ${statsLog}")
+        }
+    }
+
+    private fun formatValues(values: FloatArray, maxElements: Int = 3): String {
+        return values
+            .take(maxElements)
+            .joinToString(",") { value -> String.format(Locale.US, "%.3f", value) }
+    }
+
+    private fun resetFrameStatsLocked() {
+        totalFrameCount = 0L
+        lastStatsLogMs = 0L
+        frameCountsByKind.clear()
+        latestSampleByKind.clear()
+    }
+
+    private fun monotonicToUnixMs(monotonicNs: Long): Long {
+        val nowMonoNs = SystemClock.elapsedRealtimeNanos()
+        val nowUnixMs = System.currentTimeMillis()
+        val deltaMs = ((nowMonoNs - monotonicNs).coerceAtLeast(0L)) / 1_000_000L
+        return nowUnixMs - deltaMs
+    }
+
+    private fun mapSensorAccuracy(accuracy: Int): String {
+        return when (accuracy) {
+            SensorManager.SENSOR_STATUS_UNRELIABLE -> "unreliable"
+            SensorManager.SENSOR_STATUS_ACCURACY_LOW -> "low"
+            SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM -> "medium"
+            SensorManager.SENSOR_STATUS_ACCURACY_HIGH -> "high"
+            else -> "medium"
+        }
+    }
+
+    private fun mapLocationAccuracy(horizontalAccuracyMeters: Float): String {
+        return when {
+            horizontalAccuracyMeters <= 10f -> "high"
+            horizontalAccuracyMeters <= 50f -> "medium"
+            else -> "low"
+        }
+    }
+
+    private fun sensorTypeToKind(sensorType: Int): String? {
+        return when (sensorType) {
+            Sensor.TYPE_ACCELEROMETER -> "accelerometer"
+            Sensor.TYPE_LINEAR_ACCELERATION -> "linear_acceleration"
+            Sensor.TYPE_GRAVITY -> "gravity"
+            Sensor.TYPE_GYROSCOPE -> "gyroscope"
+            Sensor.TYPE_ROTATION_VECTOR -> "rotation_vector"
+            Sensor.TYPE_MAGNETIC_FIELD -> "magnetometer"
+            Sensor.TYPE_PRESSURE -> "barometer"
+            Sensor.TYPE_LIGHT -> "ambient_light"
+            Sensor.TYPE_PROXIMITY -> "proximity"
+            Sensor.TYPE_AMBIENT_TEMPERATURE -> "ambient_temperature"
+            Sensor.TYPE_RELATIVE_HUMIDITY -> "relative_humidity"
+            Sensor.TYPE_STEP_COUNTER -> "step_counter"
+            Sensor.TYPE_STEP_DETECTOR -> "step_detector"
+            Sensor.TYPE_HEART_RATE -> "heart_rate"
+            else -> null
+        }
+    }
+}
+
+private data class AndroidBleScanConfig(
+    val serviceUuids: List<String> = emptyList(),
+    val allowDuplicates: Boolean = false,
+    val scanMode: String? = null,
+    val frameFlushMs: Int = 500,
+)
+
+private class AndroidBleCollector(
+    private val permissions: AndroidSensorCollector,
+) {
+    private val lock = Any()
+    private val resultBuffer: ArrayDeque<JSONObject> = ArrayDeque()
+
+    private var context: Context? = null
+    private var foregroundActivityRef: WeakReference<Activity>? = null
+    private var bluetoothManager: BluetoothManager? = null
+    private var running: Boolean = false
+    private var activeSessionId: String? = null
+    private var seq: Long = 0L
+    private var config: AndroidBleScanConfig = AndroidBleScanConfig()
+
+    private val maxBufferedResults = 4096
+
+    private val scanCallback = object : ScanCallback() {
+        override fun onScanResult(callbackType: Int, result: ScanResult?) {
+            if (result != null) {
+                appendResult(result)
+            }
+        }
+
+        override fun onBatchScanResults(results: MutableList<ScanResult>?) {
+            results?.forEach { appendResult(it) }
+        }
+
+        override fun onScanFailed(errorCode: Int) {
+            Log.w(TAG, "BLE scan failed with error code=$errorCode")
+        }
+    }
+
+    fun attach(appContext: Context) {
+        context = appContext
+        bluetoothManager = appContext.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+    }
+
+    fun setForegroundActivity(activity: Activity?) {
+        foregroundActivityRef = if (activity == null) null else WeakReference(activity)
+    }
+
+    fun configure(configJson: String): Boolean {
+        return runCatching {
+            val root = JSONObject(configJson)
+            val serviceUuids = mutableListOf<String>()
+            root.optJSONArray("service_uuids")?.let { arr ->
+                for (i in 0 until arr.length()) {
+                    val raw = arr.optString(i, "").trim()
+                    if (raw.isNotEmpty()) {
+                        serviceUuids.add(raw)
+                    }
+                }
+            }
+            val next = AndroidBleScanConfig(
+                serviceUuids = serviceUuids,
+                allowDuplicates = root.optBoolean("allow_duplicates", false),
+                scanMode = root.optString("scan_mode", "").trim().ifEmpty { null },
+                frameFlushMs = root.optInt("frame_flush_ms", 500).coerceAtLeast(0),
+            )
+            synchronized(lock) {
+                config = next
+            }
+            true
+        }.getOrDefault(false)
+    }
+
+    @SuppressLint("MissingPermission")
+    fun start(sessionId: String): Boolean {
+        val normalizedId = sessionId.trim()
+        if (normalizedId.isEmpty()) {
+            return false
+        }
+
+        if (!permissions.hasBluetoothScanPermission()) {
+            return false
+        }
+
+        val adapter = bluetoothManager?.adapter ?: return false
+        if (!adapter.isEnabled) {
+            return false
+        }
+
+        val scanner = adapter.bluetoothLeScanner ?: return false
+        var restarting = false
+        val localConfig = synchronized(lock) {
+            if (running) {
+                restarting = true
+                stopInternalLocked()
+            }
+            running = true
+            activeSessionId = normalizedId
+            seq = 0L
+            resultBuffer.clear()
+            config
+        }
+        if (restarting) {
+            runCatching { scanner.stopScan(scanCallback) }
+        }
+
+        return try {
+            val filters = localConfig.serviceUuids.mapNotNull { uuidText ->
+                runCatching {
+                    ScanFilter.Builder()
+                        .setServiceUuid(ParcelUuid.fromString(uuidText))
+                        .build()
+                }.getOrNull()
+            }
+            val settings = ScanSettings.Builder()
+                .setScanMode(scanModeFromConfig(localConfig.scanMode))
+                .setReportDelay(localConfig.frameFlushMs.toLong())
+                .build()
+            scanner.startScan(filters, settings, scanCallback)
+            Log.i(TAG, "start: session=$normalizedId filters=${filters.size}")
+            true
+        } catch (security: SecurityException) {
+            synchronized(lock) { stopInternalLocked() }
+            Log.w(TAG, "BLE start failed due to missing permission", security)
+            false
+        } catch (e: Exception) {
+            synchronized(lock) { stopInternalLocked() }
+            Log.w(TAG, "BLE start failed", e)
+            false
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    fun stop(sessionId: String): Boolean {
+        val adapter = bluetoothManager?.adapter
+        val scanner = adapter?.bluetoothLeScanner
+        synchronized(lock) {
+            if (!running) {
+                return true
+            }
+            if (sessionId.isNotBlank() && sessionId != activeSessionId) {
+                return false
+            }
+            stopInternalLocked()
+        }
+        return try {
+            scanner?.stopScan(scanCallback)
+            true
+        } catch (security: SecurityException) {
+            Log.w(TAG, "BLE stop failed due to missing permission", security)
+            false
+        }
+    }
+
+    fun statusJson(): String {
+        val payload = JSONObject()
+        synchronized(lock) {
+            payload.put("running", running)
+            payload.put("buffered_results", resultBuffer.size)
+            if (activeSessionId == null) {
+                payload.put("active_session_id", JSONObject.NULL)
+            } else {
+                payload.put("active_session_id", activeSessionId)
+            }
+        }
+        return payload.toString()
+    }
+
+    fun drainResults(maxResults: Int): String {
+        val count = maxResults.coerceIn(1, 2048)
+        val arr = JSONArray()
+        synchronized(lock) {
+            repeat(count) {
+                if (resultBuffer.isEmpty()) {
+                    return@repeat
+                }
+                arr.put(resultBuffer.removeFirst())
+            }
+        }
+        return arr.toString()
+    }
+
+    private fun stopInternalLocked() {
+        running = false
+        activeSessionId = null
+    }
+
+    private fun scanModeFromConfig(raw: String?): Int {
+        return when (raw?.trim()?.lowercase(Locale.US)) {
+            "low_latency", "low-latency", "fast" -> ScanSettings.SCAN_MODE_LOW_LATENCY
+            "balanced" -> ScanSettings.SCAN_MODE_BALANCED
+            "opportunistic" -> ScanSettings.SCAN_MODE_OPPORTUNISTIC
+            else -> ScanSettings.SCAN_MODE_LOW_POWER
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun appendResult(result: ScanResult) {
+        val nowMonoNs = SystemClock.elapsedRealtimeNanos()
+        val monotonicNs = result.timestampNanos.takeIf { it > 0 } ?: nowMonoNs
+        val deltaMs = ((nowMonoNs - monotonicNs).coerceAtLeast(0L)) / 1_000_000L
+        val unixTimeMs = System.currentTimeMillis() - deltaMs
+        val scanRecord = result.scanRecord
+
+        val serviceUuids = JSONArray()
+        scanRecord?.serviceUuids?.forEach { serviceUuids.put(it.uuid.toString()) }
+
+        val txPower = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            result.txPower.takeUnless { it == Int.MAX_VALUE || it == 127 }
+        } else {
+            null
+        }
+        val connectable = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            result.isConnectable
+        } else {
+            null
+        }
+        val name = runCatching { scanRecord?.deviceName ?: result.device?.name }.getOrNull()
+        val address = runCatching { result.device.address }.getOrDefault("")
+
+        val payload = JSONObject()
+        synchronized(lock) {
+            if (!running) {
+                return
+            }
+            seq += 1
+            payload.put("seq", seq)
+            payload.put("address", address)
+            if (name.isNullOrBlank()) {
+                payload.put("name", JSONObject.NULL)
+            } else {
+                payload.put("name", name)
+            }
+            payload.put("rssi", result.rssi)
+            if (txPower == null) {
+                payload.put("tx_power", JSONObject.NULL)
+            } else {
+                payload.put("tx_power", txPower)
+            }
+            if (connectable == null) {
+                payload.put("is_connectable", JSONObject.NULL)
+            } else {
+                payload.put("is_connectable", connectable)
+            }
+            payload.put("service_uuids", serviceUuids)
+            putOptionalString(payload, "manufacturer_data", encodeManufacturerData(scanRecord))
+            putOptionalString(payload, "service_data", encodeServiceData(scanRecord))
+            payload.put("time_monotonic_ns", monotonicNs)
+            payload.put("time_unix_ms", unixTimeMs)
+
+            if (resultBuffer.size >= maxBufferedResults) {
+                resultBuffer.removeFirst()
+            }
+            resultBuffer.addLast(payload)
+        }
+    }
+
+    private fun encodeManufacturerData(scanRecord: android.bluetooth.le.ScanRecord?): String? {
+        val sparse = scanRecord?.manufacturerSpecificData ?: return null
+        if (sparse.size() == 0) {
+            return null
+        }
+        val key = sparse.keyAt(0)
+        val value = sparse.valueAt(0) ?: return null
+        val encoded = android.util.Base64.encodeToString(value, android.util.Base64.NO_WRAP)
+        return "$key:$encoded"
+    }
+
+    private fun encodeServiceData(scanRecord: android.bluetooth.le.ScanRecord?): String? {
+        val data = scanRecord?.serviceData ?: return null
+        if (data.isEmpty()) {
+            return null
+        }
+        val first = data.entries.firstOrNull() ?: return null
+        val encoded = android.util.Base64.encodeToString(first.value, android.util.Base64.NO_WRAP)
+        return "${first.key.uuid}:$encoded"
+    }
+
+    private fun putOptionalString(payload: JSONObject, key: String, value: String?) {
+        if (value == null) {
+            payload.put(key, JSONObject.NULL)
+        } else {
+            payload.put(key, value)
+        }
+    }
+
+    companion object {
+        private const val TAG = "BlincBle"
+    }
+}
+
+private data class Quadruple<A, B, C, D>(
+    val first: A,
+    val second: B,
+    val third: C,
+    val fourth: D,
+)

--- a/toolchain/templates/rust/platforms/android/app/src/main/kotlin/com/blinc/MainActivity.kt
+++ b/toolchain/templates/rust/platforms/android/app/src/main/kotlin/com/blinc/MainActivity.kt
@@ -18,6 +18,23 @@ class MainActivity : NativeActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        BlincNativeBridge.setForegroundActivity(this)
+        BlincNativeBridge.registerDefaults(applicationContext)
         super.onCreate(savedInstanceState)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        BlincNativeBridge.setForegroundActivity(this)
+    }
+
+    override fun onPause() {
+        BlincNativeBridge.setForegroundActivity(null)
+        super.onPause()
+    }
+
+    override fun onDestroy() {
+        BlincNativeBridge.setForegroundActivity(null)
+        super.onDestroy()
     }
 }

--- a/toolchain/templates/rust/platforms/ios/BlincApp/AppDelegate.swift
+++ b/toolchain/templates/rust/platforms/ios/BlincApp/AppDelegate.swift
@@ -8,6 +8,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        BlincNativeBridge.shared.registerDefaults()
+        BlincNativeBridge.shared.connectToRust()
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = BlincViewController()
         window?.makeKeyAndVisible()

--- a/toolchain/templates/rust/platforms/ios/README.md
+++ b/toolchain/templates/rust/platforms/ios/README.md
@@ -1,6 +1,7 @@
 # {{project_name}} iOS Platform
 
-A Blinc UI application for iOS with Metal rendering.
+A Blinc UI application template for iOS. The generated Xcode project wires the
+native bridge and render loop scaffolding for the current iOS runtime.
 
 ## Requirements
 
@@ -77,7 +78,8 @@ The integration uses C FFI (Foreign Function Interface):
 1. `CADisplayLink` fires at ~60fps
 2. Swift checks `blinc_needs_render()` to see if UI changed
 3. If needed, `blinc_build_frame()` rebuilds the UI tree
-4. `blinc_render_frame()` renders to the Metal surface
+4. `blinc_render_frame()` renders to the Metal surface when the runtime
+   requests a frame
 
 ### Touch Events
 
@@ -111,6 +113,14 @@ Ensure:
 1. The view controller is receiving touch events (check `touchesBegan` is called)
 2. The render context was created successfully
 3. A UI builder is registered via `blinc_set_ui_builder()`
+
+## Notes
+
+- The template now calls `BlincNativeBridge.shared.registerDefaults()` and
+  `connectToRust()` from `AppDelegate.swift`.
+- iOS support is still evolving. Treat the generated project as working
+  scaffolding around the current bridge and renderer, not as a fully finished
+  platform shell.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- improve Android/iOS runtime and template wiring so the documented native preview path matches the current code surface more closely
- add semantic component tokens in `blinc_theme` and export them through `ThemeState`/CSS variables
- refactor core `blinc_cn` defaults to consume token-driven control, container, overlay, and navigation styling instead of scattered component-local constants
- refresh docs and examples so `blinc_cn` bootstrap, native status, and mobile scaffolding guidance align with the current APIs

## Testing
- cargo fmt --all
- cargo fmt --all -- --check
- cargo test -p blinc_theme
- cargo test -p blinc_cn