### PR TITLE
Fix automation wait timing, IME text dispatch, and semantic text locator resolution

### DIFF
--- a/crates/blinc_app/src/automation_session/runner.rs
+++ b/crates/blinc_app/src/automation_session/runner.rs
@@ -71,7 +71,7 @@ where
                 let frames = wait_frames_for_duration(*ms, runtime_cfg.tick_ms);
                 session.tick_frames(frames)?;
                 elapsed_frames += frames as u64;
-                elapsed_ms += ms;
+                elapsed_ms += runtime_cfg.tick_ms.saturating_mul(frames as u64);
                 Ok(())
             }
             ScenarioStep::Tick { frames } => {

--- a/crates/blinc_app/src/tests.rs
+++ b/crates/blinc_app/src/tests.rs
@@ -1581,6 +1581,38 @@ fn semantic_locator_scenarios_execute_against_headless_runtime() {
 }
 
 #[test]
+fn wait_steps_report_elapsed_time_using_advanced_frames() {
+    use crate::{run_headless_scenario, HeadlessRunConfig, HeadlessScenario, ReportStatus};
+
+    let _guard = automation_test_guard();
+    ensure_automation_theme();
+
+    let runtime_cfg = HeadlessRunConfig {
+        tick_ms: 16,
+        ..HeadlessRunConfig::default()
+    };
+    let scenario = HeadlessScenario::from_json(
+        r#"{
+  "steps": [
+    {"type":"wait","ms":1},
+    {"type":"assert_exists","id":"missing"}
+  ]
+}"#,
+    )
+    .expect("scenario should parse");
+
+    let run = run_headless_scenario(runtime_cfg, &scenario, |ctx| {
+        div().w(ctx.width).h(ctx.height).child(text("Ready"))
+    })
+    .expect("scenario execution should finish with a failed report");
+
+    assert!(matches!(run.report.status, ReportStatus::Failed));
+    assert_eq!(run.report.failed_step_index, Some(1));
+    assert_eq!(run.report.elapsed_frames, 1);
+    assert_eq!(run.report.elapsed_ms, 16);
+}
+
+#[test]
 fn automation_session_returns_trace_linked_failure_details() {
     use crate::{AutomationLocator, AutomationSession, HeadlessRunConfig};
     use blinc_recorder::TraceEntryKind;

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -158,6 +158,17 @@ fn keyboard_text_chars(event: &blinc_platform::KeyboardEvent) -> Vec<char> {
     fallback.into_iter().collect()
 }
 
+fn keyboard_text_chars_for_dispatch(
+    event: &blinc_platform::KeyboardEvent,
+    composition_active: bool,
+) -> Vec<char> {
+    if composition_active && event.text.is_none() {
+        return Vec::new();
+    }
+
+    keyboard_text_chars(event)
+}
+
 fn visible_text_chars(text: &str) -> Vec<char> {
     text.chars().filter(|ch| !ch.is_control()).collect()
 }
@@ -2650,6 +2661,7 @@ impl WindowedApp {
         // Track committed keyboard text across platform input events so a following
         // IME commit event can suppress duplicate TEXT_INPUT dispatch.
         let mut keyboard_committed_text: Option<Vec<char>> = None;
+        let mut composition_active = false;
         // Shared dirty flag for element refs
         let ref_dirty_flag: RefDirtyFlag = Arc::new(AtomicBool::new(false));
         // Shared reactive graph for signal-based state management
@@ -3276,7 +3288,10 @@ impl WindowedApp {
                                 },
                                 InputEvent::Keyboard(kb_event) => {
                                     let mods = &kb_event.modifiers;
-                                    let text_chars = keyboard_text_chars(&kb_event);
+                                    let text_chars = keyboard_text_chars_for_dispatch(
+                                        &kb_event,
+                                        composition_active,
+                                    );
 
                                     // Key code for special key handling (backspace, arrows, etc)
                                     let key_code = match &kb_event.key {
@@ -3447,15 +3462,18 @@ impl WindowedApp {
                                     scroll_ended = true;
                                 }
                                 InputEvent::CompositionStarted => {
+                                    composition_active = true;
                                     keyboard_committed_text = None;
                                     blinc_layout::widgets::set_focused_text_widget_composition(None);
                                 }
                                 InputEvent::CompositionUpdated(update) => {
+                                    composition_active = true;
                                     blinc_layout::widgets::set_focused_text_widget_composition(Some(
                                         update,
                                     ));
                                 }
                                 InputEvent::CompositionCommitted(text) => {
+                                    composition_active = false;
                                     blinc_layout::widgets::set_focused_text_widget_composition(None);
                                     for c in take_composition_commit_text(
                                         &mut keyboard_committed_text,
@@ -3469,6 +3487,7 @@ impl WindowedApp {
                                     }
                                 }
                                 InputEvent::CompositionCancelled => {
+                                    composition_active = false;
                                     keyboard_committed_text = None;
                                     blinc_layout::widgets::set_focused_text_widget_composition(None);
                                 }
@@ -4829,6 +4848,30 @@ mod tests {
         };
 
         assert_eq!(keyboard_text_chars(&event), vec!['?']);
+    }
+
+    #[test]
+    fn keyboard_text_chars_for_dispatch_suppresses_fallback_during_composition() {
+        let event = KeyboardEvent {
+            key: Key::A,
+            text: None,
+            state: KeyState::Pressed,
+            modifiers: Modifiers::default(),
+        };
+
+        assert!(keyboard_text_chars_for_dispatch(&event, true).is_empty());
+    }
+
+    #[test]
+    fn keyboard_text_chars_for_dispatch_keeps_committed_text_during_composition() {
+        let event = KeyboardEvent {
+            key: Key::Unknown,
+            text: Some("한".to_string()),
+            state: KeyState::Pressed,
+            modifiers: Modifiers::default(),
+        };
+
+        assert_eq!(keyboard_text_chars_for_dispatch(&event, true), vec!['한']);
     }
 
     #[test]

--- a/crates/blinc_app/src/windowed.rs
+++ b/crates/blinc_app/src/windowed.rs
@@ -221,6 +221,15 @@ fn take_composition_commit_text(
     }
 }
 
+fn reset_composition_tracking_state(
+    composition_active: &mut bool,
+    tracked_text: &mut Option<Vec<char>>,
+) {
+    *composition_active = false;
+    *tracked_text = None;
+    blinc_layout::widgets::set_focused_text_widget_composition(None);
+}
+
 fn letter_key_char(key: &Key) -> Option<char> {
     match key {
         Key::A => Some('a'),
@@ -3006,6 +3015,10 @@ impl WindowedApp {
 
                             // When window loses focus, blur all text inputs/areas
                             if !focused {
+                                reset_composition_tracking_state(
+                                    &mut composition_active,
+                                    &mut keyboard_committed_text,
+                                );
                                 blinc_layout::widgets::blur_all_text_inputs();
                             }
 
@@ -3487,9 +3500,10 @@ impl WindowedApp {
                                     }
                                 }
                                 InputEvent::CompositionCancelled => {
-                                    composition_active = false;
-                                    keyboard_committed_text = None;
-                                    blinc_layout::widgets::set_focused_text_widget_composition(None);
+                                    reset_composition_tracking_state(
+                                        &mut composition_active,
+                                        &mut keyboard_committed_text,
+                                    );
                                 }
                                 InputEvent::FocusTraversal(intent) => {
                                     keyboard_events.push(PendingEvent {
@@ -4925,5 +4939,16 @@ mod tests {
             take_composition_commit_text(&mut tracked, "초성"),
             vec!['초', '성']
         );
+    }
+
+    #[test]
+    fn reset_composition_tracking_state_clears_active_flag_and_tracked_text() {
+        let mut composition_active = true;
+        let mut tracked = Some(vec!['한', '글']);
+
+        reset_composition_tracking_state(&mut composition_active, &mut tracked);
+
+        assert!(!composition_active);
+        assert!(tracked.is_none());
     }
 }

--- a/crates/blinc_layout/src/selector/semantic.rs
+++ b/crates/blinc_layout/src/selector/semantic.rs
@@ -207,6 +207,7 @@ fn preferred_text_only_matches(
 
 fn is_text_only_locator(locator: &SemanticLocator) -> bool {
     locator.text.is_some()
+        && locator.nth.is_none()
         && locator.role.is_none()
         && locator.label.is_none()
         && locator.placeholder.is_none()
@@ -554,6 +555,25 @@ mod tests {
         tree.compute_layout(320.0, 120.0);
 
         let resolution = resolve_semantic_locator(&tree, &SemanticLocator::text("Submit"));
+        assert_eq!(resolution.matched_target.as_deref(), Some("submit-button"));
+        assert_eq!(resolution.failure_reason, None);
+    }
+
+    #[test]
+    fn semantic_text_only_query_preserves_nth_selection_without_pruning() {
+        let _guard = semantic_test_guard();
+        ensure_theme();
+        blur_all_text_inputs();
+
+        let button_state = Stateful::new(ButtonState::Idle).shared_state();
+        let ui = div()
+            .id("screen")
+            .child(button(button_state, "Submit").id("submit-button"));
+
+        let mut tree = RenderTree::from_element(&ui);
+        tree.compute_layout(320.0, 120.0);
+
+        let resolution = resolve_semantic_locator(&tree, &SemanticLocator::text("Submit").nth(1));
         assert_eq!(resolution.matched_target.as_deref(), Some("submit-button"));
         assert_eq!(resolution.failure_reason, None);
     }

--- a/crates/blinc_layout/src/selector/semantic.rs
+++ b/crates/blinc_layout/src/selector/semantic.rs
@@ -190,7 +190,7 @@ fn preferred_text_only_matches(
         .filter(|&node_id| tree.layout().accessibility_metadata(node_id).is_some())
         .collect::<Vec<_>>();
     if !accessible.is_empty() {
-        return accessible;
+        return prune_ancestor_candidates(tree, accessible);
     }
 
     let actionable = matched_nodes
@@ -201,15 +201,7 @@ fn preferred_text_only_matches(
     if actionable.is_empty() {
         matched_nodes
     } else {
-        actionable
-            .iter()
-            .copied()
-            .filter(|&candidate| {
-                !actionable.iter().copied().any(|other| {
-                    other != candidate && is_ancestor_candidate(tree, candidate, other)
-                })
-            })
-            .collect()
+        prune_ancestor_candidates(tree, actionable)
     }
 }
 
@@ -224,6 +216,22 @@ fn is_text_only_locator(locator: &SemanticLocator) -> bool {
 fn is_actionable_text_candidate(tree: &RenderTree, node_id: LayoutNodeId) -> bool {
     tree.layout().accessibility_metadata(node_id).is_some()
         || tree.element_registry().get_id(node_id).is_some()
+}
+
+fn prune_ancestor_candidates(
+    tree: &RenderTree,
+    candidates: Vec<LayoutNodeId>,
+) -> Vec<LayoutNodeId> {
+    candidates
+        .iter()
+        .copied()
+        .filter(|&candidate| {
+            !candidates
+                .iter()
+                .copied()
+                .any(|other| other != candidate && is_ancestor_candidate(tree, candidate, other))
+        })
+        .collect()
 }
 
 fn is_ancestor_candidate(tree: &RenderTree, ancestor: LayoutNodeId, node_id: LayoutNodeId) -> bool {
@@ -410,6 +418,7 @@ mod tests {
     use super::*;
     use crate::div::div;
     use crate::stateful::{ButtonState, Stateful};
+    use crate::text::text;
     use crate::widgets::{
         blur_all_text_inputs, button, text_input, text_input_state,
         text_input_state_with_placeholder,
@@ -546,6 +555,42 @@ mod tests {
 
         let resolution = resolve_semantic_locator(&tree, &SemanticLocator::text("Submit"));
         assert_eq!(resolution.matched_target.as_deref(), Some("submit-button"));
+        assert_eq!(resolution.failure_reason, None);
+    }
+
+    #[test]
+    fn semantic_text_only_query_prefers_deepest_accessible_match() {
+        let _guard = semantic_test_guard();
+        ensure_theme();
+        blur_all_text_inputs();
+
+        let ui = div()
+            .id("outer-button")
+            .child(div().id("inner-checkbox").child(text("Submit")));
+
+        let mut tree = RenderTree::from_element(&ui);
+        let outer_button = tree
+            .query_by_id("outer-button")
+            .expect("outer button should resolve");
+        let inner_checkbox = tree
+            .query_by_id("inner-checkbox")
+            .expect("inner checkbox should resolve");
+        tree.layout_tree.set_accessibility_metadata(
+            outer_button,
+            crate::accessibility::AccessibilityMetadata::new(AccessibilityRole::Button)
+                .with_name(Some("Submit".to_string()))
+                .with_focusable(true),
+        );
+        tree.layout_tree.set_accessibility_metadata(
+            inner_checkbox,
+            crate::accessibility::AccessibilityMetadata::new(AccessibilityRole::Checkbox)
+                .with_name(Some("Submit".to_string()))
+                .with_focusable(true),
+        );
+        tree.compute_layout(320.0, 120.0);
+
+        let resolution = resolve_semantic_locator(&tree, &SemanticLocator::text("Submit"));
+        assert_eq!(resolution.matched_node_id, Some(inner_checkbox));
         assert_eq!(resolution.failure_reason, None);
     }
 

--- a/crates/blinc_layout/src/selector/semantic.rs
+++ b/crates/blinc_layout/src/selector/semantic.rs
@@ -145,6 +145,7 @@ pub fn resolve_semantic_locator(
         .into_iter()
         .filter(|&node_id| matches_locator(tree, node_id, locator))
         .collect::<Vec<_>>();
+    let matched_nodes = preferred_text_only_matches(tree, locator, matched_nodes);
     let candidate_targets = matched_nodes
         .iter()
         .map(|&node_id| target_label(tree, node_id))
@@ -172,6 +173,68 @@ pub fn resolve_semantic_locator(
         candidate_targets,
         failure_reason,
     })
+}
+
+fn preferred_text_only_matches(
+    tree: &RenderTree,
+    locator: &SemanticLocator,
+    matched_nodes: Vec<LayoutNodeId>,
+) -> Vec<LayoutNodeId> {
+    if !is_text_only_locator(locator) || matched_nodes.len() <= 1 {
+        return matched_nodes;
+    }
+
+    let accessible = matched_nodes
+        .iter()
+        .copied()
+        .filter(|&node_id| tree.layout().accessibility_metadata(node_id).is_some())
+        .collect::<Vec<_>>();
+    if !accessible.is_empty() {
+        return accessible;
+    }
+
+    let actionable = matched_nodes
+        .iter()
+        .copied()
+        .filter(|&node_id| is_actionable_text_candidate(tree, node_id))
+        .collect::<Vec<_>>();
+    if actionable.is_empty() {
+        matched_nodes
+    } else {
+        actionable
+            .iter()
+            .copied()
+            .filter(|&candidate| {
+                !actionable.iter().copied().any(|other| {
+                    other != candidate && is_ancestor_candidate(tree, candidate, other)
+                })
+            })
+            .collect()
+    }
+}
+
+fn is_text_only_locator(locator: &SemanticLocator) -> bool {
+    locator.text.is_some()
+        && locator.role.is_none()
+        && locator.label.is_none()
+        && locator.placeholder.is_none()
+        && locator.tag.is_none()
+}
+
+fn is_actionable_text_candidate(tree: &RenderTree, node_id: LayoutNodeId) -> bool {
+    tree.layout().accessibility_metadata(node_id).is_some()
+        || tree.element_registry().get_id(node_id).is_some()
+}
+
+fn is_ancestor_candidate(tree: &RenderTree, ancestor: LayoutNodeId, node_id: LayoutNodeId) -> bool {
+    let mut current = tree.element_registry().get_parent(node_id);
+    while let Some(parent) = current {
+        if parent == ancestor {
+            return true;
+        }
+        current = tree.element_registry().get_parent(parent);
+    }
+    false
 }
 
 fn record_resolution(resolution: SemanticLocatorResolution) -> SemanticLocatorResolution {
@@ -463,6 +526,25 @@ mod tests {
             &tree,
             &SemanticLocator::role(AccessibilityRole::Button).with_text("Submit"),
         );
+        assert_eq!(resolution.matched_target.as_deref(), Some("submit-button"));
+        assert_eq!(resolution.failure_reason, None);
+    }
+
+    #[test]
+    fn semantic_text_only_query_prefers_actionable_node_over_ancestor_text_matches() {
+        let _guard = semantic_test_guard();
+        ensure_theme();
+        blur_all_text_inputs();
+
+        let button_state = Stateful::new(ButtonState::Idle).shared_state();
+        let ui = div()
+            .id("screen")
+            .child(button(button_state, "Submit").id("submit-button"));
+
+        let mut tree = RenderTree::from_element(&ui);
+        tree.compute_layout(320.0, 120.0);
+
+        let resolution = resolve_semantic_locator(&tree, &SemanticLocator::text("Submit"));
         assert_eq!(resolution.matched_target.as_deref(), Some("submit-button"));
         assert_eq!(resolution.failure_reason, None);
     }


### PR DESCRIPTION
## Summary
- align headless automation wait reporting with the actual advanced frame budget
- suppress fallback text dispatch during IME composition while keeping committed text events
- prefer actionable targets for text-only semantic locators to reduce ambiguous matches

## Test Plan
- cargo fmt --all
- cargo fmt --all -- --check
- cargo test -p blinc_app
- cargo test -p blinc_layout